### PR TITLE
Missing "

### DIFF
--- a/content/library/api/control-flow/control-flow.md
+++ b/content/library/api/control-flow/control-flow.md
@@ -38,7 +38,7 @@ widgets is filled before actually rerunning the script. That's what `st.form` is
 Create a form that batches elements together with a “Submit” button.
 
 ```python
-with st.form(key="my_form):
+with st.form(key="my_form"):
     username = st.text_input("Username")
     password = st.text_input("Password")
     st.form_submit_button("Login")


### PR DESCRIPTION
Spotted a missing `"`
Btw, I could see both `"` and `'` being used in the docs. 