### PR TITLE
Fixes issue #79. Missing Streamlit href on homepage

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -41,7 +41,7 @@ export default function Home({ window, menu, gdpr_data }) {
         <section className="content wide">
           <article>
             <H1>Welcome to Streamlit docs</H1>
-            <p><a>Streamlit</a> is an open-source Python library that makes it easy to create and share beautiful, custom web apps for machine learning and data science. In just a few minutes you can build and deploy powerful data apps - so let’s get started!</p>
+            <p><a href="https://www.streamlit.io">Streamlit</a> is an open-source Python library that makes it easy to create and share beautiful, custom web apps for machine learning and data science. In just a few minutes you can build and deploy powerful data apps - so let’s get started!</p>
 
             <Spacer size="2rem" />
 


### PR DESCRIPTION
Adds a missing link to the main Streamlit website on the docs homepage. Fixes issue #79. 