### PR TITLE
Fix broken links to API functions in docs

### DIFF
--- a/content/library/advanced-features/caching.md
+++ b/content/library/advanced-features/caching.md
@@ -5,9 +5,9 @@ slug: /library/advanced-features/caching
 
 # Optimize performance with st.cache
 
-Streamlit provides a caching mechanism that allows your app to stay performant even when loading data from the web, manipulating large datasets, or performing expensive computations. This is done with the [`@st.cache`](/library/api-reference/performance#stcache) decorator.
+Streamlit provides a caching mechanism that allows your app to stay performant even when loading data from the web, manipulating large datasets, or performing expensive computations. This is done with the [`@st.cache`](/library/api-reference/performance/st.cache) decorator.
 
-When you mark a function with the [`@st.cache`](/library/api-reference/performance#stcache) decorator, it tells Streamlit that whenever the function is called it needs to check a few things:
+When you mark a function with the [`@st.cache`](/library/api-reference/performance/st.cache) decorator, it tells Streamlit that whenever the function is called it needs to check a few things:
 
 1. The input parameters that you called the function with
 2. The value of any external variable used in the function
@@ -18,7 +18,7 @@ If this is the first time Streamlit has seen these four components with these ex
 
 The way Streamlit keeps track of changes in these components is through hashing. Think of the cache as an in-memory key-value store, where the key is a hash of all of the above and the value is the actual output object passed by reference.
 
-Finally, [`@st.cache`](/library/api-reference/performance#stcache) supports arguments to configure the cache's behavior. You can find more information on those in our [API reference](/library/api-reference).
+Finally, [`@st.cache`](/library/api-reference/performance/st.cache) supports arguments to configure the cache's behavior. You can find more information on those in our [API reference](/library/api-reference).
 
 Let's take a look at a few examples that illustrate how caching works in a Streamlit app.
 
@@ -43,7 +43,7 @@ st.write("Result:", res)
 
 Try pressing **R** to rerun the app, and notice how long it takes for the result to show up. This is because `expensive_computation(a, b)` is being re-executed every time the app runs. This isn't a great experience.
 
-Let's add the [`@st.cache`](/library/api-reference/performance#stcache) decorator:
+Let's add the [`@st.cache`](/library/api-reference/performance/st.cache) decorator:
 
 ```python
 import streamlit as st
@@ -196,7 +196,7 @@ res = expensive_computation(a, b)
 st.write("Result:", res)
 ```
 
-Even though `inner_func()` is not annotated with [`@st.cache`](/library/api-reference/performance#stcache), when we edit its body we cause a "Cache miss" in the outer `expensive_computation()`.
+Even though `inner_func()` is not annotated with [`@st.cache`](/library/api-reference/performance/st.cache), when we edit its body we cause a "Cache miss" in the outer `expensive_computation()`.
 
 That's because Streamlit always traverses your code and its dependencies to verify that the cached values are still valid. This means that while developing your app you can edit your code freely without worrying about the cache. Any change you make to your app, Streamlit should do the right thing!
 
@@ -228,7 +228,7 @@ What you'll see:
 - If you move the slider to a number Streamlit hasn't seen before, you'll have a cache miss again. And every subsequent rerun with the same number will be a cache hit, of course.
 - If you move the slider back to a number Streamlit has seen before, the cache is hit and the app is fast as expected.
 
-In computer science terms, what is happening here is that [`@st.cache`](/library/api-reference/performance#stcache) is [memoizing](https://en.wikipedia.org/wiki/Memoization) `expensive_computation(a, b)`.
+In computer science terms, what is happening here is that [`@st.cache`](/library/api-reference/performance/st.cache) is [memoizing](https://en.wikipedia.org/wiki/Memoization) `expensive_computation(a, b)`.
 
 But now let's go one step further! Try the following:
 
@@ -289,7 +289,7 @@ In this specific case, the fix is just to not mutate `res["output"]` outside the
 
 ## Advanced caching
 
-In [caching](/library/advanced-features/caching), you learned about the Streamlit cache, which is accessed with the [`@st.cache`](/library/api-reference/performance#stcache) decorator. In this article you'll see how Streamlit's caching functionality is implemented, so that you can use it to improve the performance of your Streamlit apps.
+In [caching](/library/advanced-features/caching), you learned about the Streamlit cache, which is accessed with the [`@st.cache`](/library/api-reference/performance/st.cache) decorator. In this article you'll see how Streamlit's caching functionality is implemented, so that you can use it to improve the performance of your Streamlit apps.
 
 The cache is a key-value store, where the key is a hash of:
 
@@ -305,7 +305,7 @@ And the value is a tuple of:
 
 For both the key and the output hash, Streamlit uses a specialized hash function that knows how to traverse code, hash special objects, and can have its [behavior customized by the user](#the-hash_funcs-parameter).
 
-For example, when the function `expensive_computation(a, b)`, decorated with [`@st.cache`](/library/api-reference/performance#stcache), is executed with `a=2` and `b=21`, Streamlit does the following:
+For example, when the function `expensive_computation(a, b)`, decorated with [`@st.cache`](/library/api-reference/performance/st.cache), is executed with `a=2` and `b=21`, Streamlit does the following:
 
 1. Computes the cache key
 1. If the key is found in the cache, then:
@@ -339,7 +339,7 @@ def func(file_reference):
 
 By default, Streamlit hashes custom classes like `FileReference` by recursively navigating their structure. In this case, its hash is the hash of the filename property. As long as the file name doesn't change, the hash will remain constant.
 
-However, what if you wanted to have the hasher check for changes to the file's modification time, not just its name? This is possible with [`@st.cache`](/library/api-reference/performance#stcache)'s `hash_funcs` parameter:
+However, what if you wanted to have the hasher check for changes to the file's modification time, not just its name? This is possible with [`@st.cache`](/library/api-reference/performance/st.cache)'s `hash_funcs` parameter:
 
 ```python
 class FileReference:

--- a/content/library/advanced-features/cookbook.md
+++ b/content/library/advanced-features/cookbook.md
@@ -60,7 +60,7 @@ some **constraints**:
 
 ## Insert elements out of order
 
-You can use the [`st.empty`](/library/api-reference/layout#stempty) method as a placeholder,
+You can use the [`st.empty`](/library/api-reference/layout/st.empty) method as a placeholder,
 to "save" a slot in your app that you can use later.
 
 ```python

--- a/content/library/advanced-features/session-state.md
+++ b/content/library/advanced-features/session-state.md
@@ -13,7 +13,7 @@ Session State is a way to share variables between reruns, for each user session.
 
 In this guide, we will illustrate the usage of **Session State** and **Callbacks** as we build a stateful Counter app.
 
-For details on the Session State and Callbacks API, please refer to our [Session State API Reference Guide](/library/api-reference/state).
+For details on the Session State and Callbacks API, please refer to our [Session State API Reference Guide](/library/api-reference/session-state).
 
 ## Build a Counter
 
@@ -111,7 +111,7 @@ As you can see in the above example, pressing the **_Increment_** button updates
 
 Now that we've built a basic Counter app using Session State, let's move on to something a little more complex. The next example uses Callbacks with Session State.
 
-**Callbacks**: A callback is a Python function which gets called when an input widget changes. Callbacks can be used with widgets using the parameters `on_change` (or `on_click`), `args`, and `kwargs`. The full Callbacks API can be found in our [Session State API Reference Guide](/library/api-reference/state#use-callbacks-to-update-session-state).
+**Callbacks**: A callback is a Python function which gets called when an input widget changes. Callbacks can be used with widgets using the parameters `on_change` (or `on_click`), `args`, and `kwargs`. The full Callbacks API can be found in our [Session State API Reference Guide](/library/api-reference/session-state#use-callbacks-to-update-session-state).
 
 ```python
 import streamlit as st
@@ -256,5 +256,5 @@ Here are some limitations to keep in mind when using Session State:
 
 - Session State exists for as long as the tab is open and connected to the Streamlit server. As soon as you close the tab, everything stored in Session State is lost.
 - Session State is not persisted. If the Streamlit server crashes, then everything stored in Session State gets wiped
-- For caveats and limitations with the Session State API, please see the [API limitations](/library/api-reference/state#caveats-and-limitations).
+- For caveats and limitations with the Session State API, please see the [API limitations](/library/api-reference/session-state#caveats-and-limitations).
 

--- a/content/library/api/performance/performance.md
+++ b/content/library/api/performance/performance.md
@@ -24,7 +24,7 @@ The main limitation is that Streamlit’s cache feature doesn’t know about
 changes that take place outside the body of the annotated function.
 
 For more information about the Streamlit cache, its configuration parameters,
-and its limitations, see [Caching](caching.md).
+and its limitations, see [Caching](/library/api-reference/performance/st.cache).
 
 <TileContainer>
 <RefCard href="/library/api-reference/performance/st.cache">

--- a/content/library/components/components-api.md
+++ b/content/library/components/components-api.md
@@ -15,7 +15,7 @@ If you are unsure whether you need bi-directional communication, **start here fi
 
 ### Render an HTML string
 
-While [`st.text`](/library/api-reference/text#sttext), [`st.markdown`](/library/api-reference/text#stmarkdown) and [`st.write`](library/api-reference/write-magic#stwrite) make it easy to write text to a Streamlit app, sometimes you'd rather implement a custom piece of HTML. Similarly, while Streamlit natively supports [many charting libraries](/library/api-reference/charts#chart-elements), you may want to implement a specific HTML/JavaScript template for a new charting library. `components.html` works by giving you the ability to embed an iframe inside of a Streamlit app that contains your desired output.
+While [`st.text`](/library/api-reference/text/st.text), [`st.markdown`](/library/api-reference/text/st.markdown) and [`st.write`](/library/api-reference/write-magic/st.write) make it easy to write text to a Streamlit app, sometimes you'd rather implement a custom piece of HTML. Similarly, while Streamlit natively supports [many charting libraries](/library/api-reference/charts#chart-elements), you may want to implement a specific HTML/JavaScript template for a new charting library. `components.html` works by giving you the ability to embed an iframe inside of a Streamlit app that contains your desired output.
 
 <Autofunction function="streamlit.components.v1.html" />
 
@@ -205,11 +205,11 @@ This template has much more code than its React sibling, in that all the mechani
 
 #### Working with Themes
 
-```eval_rst
-.. note::
-   Custom component theme support requires streamlit-component-lib version
-   1.2.0 or higher.
-```
+<Note>
+
+Custom component theme support requires streamlit-component-lib version 1.2.0 or higher.
+
+</Note>
 
 Along with sending an `args` object to your component, Streamlit also sends
 a `theme` object defining the active theme so that your component can adjust
@@ -267,7 +267,7 @@ of personal preference.
 npm add baseui
 ```
 
-- To build a static version of your component, run `npm run build`. See [Prepare your Component](publish_streamlit_components.md) for more information
+- To build a static version of your component, run `npm run build`. See [Prepare your Component](publish#prepare-your-component) for more information
 
 ### Python API
 

--- a/content/library/get-started/create-an-app.md
+++ b/content/library/get-started/create-an-app.md
@@ -17,8 +17,8 @@ spin up and your app will open in a new tab your default web browser. The app
 is your canvas, where you'll draw charts, text, widgets, tables, and more.
 
 What gets drawn in the app is up to you. For example
-[`st.text`](/library/api-reference/text#sttext) writes raw text to your app, and
-[`st.line_chart`](/library/api-reference/charts#stline_chart) draws — you guessed it — a
+[`st.text`](/library/api-reference/text/st.text) writes raw text to your app, and
+[`st.line_chart`](/library/api-reference/charts/st.line_chart) draws — you guessed it — a
 line chart. Refer to our [API documentation](/library/api-reference) to see all commands that
 are available to you.
 
@@ -74,7 +74,7 @@ This can happen in two situations:
 - Whenever a user interacts with widgets in the app. For example, when dragging
   a slider, entering text in an input box, or clicking a button.
 
-Whenever a callback is passed to a widget via the `on_change` (or `on_click`) parameter, the callback will always run before the rest of your script. For details on the Callbacks API, please refer to our [Session State API Reference Guide](/library/api-reference/state#use-callbacks-to-update-session-state).
+Whenever a callback is passed to a widget via the `on_change` (or `on_click`) parameter, the callback will always run before the rest of your script. For details on the Callbacks API, please refer to our [Session State API Reference Guide](/library/api-reference/session-state#use-callbacks-to-update-session-state).
 
 And to make all of this fast and seamless, Streamlit does some heavy lifting
 for you behind the scenes. A big player in this story is the
@@ -86,18 +86,18 @@ page.
 
 There are a few ways to display data (tables, arrays, data frames) in Streamlit
 apps. In [getting started](/library/get-started), you were introduced to _magic_
-and [`st.write()`](/library/api-reference/write-magic#stwrite), which can be used to write
+and [`st.write()`](/library/api-reference/write-magic/st.write), which can be used to write
 anything from text to tables. Now let's take a look at methods designed
 specifically for visualizing data.
 
-You might be asking yourself, "why wouldn't I always use st.write()?" There are
+You might be asking yourself, "why wouldn't I always use `st.write()`?" There are
 a few reasons:
 
-1. _Magic_ and [`st.write()`](/library/api-reference/write-magic#stwrite) inspect the type of
+1. _Magic_ and [`st.write()`](/library/api-reference/write-magic/st.write) inspect the type of
    data that you've passed in, and then decide how to best render it in the
    app. Sometimes you want to draw it another way. For example, instead of
    drawing a dataframe as an interactive table, you may want to draw it as a
-   static table by using st.table(df).
+   static table by using `st.table(df)`.
 2. The second reason is that other methods return an object that can be used
    and modified, either by adding data to it or replacing it.
 3. Finally, if you use a more specific Streamlit method you can pass additional
@@ -105,7 +105,7 @@ a few reasons:
 
 For example, let's create a data frame and change its formatting with a Pandas
 `Styler` object. In this example, you'll use Numpy to generate a random sample,
-and the [`st.dataframe()`](/library/api-reference/data#stdataframe) method to draw an
+and the [`st.dataframe()`](/library/api-reference/data/st.dataframe) method to draw an
 interactive table.
 
 <Note>
@@ -132,7 +132,7 @@ st.dataframe(dataframe.style.highlight_max(axis=0))
 ```
 
 Streamlit also has a method for static table generation:
-[`st.table()`](/library/api-reference/data#sttable).
+[`st.table()`](/library/api-reference/data/st.table).
 
 ```python
 dataframe = pd.DataFrame(
@@ -144,9 +144,9 @@ st.table(dataframe)
 ## Widgets
 
 When you've got the data or model into the state that you want to explore, you
-can add in widgets like [`st.slider()`](/library/api-reference/widgets#stslider),
-[`st.button()`](/library/api-reference/widgets#stbutton) or
-[`st.selectbox()`](/library/api-reference/widgets#stselectbox). It's really straightforward
+can add in widgets like [`st.slider()`](/library/api-reference/widgets/st.slider),
+[`st.button()`](/library/api-reference/widgets/st.button) or
+[`st.selectbox()`](/library/api-reference/widgets/st.selectbox). It's really straightforward
 — treat widgets as variables:
 
 ```python
@@ -174,7 +174,7 @@ st.text_input("Your name", key="name")
 st.session_state.name
 ```
 
-Every widget with a key is automatically added to Session State. For more information about Session State, its association with widget state, and its limitations, see [Session State API Reference Guide](/library/api-reference/state).
+Every widget with a key is automatically added to Session State. For more information about Session State, its association with widget state, and its limitations, see [Session State API Reference Guide](/library/api-reference/session-state).
 
 ## Layout
 
@@ -205,8 +205,8 @@ add_slider = st.sidebar.slider(
 ```
 
 Beyond the sidebar, Streamlit offers several other ways to control the layout
-of your app. [`st.columns`](/library/api-reference/layout#stcolumns) lets you place widgets side-by-side, and
-[`st.expander`](/library/api-reference/layout#stexpander) lets you conserve space by hiding away large content.
+of your app. [`st.columns`](/library/api-reference/layout/st.columns) lets you place widgets side-by-side, and
+[`st.expander`](/library/api-reference/layout/st.expander) lets you conserve space by hiding away large content.
 
 ```python
 import streamlit as st
@@ -278,7 +278,7 @@ from the web, manipulating large datasets, or performing expensive
 computations.
 
 To use the cache, wrap functions with the
-[`@st.cache`](/library/api-reference/performance#stcache) decorator:
+[`@st.cache`](/library/api-reference/performance/st.cache) decorator:
 
 ```python
 @st.cache  # 👈 This function will be cached
@@ -287,7 +287,7 @@ def my_slow_function(arg1, arg2):
     return the_output
 ```
 
-When you mark a function with the [`@st.cache`](/library/api-reference/performance#stcache)
+When you mark a function with the [`@st.cache`](/library/api-reference/performance/st.cache)
 decorator, it tells Streamlit that whenever the function is called it needs to
 check a few things:
 

--- a/content/library/get-started/get-started.md
+++ b/content/library/get-started/get-started.md
@@ -81,14 +81,14 @@ st.title('My first app')
 ```
 
 That's it! Your app has a title. You can use specific text functions to add
-content to your app, or you can use [`st.write()`](/library/api-reference/write-magic#stwrite)
+content to your app, or you can use [`st.write()`](/library/api-reference/write-magic/st.write)
 and add your own markdown.
 
 ### Write a data frame
 
-Along with [magic commands](/library/api-reference/write-magic#magic),
-[`st.write()`](/library/api-reference/write-magic#stwrite) is Streamlit's "Swiss Army knife". You
-can pass almost anything to [`st.write()`](/library/api-reference/write-magic#stwrite):
+Along with [magic commands](/library/api-reference/write-magic/magic),
+[`st.write()`](/library/api-reference/write-magic/st.write) is Streamlit's "Swiss Army knife". You
+can pass almost anything to [`st.write()`](/library/api-reference/write-magic/st.write):
 text, data, Matplotlib figures, Altair charts, and more. Don't worry, Streamlit
 will figure it out and render things the right way.
 
@@ -101,8 +101,8 @@ st.write(pd.DataFrame({
 ```
 
 There are other data specific functions like
-[`st.dataframe()`](/library/api-reference/data#stdataframe) and
-[`st.table()`](/library/api-reference/data#sttable) that you can also use for displaying
+[`st.dataframe()`](/library/api-reference/data/st.dataframe) and
+[`st.table()`](/library/api-reference/data/st.table) that you can also use for displaying
 data. Check our advanced guides on displaying data to understand when to use
 these features and how to add colors and styling to your data frames.
 
@@ -119,8 +119,8 @@ cache it.
 
 You can also write to your app without calling any
 Streamlit methods. Streamlit supports "[magic
-commands](/library/api-reference/write-magic#magic)," which means you don't have to use
-[`st.write()`](/library/api-reference/write-magic#stwrite) at all! Try replacing the code above
+commands](/library/api-reference/write-magic/magic)," which means you don't have to use
+[`st.write()`](/library/api-reference/write-magic/st.write) at all! Try replacing the code above
 with this snippet:
 
 ```python
@@ -139,8 +139,8 @@ df
 
 Any time that Streamlit sees a variable or a literal
 value on its own line, it automatically writes that to your app using
-[`st.write()`](/library/api-reference/write-magic#stwrite). For more information, refer to the
-documentation on [magic commands](/library/api-reference/write-magic#magic).
+[`st.write()`](/library/api-reference/write-magic/st.write). For more information, refer to the
+documentation on [magic commands](/library/api-reference/write-magic/magic).
 
 ## Draw charts and maps
 
@@ -151,7 +151,7 @@ add a bar chart, line chart, and a map to your app.
 ### Draw a line chart
 
 You can easily add a line chart to your app with
-[`st.line_chart()`](/library/api-reference/charts#stline_chart). We'll generate a random
+[`st.line_chart()`](/library/api-reference/charts/st.line_chart). We'll generate a random
 sample using Numpy and then chart it.
 
 ```python
@@ -164,7 +164,7 @@ st.line_chart(chart_data)
 
 ### Plot a map
 
-With [`st.map()`](/library/api-reference/charts#stmap) you can display data points on a map.
+With [`st.map()`](/library/api-reference/charts/st.map) you can display data points on a map.
 Let's use Numpy to generate some sample data and plot it on a map of
 San Francisco.
 
@@ -185,7 +185,7 @@ reference](/library/api-reference) for a full list of interactive widgets.
 ### Use checkboxes to show/hide data
 
 One use case for checkboxes is to hide or show a specific chart or section in
-an app. [`st.checkbox()`](/library/api-reference/widgets#stcheckbox) takes a single argument,
+an app. [`st.checkbox()`](/library/api-reference/widgets/st.checkbox) takes a single argument,
 which is the widget label. In this sample, the checkbox is used to toggle a
 conditional statement.
 
@@ -200,7 +200,7 @@ if st.checkbox('Show dataframe'):
 
 ### Use a selectbox for options
 
-Use [`st.selectbox`](/library/api-reference/widgets#stselectbox) to choose from a series. You
+Use [`st.selectbox`](/library/api-reference/widgets/st.selectbox) to choose from a series. You
 can write in the options you want, or pass through an array or data frame
 column.
 
@@ -218,7 +218,7 @@ option = st.selectbox(
 
 For a cleaner look, you can move your widgets into a sidebar. This keeps your
 app central, while widgets are pinned to the left. Let's take a look at how you
-can use [`st.sidebar`](api.html#add-widgets-to-sidebar) in your app.
+can use [`st.sidebar`](/library/api-reference/layout#add-widgets-to-sidebar) in your app.
 
 ```python
 option = st.sidebar.selectbox(
@@ -231,8 +231,8 @@ option = st.sidebar.selectbox(
 Most of the elements you can put into your app can also be put into a sidebar using this syntax:
 `st.sidebar.[element_name]()`. Here are a few examples that show how it's used: `st.sidebar.markdown()`, `st.sidebar.slider()`, `st.sidebar.line_chart()`.
 
-You can also use [`st.columns`](/library/api-reference/layout#stcolumns) to lay out widgets side-by-side, or
-[`st.expander`](/library/api-reference/layout#stexpander) to conserve space by hiding away large content.
+You can also use [`st.columns`](/library/api-reference/layout/st.columns) to lay out widgets side-by-side, or
+[`st.expander`](/library/api-reference/layout/st.expander) to conserve space by hiding away large content.
 
 ```python
 left_column, right_column = st.columns(2)
@@ -244,13 +244,13 @@ expander = st.expander("FAQ")
 expander.write("Here you could put in some really, really long explanations...")
 ```
 
-The only exceptions right now are [`st.echo`](/library/api-reference/text#stecho) and [`st.spinner`](/library/api-reference/status#stspinner). Rest
+The only exceptions right now are [`st.echo`](/library/api-reference/text/st.echo) and [`st.spinner`](/library/api-reference/status/st.spinner). Rest
 assured, though, we're currently working on adding support for those too!
 
 ## Show progress
 
 When adding long running computations to an app, you can use
-[`st.progress()`](/library/api-reference/status#stprogress) to display status in real time.
+[`st.progress()`](/library/api-reference/status/st.progress) to display status in real time.
 
 First, let's import time. We're going to use the `time.sleep()` method to
 simulate a long running computation:
@@ -289,7 +289,7 @@ It works in 3 simple steps:
 2. Sign into [share.streamlit.io](https://share.streamlit.io)
 3. Click 'Deploy an app' and then paste in your GitHub URL
 
-That's it! **🎈**You now have a publicly deployed app that you can share with the world. Click to learn more about [how to use Streamlit Cloud](/library/get-started/deploy-an-app). If you're looking for private sharing for your team, check out the [Team and Enterprise tiers](https://streamlit.io/cloud-sign-up).
+That's it! **🎈**You now have a publicly deployed app that you can share with the world. Click to learn more about [how to use Streamlit Cloud](/streamlit-cloud/community). If you're looking for private sharing for your team, check out the [Team and Enterprise tiers](https://streamlit.io/cloud-sign-up).
 
 ## Get help
 

--- a/content/library/get-started/installation.md
+++ b/content/library/get-started/installation.md
@@ -10,7 +10,7 @@ slug: /library/get-started/installation
 Before you get started, you're going to need a few things:
 
 - Your favorite IDE or text editor
-- [Python 3.6 - 3.8](https://www.python.org/downloads/)
+- [Python 3.6+](https://www.python.org/downloads/)
 - [PIP](https://pip.pypa.io/en/stable/installing/)
 
 If you haven't already, take a few minutes to read through [Main


### PR DESCRIPTION
With PR #9, each `st` function gets its own page. As such, links to `st` functions elsewhere in the docs have been updated to point to the new location.