### PR TITLE
Populates st.sidebar API page

### DIFF
--- a/content/kb/components/add-component-sidebar.md
+++ b/content/kb/components/add-component-sidebar.md
@@ -5,7 +5,7 @@ slug: /knowledge-base/components/add-component-sidebar
 
 # How do I add a Component to the sidebar?
 
-You can add a component to st.sidebar using the `with` syntax. For example:
+You can add a component to [st.sidebar](/library/api-reference/layout/st.sidebar) using the `with` syntax. For example:
 
 ```python
 with st.sidebar:

--- a/content/library/api/layout/layout.md
+++ b/content/library/api/layout/layout.md
@@ -5,21 +5,6 @@ slug: /library/api-reference/layout
 
 # Layouts and Containers
 
-## Add widgets to sidebar
-
-Not only can you add interactivity to your report with widgets, you can organize them into a sidebar with `st.sidebar.[element_name]`. Each element that's passed to `st.sidebar` is pinned to the left, allowing users to focus on the content in your app. The only elements that aren't supported are `st.echo` and `st.spinner`.
-
-Here's an example of how you'd add a selectbox to your sidebar.
-
-```python
-import streamlit as st
-
-add_selectbox = st.sidebar.selectbox(
-    "How would you like to be contacted?",
-    ("Email", "Home phone", "Mobile phone")
-)
-```
-
 ## Complex layouts
 
 Streamlit provides several options for controlling different elements are laid out on the screen.

--- a/content/library/api/layout/sidebar.md
+++ b/content/library/api/layout/sidebar.md
@@ -1,0 +1,21 @@
+---
+title: st.sidebar
+slug: /library/api-reference/layout/st.sidebar
+---
+
+## st.sidebar
+
+## Add widgets to sidebar
+
+Not only can you add interactivity to your report with widgets, you can organize them into a sidebar with `st.sidebar.[element_name]`. Each element that's passed to `st.sidebar` is pinned to the left, allowing users to focus on the content in your app. The only elements that aren't supported are `st.echo` and `st.spinner`.
+
+Here's an example of how you'd add a selectbox to your sidebar.
+
+```python
+import streamlit as st
+
+add_selectbox = st.sidebar.selectbox(
+    "How would you like to be contacted?",
+    ("Email", "Home phone", "Mobile phone")
+)
+```

--- a/content/library/get-started/main-concepts.md
+++ b/content/library/get-started/main-concepts.md
@@ -293,8 +293,8 @@ option = st.selectbox(
 ## Layout
 
 Streamlit makes it easy to organize your widgets in a left panel sidebar with
-[`st.sidebar`](/library/api-reference/layout#add-widgets-to-sidebar). Each element that's passed to
-[`st.sidebar`](/library/api-reference/layout#add-widgets-to-sidebar) is pinned to the left, allowing
+[`st.sidebar`](/library/api-reference/layout/st.sidebar). Each element that's passed to
+[`st.sidebar`](/library/api-reference/layout/st.sidebar) is pinned to the left, allowing
 users to focus on the content in your app while still having access to UI
 controls.
 

--- a/content/menu.md
+++ b/content/menu.md
@@ -124,6 +124,8 @@ site_menu:
     url: /library/api-reference/media/st.video
   - category: Streamlit library / API reference / Layouts and containers
     url: /library/api-reference/layout
+  - category: Streamlit library / API reference / Layouts and containers / st.sidebar
+    url: /library/api-reference/layout/st.sidebar
   - category: Streamlit library / API reference / Layouts and containers / st.columns
     url: /library/api-reference/layout/st.columns
   - category: Streamlit library / API reference / Layouts and containers / st.expander


### PR DESCRIPTION
- Moved `st.sidebar` content from "Layouts and containers" to its own page
- Added `st.sidebar` to the docs sidebar menu
- Updated links that referred to `st.sidebar` elsewhere in the docs to `/library/api-reference/layout/st.sidebar`