### PR TITLE
Point Streamlit Library top-lvl heading to Get Started

### DIFF
--- a/content/menu.md
+++ b/content/menu.md
@@ -1,7 +1,7 @@
 ---
 site_menu:
   - category: Streamlit Library
-    url: /library
+    url: /library/get-started
     color: violet-70
     icon: description
   - category: Streamlit Library / Get Started


### PR DESCRIPTION
- Changes the url of Streamlit Library section (`/library`) in the sidebar to point to `/library/get-started/` until we complete the landing page. 
- Note that `/library` still exists, but is not findable until one types in `streamlit.io/library`. 
- Clicking on Streamlit Library should take one to Get Started.
- As a result of this change, the next button at the bottom of Get Started points to Streamlit Cloud instead of API Reference. This should hopefully be a fast-follow fix, post launch.