### PR TITLE
Fix on nav breakpoint to show button on 1024px width

### DIFF
--- a/components/navigation/header.js
+++ b/components/navigation/header.js
@@ -45,7 +45,7 @@ export default class Header extends React.Component {
 
         let mobileNav;
 
-        if (this.state.windowWidth < 1025) {
+        if (this.state.windowWidth <= 1024) {
             mobileNav = <MobileNav />
         }
 


### PR DESCRIPTION
Currently, the left navigation dissappears at `1024px`, but the mobile toggle button shows up at `1023px`, which means that we don't get neither options on iPad landscape resolutions. Changing the breakpoint for the toggle button fixes it.