### PR TITLE
Removes #anchor tags in left sidebar

### DIFF
--- a/content/library/get-started/installation.md
+++ b/content/library/get-started/installation.md
@@ -5,6 +5,12 @@ slug: /library/get-started/installation
 
 # Install Streamlit
 
+## Table of contents
+
+1. [Prerequisites](#prerequisites)
+2. [Install Streamlit on Windows](#install-streamlit-on-windows)
+3. [Install Streamlit on macOS/Linux](#install-streamlit-on-macoslinux)
+
 ## Prerequisites
 
 Before you get started, you're going to need a few things:

--- a/content/menu.md
+++ b/content/menu.md
@@ -10,12 +10,6 @@ site_menu:
     url: /library/get-started/main-concepts
   - category: Streamlit library / Get started / Installation
     url: /library/get-started/installation
-  - category: Streamlit library / Get started / Installation / Prerequisites
-    url: /library/get-started/installation#prerequisites
-  - category: Streamlit library / Get started / Installation / Windows
-    url: /library/get-started/installation#install-streamlit-on-windows
-  - category: Streamlit library / Get started / Installation / Linux and macOS
-    url: /library/get-started/installation#install-streamlit-on-macoslinux
   - category: Streamlit library / Get started / Create an app
     url: /library/get-started/create-an-app
   # - category: Streamlit library / Get started / Deploy an app
@@ -216,24 +210,6 @@ site_menu:
     icon: cloud
   - category: Streamlit Cloud / Community tier
     url: /streamlit-cloud/community
-  - category: Streamlit Cloud / Community tier / Sign up
-    url: /streamlit-cloud/community#sign-up-for-streamlit-cloud
-  - category: Streamlit Cloud / Community tier / Put your Streamlit app on GitHub
-    url: /streamlit-cloud/community#put-your-streamlit-app-on-github
-  - category: Streamlit Cloud / Community tier / Log in to share.streamlit.io
-    url: /streamlit-cloud/community#log-in-to-sharestreamlitio
-  - category: Streamlit Cloud / Community tier / Deploy your app
-    url: /streamlit-cloud/community#deploy-your-app
-  - category: Streamlit Cloud / Community tier / Secrets management
-    url: /streamlit-cloud/community#secrets-management
-  - category: Streamlit Cloud / Community tier / Share, update, and collaborate
-    url: /streamlit-cloud/community#share-update-and-collaborate
-  - category: Streamlit Cloud / Community tier / App access and usage
-    url: /streamlit-cloud/community#app-access-and-usage
-  - category: Streamlit Cloud / Community tier / Managing apps
-    url: /streamlit-cloud/community#managing-apps
-  - category: Streamlit Cloud / Community tier / Limitations and known issues
-    url: /streamlit-cloud/community#limitations-and-known-issues
 
 
   - category: Streamlit Cloud / Teams and enterprise
@@ -290,16 +266,8 @@ site_menu:
     url: /knowledge-base/using-streamlit
   - category: Knowledge base / Streamlit Components
     url: /knowledge-base/components
-  # - category: Knowledge base / Troubleshooting
-  #   url: /knowledge-base/troubleshooting
-  # - category: Knowledge base / Troubleshooting / Sanity checks
-  #   url: /knowledge-base/troubleshooting/sanity-checks
-  # - category: Knowledge base / Troubleshooting / Caching issues
-  #   url: /knowledge-base/troubleshooting/caching-issues
   - category: Knowledge base / Installing dependencies
     url: /knowledge-base/dependencies
-  # - category: Knowledge base / Error messages
-  #   url: /knowledge-base/error-messages
   - category: Knowledge base / Deployment issues
     url: /knowledge-base/deploy
 

--- a/content/streamlit-cloud/community/deploy-app-streamlit-cloud.md
+++ b/content/streamlit-cloud/community/deploy-app-streamlit-cloud.md
@@ -5,6 +5,18 @@ slug: /streamlit-cloud/community
 
 # Deploy on Streamlit Cloud
 
+## Table of contents
+
+1. [Sign up](#sign-up-for-streamlit-cloud)
+2. [Put your Streamlit app on GitHub](#put-your-streamlit-app-on-github)
+3. [Log in to share.streamlit.io](#log-in-to-sharestreamlitio)
+4. [Deploy your app](#deploy-your-app)
+5. [Secrets management](#secrets-management)
+6. [Share, update, and collaborate](#share-update-and-collaborate)
+7. [App access and usage](#app-access-and-usage)
+8. [Managing apps](#managing-apps)
+9. [Limitations and known issues](#limitations-and-known-issues)
+
 ## Sign up for Streamlit Cloud
 
 To get started, first request an invite on the [Streamlit Cloud Community sign-up](https://forms.streamlit.io/community-sign-up) form. Once you receive your invite email, you're ready to deploy!

--- a/content/streamlit-cloud/index.md
+++ b/content/streamlit-cloud/index.md
@@ -15,7 +15,7 @@ Cloud](https://streamlit.io/cloud) to deploy and share your app. Streamlit Cloud
     bold="Community Tier."
     href="/streamlit-cloud/community"
   >
-    Formerly called Streamlit sharing, this is the perfect solution if your app is hosted in a public GitHub repo and you’d like anyone in the world to be able to access it **for free**!
+    Formerly called Streamlit sharing, this is the perfect solution if your app is hosted in a public GitHub repo and you’d like anyone in the world to be able to access it <b>for free</b>!
   </InlineCallout>
   <InlineCallout
     color="l-blue-70"


### PR DESCRIPTION
- Removes #anchor tags from the left sidebar for the "Installation" and "Community tier" pages
- Substitutes anchor tags with table of contents (as an ordered list) within the above pages
- Allows #42 and #53 to be merged