### PR TITLE
Fixes broken links in components section

### DIFF
--- a/content/library/components/components-api.md
+++ b/content/library/components/components-api.md
@@ -15,7 +15,7 @@ If you are unsure whether you need bi-directional communication, **start here fi
 
 ### Render an HTML string
 
-While [`st.text`](api.html#streamlit.text), [`st.markdown`](api.html#streamlit.text) and [`st.write`](api.html#streamlit.text) make it easy to write text to a Streamlit app, sometimes you'd rather implement a custom piece of HTML. Similarly, while Streamlit natively supports [many charting libraries](api.html#display-charts), you may want to implement a specific HTML/JavaScript template for a new charting library. `components.html` works by giving you the ability to embed an iframe inside of a Streamlit app that contains your desired output.
+While [`st.text`](/library/api-reference/text#sttext), [`st.markdown`](/library/api-reference/text#stmarkdown) and [`st.write`](library/api-reference/write-magic#stwrite) make it easy to write text to a Streamlit app, sometimes you'd rather implement a custom piece of HTML. Similarly, while Streamlit natively supports [many charting libraries](/library/api-reference/charts#chart-elements), you may want to implement a specific HTML/JavaScript template for a new charting library. `components.html` works by giving you the ability to embed an iframe inside of a Streamlit app that contains your desired output.
 
 <Autofunction function="streamlit.components.v1.html" />
 

--- a/content/library/components/create-component.md
+++ b/content/library/components/create-component.md
@@ -13,7 +13,7 @@ components created by the community!
 
 </Note>
 
-Starting with version [0.63.0](changelog.html#version-0-63-0), developers can write JavaScript and HTML "components" that can be rendered in Streamlit apps. Streamlit Components can receive data from, and also send data to, Streamlit Python scripts.
+Starting with version [0.63.0](/library/changelog#version-0630), developers can write JavaScript and HTML "components" that can be rendered in Streamlit apps. Streamlit Components can receive data from, and also send data to, Streamlit Python scripts.
 
 Streamlit Components let you expand the functionality provided in the base Streamlit package. Use Streamlit Components to create the needed functionality for your use case, then wrap it up in a Python package and share with the broader Streamlit community!
 

--- a/content/library/components/publish-component.md
+++ b/content/library/components/publish-component.md
@@ -11,13 +11,13 @@ Publishing your Streamlit Component to [PyPI](https://pypi.org/) makes it easily
 
 <Note>
 
-For [static Streamlit Components](/develop_streamlit_components.html#create-a-static-component>), publishing a Python package to PyPI follows the same steps as the
+For [static Streamlit Components](/library/components/components-api#create-a-static-component), publishing a Python package to PyPI follows the same steps as the
 [core PyPI packaging instructions](https://packaging.python.org/tutorials/packaging-projects/). A static Component likely contains only Python code, so once you have your
 [setup.py](https://packaging.python.org/tutorials/packaging-projects/#creating-setup-py) file correct and 
 [generate your distribution files](https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives), you're ready to
 [upload to PyPI](https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives).
 
-[Bi-directional Streamlit Components](/develop_streamlit_components.html#create-a-bi-directional-component) at minimum include both Python and JavaScript code, and as such, need a bit more preparation before they can be published on PyPI. The remainder of this page focuses on the bi-directional Component preparation process.
+[Bi-directional Streamlit Components](/library/components/components-api#create-a-bi-directional-component) at minimum include both Python and JavaScript code, and as such, need a bit more preparation before they can be published on PyPI. The remainder of this page focuses on the bi-directional Component preparation process.
 
 </Note>
 


### PR DESCRIPTION
Fixes broken links to other pages in the documentation for all pages under `/library/components`.

TODO: Autofunction docstrings for `streamlit.components.v1.html` and `streamlit.components.v1.iframe` are broken and need to be fixed:
![image](https://user-images.githubusercontent.com/20672874/132342424-75c7bd1c-5014-4464-aac9-86b3e5702712.png)
