### PR TITLE
Fix broken URLs

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -5,14 +5,14 @@ features:
     body: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
     color: violet-70
     icon: arrow_forward
-    url: /tutorials/get-started
+    url: /library/get-started
     image: ""
   - title: API reference
     body: Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut
       fugit, sed quia.
     color: orange-70
     icon: dvr
-    url: /reference-guides/api-reference
+    url: /library/api-reference
     image: ""
   - title: Topic guides
     body: Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut
@@ -28,27 +28,27 @@ whats_new:
       facilisis sagittis, vitae nibh massa in facilisis et. Pretium eget non
       cursus purus tempus porta sodales.
     icon: visibility
-    url: /tutorials/get-started
+    url: /library/get-started
     image: /img/logo.svg
   - title: Feature title
     body: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Eleifend a
       facilisis sagittis, vitae nibh massa in facilisis et. Pretium eget non
       cursus purus tempus porta sodales.
-    url: /tutorials/get-started
+    url: /library/get-started
     icon: visibility
     image: ""
   - body: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Eleifend a
       facilisis sagittis, vitae nibh massa in facilisis et. Pretium eget non
       cursus purus tempus porta sodales.
     title: Feature title
-    url: /tutorials/get-started
+    url: /library/get-started
     image: /img/logo.svg
     icon: edit
   - title: Feature title
     body: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Eleifend a
       facilisis sagittis, vitae nibh massa in facilisis et. Pretium eget non
       cursus purus tempus porta sodales.
-    url: /tutorials/get-started
+    url: /library/get-started
     icon: edit
     image: ""
 news:

--- a/content/kb/tutorials/data-explorer.md
+++ b/content/kb/tutorials/data-explorer.md
@@ -6,8 +6,8 @@ slug: /kb/tutorials/data-explorer
 # Create a data explorer app
 
 If you've made it this far, chances are you've
