### PR TITLE
Promote Cheatsheet to top-level nav.

### DIFF
--- a/content/library/get-started/api-cheat-sheet.md
+++ b/content/library/get-started/api-cheat-sheet.md
@@ -1,6 +1,6 @@
 ---
 title: Cheat Sheet
-slug: /library/get-started/cheatsheet
+slug: /library/cheatsheet
 ---
 
 # Cheat Sheet

--- a/content/menu.md
+++ b/content/menu.md
@@ -18,8 +18,6 @@ site_menu:
     url: /library/get-started/create-an-app
   - category: Streamlit Library / Get Started / Deploy an app 
     url: /library/get-started/deploy-an-app
-  - category: Streamlit Library / Get Started / Cheat sheet
-    url: /library/get-started/cheatsheet
   # - category: Streamlit Library / Get Started / App gallery
   #   url: https://streamlit.io/gallery
   - category: Streamlit Library / API Reference
@@ -206,6 +204,8 @@ site_menu:
     url: https://streamlit.io/components
   - category: Streamlit Library / Changelog
     url: /library/changelog
+  - category: Streamlit Library / Cheat sheet
+    url: /library/cheatsheet
     
 
   - category: Streamlit Cloud


### PR DESCRIPTION
The cheatsheet is super important -- how about we make it way more discoverable and accessible, by moving to the top level of the Library navigation menu?