### PR TITLE
Point Streamlit Library link to Get Started

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -65,7 +65,7 @@ export default function Home({ window, menu, gdpr_data }) {
 
             <H2>How to use our docs</H2>
             <InlineCalloutContainer>
-              <InlineCallout color="violet-70" icon="description" bold="Streamlit Library" href="/library">
+              <InlineCallout color="violet-70" icon="description" bold="Streamlit Library" href="/library/get-started">
                 includes our Get Started guide, API Reference, and more advanced features of the core library including caching, theming, and Streamlit components.
               </InlineCallout>
               <InlineCallout color="l-blue-70" icon="cloud" bold="Streamlit Cloud" href="/streamlit-cloud">


### PR DESCRIPTION
Like we did in sidebar, we should temporarily make instances of `/library` point to `/library/get-started` until we have populated the Streamlit Library page. 

This PR changes the href of the "Streamlit Library" `InlineCallout` on the index page to `/library/get-started`.