### PR TITLE
Makes API version selector respect dark-mode

### DIFF
--- a/styles/global/dark.scss
+++ b/styles/global/dark.scss
@@ -264,6 +264,7 @@ body[data-theme="dark-mode"] {
         .code-header .title-with-select .version-select { 
             select {
                 color: $white;
+                background-color: $off-black;
             }
             &.old-version select {
                 color: $red-70;


### PR DESCRIPTION
- Makes API version selector drop-down respect dark-mode by setting `background-color: $off-black;`.
- Fixes #114.