-[installed Streamlit](https://docs.streamlit.io/en/latest/#install-streamlit) and
-run through the basics in our [get started guide](../getting_started.md). If
+[installed Streamlit](/library/get-started/installation) and
+run through the basics in our [Get Started](/library/get-started) guide. If
 not, now is a good time to take a look.
 
 In this tutorial, you're going to use Streamlit's core features to
@@ -19,7 +19,7 @@ widgets, like a slider, to filter results.
 <Tip>
 
 If you'd like to skip ahead and see everything at once, the [complete script
-is available below](#let-s-put-it-all-together).
+is available below](#lets-put-it-all-together).
 
 </Tip>
 
@@ -186,15 +186,15 @@ st.subheader('Raw data')
 st.write(data)
 ```
 
-In the [get started guide](../getting_started.md) you learned that
-[`st.write`](../api.html#streamlit.write) will render almost anything you pass
+In the [Get Started](/library/get-started/) guide you learned that
+[`st.write`](/library/api-reference/write-magic/st.write) will render almost anything you pass
 to it. In this case, you're passing in a dataframe and it's rendering as an
 interactive table.
 
-[`st.write`](../api.html#streamlit.text) tries to do the right thing based on
+[`st.write`](/library/api-reference/write-magic/st.write) tries to do the right thing based on
 the data type of the input. If it isn't doing what you expect you can use a
-specialized command like [`st.dataframe`](../api.html#streamlit.dataframe)
-instead. For a full list, see [API reference](../api.md).
+specialized command like [`st.dataframe`](/library/api-reference/data/st.dataframe)
+instead. For a full list, see [API reference](/library/api-reference).
 
 ## Draw a histogram
 
@@ -217,7 +217,7 @@ Uber's busiest hours are in New York City.
    ```
 
 3. Now, let's use Streamlit's
-   [`st.bar_chart()`](../api.html#streamlit.bar_chart) method to draw this
+   [`st.bar_chart()`](/library/api-reference/charts/st.bar_chart) method to draw this
    histogram.
 
    ```python
@@ -230,7 +230,7 @@ Uber's busiest hours are in New York City.
 To draw this diagram we used Streamlit's native `bar_chart()` method, but it's
 important to know that Streamlit supports more complex charting libraries like
 Altair, Bokeh, Plotly, Matplotlib and more. For a full list, see
-[supported charting libraries](../api.html#display-charts).
+[supported charting libraries](/library/api-reference/charts).
 
 ## Plot data on a map
 
@@ -239,7 +239,7 @@ times are for pickups, but what if we wanted to figure out where pickups were
 concentrated throughout the city. While you could use a bar chart to show this
 data, it wouldn't be easy to interpret unless you were intimately familiar with
 latitudinal and longitudinal coordinates in the city. To show pickup
-concentration, let's use Streamlit [`st.map()`](../api.html#streamlit.map)
+concentration, let's use Streamlit [`st.map()`](/library/api-reference/charts/st.map)
 function to overlay the data on a map of New York City.
 
 1. Add a subheader for the section:
@@ -279,9 +279,9 @@ at 17:00.
 
 3. You should see the data update instantly.
 
-To draw this map we used the [`st.map`](../api.html#streamlit.map) function that's built into Streamlit, but
+To draw this map we used the [`st.map`](/library/api-reference/charts/st.map) function that's built into Streamlit, but
 if you'd like to visualize complex map data, we encourage you to take a look at
-the [`st.pydeck_chart`](../api.html#streamlit.pydeck_chart).
+the [`st.pydeck_chart`](/library/api-reference/charts/st.pydeck_chart).
 
 ## Filter results with a slider
 
@@ -301,7 +301,7 @@ slider to the app with the `st.slider()` method.
 ## Use a button to toggle data
 
 Sliders are just one way to dynamically change the composition of your app.
-Let's use the [`st.checkbox`](../api.html#streamlit.checkbox) function to add a
+Let's use the [`st.checkbox`](/library/api-reference/widgets/st.checkbox) function to add a
 checkbox to your app. We'll use this checkbox to show/hide the raw data
 table at the top of your app.
 
@@ -320,14 +320,11 @@ table at the top of your app.
        st.write(data)
    ```
 
-We're sure you've got your own ideas. When you're done with this tutorial,
-check out all the widgets that Streamlit exposes in our [API
-reference](../api.md).
+We're sure you've got your own ideas. When you're done with this tutorial, check out all the widgets that Streamlit exposes in our [API Reference](/library/api-reference).
 
 ## Let's put it all together
 
-That's it, you've made it to the end. Here's the complete script for our interactive
-app.
+That's it, you've made it to the end. Here's the complete script for our interactive app.
 
 <Tip>
 

--- a/content/kb/tutorials/databases/private-gsheet.md
+++ b/content/kb/tutorials/databases/private-gsheet.md
@@ -9,7 +9,7 @@ slug: /kb/tutorials/databases/private-gsheet
 
 This guide explains how to securely access a private Google Sheet from Streamlit Cloud. It uses the [gsheetsdb](https://github.com/betodealmeida/gsheets-db-api) library and Streamlit's [secrets management](/streamlit-cloud/community#secrets-management).
 
-If you are fine with enabling link sharing for your Google Sheet (i.e. everyone with the link can view it), the guide [Connect Streamlit to a public Google Sheet](public_gsheet.md) shows a simpler method of doing this. If your Sheet contains sensitive information and you cannot enable link sharing, keep on reading.
+If you are fine with enabling link sharing for your Google Sheet (i.e. everyone with the link can view it), the guide [Connect Streamlit to a public Google Sheet](/kb/tutorials/databases/public-gsheet) shows a simpler method of doing this. If your Sheet contains sensitive information and you cannot enable link sharing, keep on reading.
 
 ## Create a Google Sheet
 

--- a/content/kb/using-streamlit/sanity-checks.md
+++ b/content/kb/using-streamlit/sanity-checks.md
@@ -56,7 +56,7 @@ st.write(st.__version__)
 
 ...then call `streamlit run` on your script and make sure it says the same
 version as above. If not the same version, check out [these
-instructions](clean-install.md) for some sure-fire ways to set up your
+instructions](/library/get-started/installation) for some sure-fire ways to set up your
 environment.
 
 ## Check #4: Is your browser caching your app too aggressively?
@@ -84,7 +84,7 @@ pip install --upgrade streamlit==0.50
 ```
 
 ...where `0.50` is the version you'd like to downgrade to. See
-[Changelog](../changelog.md) for a complete list of Streamlit versions.
+[Changelog](/library/changelog) for a complete list of Streamlit versions.
 
 ## Check #6 [Windows]: Is Python added to your PATH?
 

--- a/content/library/advanced-features/caching.md
+++ b/content/library/advanced-features/caching.md
@@ -285,7 +285,7 @@ What's going on here is that Streamlit caches the output `res` by reference. Whe
 
 Since this behavior is usually not what you'd expect, Streamlit tries to be helpful and show you a warning, along with some ideas about how to fix your code.
 
-In this specific case, the fix is just to not mutate `res["output"]` outside the cached function. There was no good reason for us to do that anyway! Another solution would be to clone the result value with `res = deepcopy(expensive_computation(2, 21))`. Check out the section entitled [Fixing caching issues](/kb/troubleshooting/caching-issues) for more information on these approaches and more.
+In this specific case, the fix is just to not mutate `res["output"]` outside the cached function. There was no good reason for us to do that anyway! Another solution would be to clone the result value with `res = deepcopy(expensive_computation(2, 21))`. Check out the section entitled [Fixing caching issues](/kb/using-streamlit/caching-issues) for more information on these approaches and more.
 
 ## Advanced caching
 
@@ -318,7 +318,7 @@ For example, when the function `expensive_computation(a, b)`, decorated with [`@
    - Stores `key → (output, output_hash)` in the cache.
 1. Returns the output.
 
-If an error is encountered an exception is raised. If the error occurs while hashing either the key or the output an `UnhashableTypeError` error is thrown. If you run into any issues, see [fixing caching issues](/kb/troubleshooting/caching-issues).
+If an error is encountered an exception is raised. If the error occurs while hashing either the key or the output an `UnhashableTypeError` error is thrown. If you run into any issues, see [fixing caching issues](/kb/using-streamlit/caching-issues).
 
 ### The hash_funcs parameter
 

--- a/content/library/api/performance/cache.md
+++ b/content/library/api/performance/cache.md
@@ -22,6 +22,6 @@ The main limitation is that Streamlit’s cache feature doesn’t know about
 changes that take place outside the body of the annotated function.
 
 For more information about the Streamlit cache, its configuration parameters,
-and its limitations, see [Caching](caching.md).
+and its limitations, see [Caching](/library/advanced-features/caching).
 
 <Autofunction function="streamlit.cache" />

--- a/content/library/api/text/text-elements.md
+++ b/content/library/api/text/text-elements.md
@@ -14,7 +14,7 @@ Pure text is entered with `st.text`, and Markdown with
 
 We also offer a "swiss-army knife" command called `st.write`, which accepts
 multiple arguments, and multiple data types. And as described above, you can
-also use [magic commands](api.html#magic-commands) in place of `st.write`.
+also use [magic commands](/library/api-reference/write-magic/magic) in place of `st.write`.
 
 <TileContainer>
 <RefCard href="/library/api-reference/text/st.markdown">

--- a/content/library/api/write-magic/magic.md
+++ b/content/library/api/write-magic/magic.md
@@ -39,7 +39,7 @@ fig  # 👈 Draw a Matplotlib chart
 
 Any time Streamlit sees either a variable or literal
 value on its own line, it automatically writes that to your app using
-[`st.write`](api.html#streamlit.write) (which you'll learn about later).
+[`st.write`](/library/api-reference/write-magic/st.write) (which you'll learn about later).
 
 Also, magic is smart enough to ignore docstrings. That is, it ignores the
 strings at the top of files and functions.

--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -5,7 +5,7 @@ slug: /library/changelog
 
 # Changelog
 
-This page lists highlights, bug fixes, and known issues for official Streamlit releases. If you're looking for information about nightly releases, beta features, or experimental features, see [Try pre-release features](api.html#pre-release-features).
+This page lists highlights, bug fixes, and known issues for official Streamlit releases. If you're looking for information about nightly releases, beta features, or experimental features, see [Try pre-release features](/library/advanced-features/prerelease).
 
 <Tip>
 
@@ -571,10 +571,10 @@ _Release date: November 10, 2019_
 **Highlights:**
 
 - 👩‍🎓 SymPy support and ability to draw mathematical expressions using LaTeX! See
-  [`st.latex`](api.html#streamlit.latex),
-  [`st.markdown`](api.html#streamlit.markdown),
+  [`st.latex`](/library/api-reference/text/st.latex),
+  [`st.markdown`](/library/api-reference/text/st.markdown),
   and
-  [`st.write`](api.html#streamlit.write).
+  [`st.write`](/library/api-reference/write-magic/st.write).
 - 🌄 You can now set config options using environment variables. For example,
   `export STREAMLIT_SERVER_PORT=9876`.
 - 🐱 Ability to call `streamlit run` directly with Github and Gist URLs. No

--- a/content/library/landing_page.md
+++ b/content/library/landing_page.md
@@ -1,0 +1,6 @@
+---
+title: Streamlit Library
+slug: /library
+---
+
+# Streamlit Library

--- a/pages/404.js
+++ b/pages/404.js
@@ -24,9 +24,9 @@ export default function Home({ window, menu }) {
                         <Spacer size="2rem" />
 
                         <TileContainer>
-                            <Tile icon="arrow_forward" title="Get Started" text="Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia." background="violet-70" link="/tutorials/get-started" />
-                            <Tile icon="dvr" title="API reference" text="Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia." background="orange-70" link="/reference-guides/api-reference" />
-                            <Tile icon="description" title="Topic guides" text="Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia." background="l-blue-70" link="/topic-guides" />
+                            <Tile icon="arrow_forward" title="Get Started" text="If you're new to Streamlit and don't know where to start, this is a good place." background="violet-70" link="/library/get-started" />
+                            <Tile icon="dvr" title="API Reference" text="Learn how our APIs, with actionable explanations of specific functions and features." background="violet-70" link="/library/api-reference" />
+                            <Tile icon="grid_view" title="App Gallery" text="Try out awesome apps created by our users, and curated from our forums or Twitter." background="green-70" link="https://streamlit.io/gallery" />
                         </TileContainer>
                     </article>
                 </section>

--- a/pages/index.js
+++ b/pages/index.js
@@ -99,7 +99,7 @@ export default function Home({ window, menu, gdpr_data }) {
           <SocialCallouts />
 
           <ArrowLinkContainer>
-            <ArrowLink link="/tutorials/get-started" type="next" content="Get Started" />
+            <ArrowLink link="/library/get-started" type="next" content="Get Started" />
           </ArrowLinkContainer>
         </section>
       </section>

--- a/pages/style-guide.js
+++ b/pages/style-guide.js
@@ -101,7 +101,7 @@ ls -l myscript.sh`} />
                 <Component label="Arrow Links">
                     <ArrowLinkContainer>
                         <ArrowLink link="/" type="back" content="Welcome to Streamlit" />
-                        <ArrowLink link="/getting-started" type="next" content="Get Started" />
+                        <ArrowLink link="/library/get-started" type="next" content="Get Started" />
                     </ArrowLinkContainer>
                 </Component>
                 <Component label="Note Block">
@@ -226,10 +226,10 @@ st.altair_chart(chart_data)`} />
                 </Component>
                 <Component label="Featured update">
                     <TilesContainer>
-                        <Tile size={"half"} background={"unset"} color={"unset"} dark={{ background: 'unset', color: 'white', border_color: 'gray-90' }} border_color={"gray-40"} img={"/logo.svg"} link={"/getting-started"} />
-                        <Tile size={"half"} background={"unset"} color={"unset"} dark={{ background: 'unset', color: 'white', border_color: 'gray-90' }} border_color={"gray-40"} img={"/logo.svg"} link={"/getting-started"} />
-                        <Tile size={"half"} background={"unset"} color={"unset"} dark={{ background: 'unset', color: 'white', border_color: 'gray-90' }} border_color={"gray-40"} img={"/logo.svg"} link={"/getting-started"} />
-                        <Tile size={"half"} background={"unset"} color={"unset"} dark={{ background: 'unset', color: 'white', border_color: 'gray-90' }} border_color={"gray-40"} img={"/logo.svg"} link={"/getting-started"} />
+                        <Tile size={"half"} background={"unset"} color={"unset"} dark={{ background: 'unset', color: 'white', border_color: 'gray-90' }} border_color={"gray-40"} img={"/logo.svg"} link={"/library/get-started"} />
+                        <Tile size={"half"} background={"unset"} color={"unset"} dark={{ background: 'unset', color: 'white', border_color: 'gray-90' }} border_color={"gray-40"} img={"/logo.svg"} link={"/library/get-started"} />
+                        <Tile size={"half"} background={"unset"} color={"unset"} dark={{ background: 'unset', color: 'white', border_color: 'gray-90' }} border_color={"gray-40"} img={"/logo.svg"} link={"/library/get-started"} />
+                        <Tile size={"half"} background={"unset"} color={"unset"} dark={{ background: 'unset', color: 'white', border_color: 'gray-90' }} border_color={"gray-40"} img={"/logo.svg"} link={"/library/get-started"} />
                     </TilesContainer>
                 </Component>
                 <Component label="News entry">
@@ -251,8 +251,8 @@ st.altair_chart(chart_data)`} />
                 </Component>
                 <Component label="Inline callout">
                     <InlineCalloutContainer>
-                        <InlineCallout color="violet-70" icon="school" bold="Tutorials" href="/">include our <Link href="/tutorials/get-started"><a>Get Started</a></Link> guide and a few step-by-step examples to building different types of apps in Streamlit.</InlineCallout>
-                        <InlineCallout color="violet-70" icon="school" bold="Tutorials" href="/">include our <Link href="/tutorials/get-started"><a>Get Started</a></Link> guide and a few step-by-step examples to building different types of apps in Streamlit.</InlineCallout>
+                        <InlineCallout color="violet-70" icon="school" bold="Tutorials" href="/">include our <Link href="/library/get-started"><a>Get Started</a></Link> guide and a few step-by-step examples to building different types of apps in Streamlit.</InlineCallout>
+                        <InlineCallout color="violet-70" icon="school" bold="Tutorials" href="/">include our <Link href="/library/get-started"><a>Get Started</a></Link> guide and a few step-by-step examples to building different types of apps in Streamlit.</InlineCallout>
                     </InlineCalloutContainer>
                 </Component>
                 <Component label="Social callouts">


### PR DESCRIPTION
### Fixes broken URLs in the docs

@CharlyWargnier crawled the site for links that 404'd:

```
https://streamlit-docs.netlify.app/kb/api.html
https://streamlit-docs.netlify.app/kb/api.md
https://streamlit-docs.netlify.app/kb/changelog.md
https://streamlit-docs.netlify.app/kb/getting_started.md
https://streamlit-docs.netlify.app/kb/troubleshooting/caching-issues
https://streamlit-docs.netlify.app/kb/tutorials/databases/public_gsheet.md
https://streamlit-docs.netlify.app/kb/using-streamlit/clean-install.md
https://streamlit-docs.netlify.app/library
https://streamlit-docs.netlify.app/library/api-reference/api.html
https://streamlit-docs.netlify.app/library/api-reference/performance/caching.md
https://streamlit-docs.netlify.app/library/api-reference/write-magic/api.html
https://streamlit-docs.netlify.app/library/api.html
https://streamlit-docs.netlify.app/tutorials/get-started
```

### Changes

- Searched through our docs to find mentions of those URLs and mapped them to their working counterparts. 
-  Created a blank landing page for Streamlit Library to avoid 404s in subsequent crawls.
- Updated tiles in `pages/404.js` to look like the tiles on the docs homepage.