### PR TITLE
Add interactive timeline to Streamlit Library homepage

### DIFF
--- a/content/library/landing_page.md
+++ b/content/library/landing_page.md
@@ -4,3 +4,5 @@ slug: /library
 ---
 
 # Streamlit Library
+
+<iframe src='https://cdn.knightlab.com/libs/timeline3/latest/embed/index.html?source=1xCKGuO3ClUHDvUyjlxc4Iz7kGduplpuZwDLNW4r7QV4&font=Default&lang=en&initial_zoom=2&height=650' width='100%' height='650' webkitallowfullscreen mozallowfullscreen allowfullscreen frameborder='0'></iframe>


### PR DESCRIPTION
This is a work-in-progress timeline for the Streamlit Library homepage. It uses [TimelineJS v3: A Storytelling Timeline built in JavaScript](https://github.com/NUKnightLab/TimelineJS3). 

The spreadsheet used to populate the timeline is available [here](https://docs.google.com/spreadsheets/d/1xCKGuO3ClUHDvUyjlxc4Iz7kGduplpuZwDLNW4r7QV4/edit#gid=0).

### Demo
https://user-images.githubusercontent.com/20672874/134893897-28a0f84b-54c7-410f-8c14-dbf5219f1dbf.mp4



