### PR TITLE
Replace "Community" in sidebar with "Community Tier"

### DIFF
--- a/content/menu.md
+++ b/content/menu.md
@@ -212,25 +212,25 @@ site_menu:
     url: /streamlit-cloud
     color: l-blue-70
     icon: cloud
-  - category: Streamlit Cloud / Community
+  - category: Streamlit Cloud / Community Tier
     url: /streamlit-cloud/community
-  - category: Streamlit Cloud / Community / Sign up
+  - category: Streamlit Cloud / Community Tier / Sign up
     url: /streamlit-cloud/community#sign-up-for-streamlit-cloud
-  - category: Streamlit Cloud / Community / Put your Streamlit app on GitHub
+  - category: Streamlit Cloud / Community Tier / Put your Streamlit app on GitHub
     url: /streamlit-cloud/community#put-your-streamlit-app-on-github
-  - category: Streamlit Cloud / Community / Log in to share.streamlit.io
+  - category: Streamlit Cloud / Community Tier / Log in to share.streamlit.io
     url: /streamlit-cloud/community#log-in-to-sharestreamlitio
-  - category: Streamlit Cloud / Community / Deploy your app
+  - category: Streamlit Cloud / Community Tier / Deploy your app
     url: /streamlit-cloud/community#deploy-your-app
-  - category: Streamlit Cloud / Community / Secrets management
+  - category: Streamlit Cloud / Community Tier / Secrets management
     url: /streamlit-cloud/community#secrets-management
-  - category: Streamlit Cloud / Community / Share, update, and collaborate
+  - category: Streamlit Cloud / Community Tier / Share, update, and collaborate
     url: /streamlit-cloud/community#share-update-and-collaborate
-  - category: Streamlit Cloud / Community / App access and usage
+  - category: Streamlit Cloud / Community Tier / App access and usage
     url: /streamlit-cloud/community#app-access-and-usage
-  - category: Streamlit Cloud / Community / Managing apps
+  - category: Streamlit Cloud / Community Tier / Managing apps
     url: /streamlit-cloud/community#managing-apps
-  - category: Streamlit Cloud / Community / Limitations and known issues
+  - category: Streamlit Cloud / Community Tier / Limitations and known issues
     url: /streamlit-cloud/community#limitations-and-known-issues
 
 


### PR DESCRIPTION
I find the "Community" label in the sidebar confusing — I'd expect it to link to the forums. How about "Community Tier"?

I don't even think Enterprise needs to have "Tier" at the end. That's clear enough as it is.
 
WDYT?