### PR TITLE
Move api examples from streamlit core to docs repo

### DIFF
--- a/python/api-examples-source/charts.area_chart.py
+++ b/python/api-examples-source/charts.area_chart.py
@@ -1,0 +1,7 @@
+import streamlit as st
+import pandas as pd
+import numpy as np
+
+chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
+
+st.area_chart(chart_data)

--- a/python/api-examples-source/charts.audio.py
+++ b/python/api-examples-source/charts.audio.py
@@ -1,0 +1,31 @@
+import requests
+import streamlit as st
+
+
+@st.cache
+def read_file_from_url(url):
+    return requests.get(url).content
+
+
+file_bytes = read_file_from_url(
+    "https://streamlit.io/media/Muriel-Nguyen-Xuan-Chopin-valse-opus64-1.ogg"
+)
+
+st.audio(file_bytes, format="audio/ogg")
+
+st.write(
+    """
+    #### Audio credit:
+
+    Performer: _Muriel Nguyen Xuan_ and _Stéphane Magnenat_
+
+    Composer: Frédéric Chopin
+
+    License: Creative Commons Attribution-Share Alike 4.0 International, 3.0 Unported, 2.5 Generic, 2.0 Generic and 1.0 Generic license.
+    https://creativecommons.org/licenses/by-sa/4.0/
+
+    URL:
+    https://upload.wikimedia.org/wikipedia/commons/c/c4/Muriel-Nguyen-Xuan-Chopin-valse-opus64-1.ogg
+
+"""
+)

--- a/python/api-examples-source/charts.bar_chart.py
+++ b/python/api-examples-source/charts.bar_chart.py
@@ -1,0 +1,7 @@
+import streamlit as st
+import pandas as pd
+import numpy as np
+
+chart_data = pd.DataFrame(np.random.randn(50, 3), columns=["a", "b", "c"])
+
+st.bar_chart(chart_data)

--- a/python/api-examples-source/charts.bokeh_chart.py
+++ b/python/api-examples-source/charts.bokeh_chart.py
@@ -1,0 +1,12 @@
+import streamlit as st
+from bokeh.plotting import figure
+
+
+x = [1, 2, 3, 4, 5]
+y = [6, 7, 2, 4, 5]
+
+p = figure(title="simple line example", x_axis_label="x", y_axis_label="y")
+
+p.line(x, y, legend_label="Trend", line_width=2)
+
+st.bokeh_chart(p)

--- a/python/api-examples-source/charts.graphviz_chart.py
+++ b/python/api-examples-source/charts.graphviz_chart.py
@@ -1,0 +1,20 @@
+import streamlit as st
+import graphviz as graphviz
+
+# Create a graphlib graph object
+graph = graphviz.Digraph()
+graph.edge("run", "intr")
+graph.edge("intr", "runbl")
+graph.edge("runbl", "run")
+graph.edge("run", "kernel")
+graph.edge("kernel", "zombie")
+graph.edge("kernel", "sleep")
+graph.edge("kernel", "runmem")
+graph.edge("sleep", "swap")
+graph.edge("swap", "runswap")
+graph.edge("runswap", "new")
+graph.edge("runswap", "runmem")
+graph.edge("new", "runmem")
+graph.edge("sleep", "runmem")
+
+st.graphviz_chart(graph)

--- a/python/api-examples-source/charts.image.py
+++ b/python/api-examples-source/charts.image.py
@@ -1,0 +1,20 @@
+import streamlit as st
+
+IMAGE_URL = "https://images.unsplash.com/photo-1548407260-da850faa41e3?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1487&q=80"
+
+st.image(IMAGE_URL, caption="Sunrise by the mountains")
+
+st.write(
+    """
+    #### Image credit:
+
+    Creator: User _Neil Iris (@neil_ingham)_ from _Unsplash_
+
+    License: Do whatever you want.
+    https://unsplash.com/license
+
+    URL:
+    https://unsplash.com/photos/I2UR7wEftf4
+
+"""
+)

--- a/python/api-examples-source/charts.line_chart.py
+++ b/python/api-examples-source/charts.line_chart.py
@@ -1,0 +1,7 @@
+import streamlit as st
+import pandas as pd
+import numpy as np
+
+chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
+
+st.line_chart(chart_data)

--- a/python/api-examples-source/charts.map.py
+++ b/python/api-examples-source/charts.map.py
@@ -1,0 +1,9 @@
+import streamlit as st
+import pandas as pd
+import numpy as np
+
+df = pd.DataFrame(
+    np.random.randn(1000, 2) / [50, 50] + [37.76, -122.4], columns=["lat", "lon"]
+)
+
+st.map(df)

--- a/python/api-examples-source/charts.plotly_chart.py
+++ b/python/api-examples-source/charts.plotly_chart.py
@@ -1,0 +1,19 @@
+import streamlit as st
+import plotly.figure_factory as ff
+import numpy as np
+
+# Add histogram data
+x1 = np.random.randn(200) - 2
+x2 = np.random.randn(200)
+x3 = np.random.randn(200) + 2
+
+# Group data together
+hist_data = [x1, x2, x3]
+
+group_labels = ["Group 1", "Group 2", "Group 3"]
+
+# Create distplot with custom bin_size
+fig = ff.create_distplot(hist_data, group_labels, bin_size=[0.1, 0.25, 0.5])
+
+# Plot!
+st.plotly_chart(fig)

--- a/python/api-examples-source/charts.pyplot.py
+++ b/python/api-examples-source/charts.pyplot.py
@@ -1,0 +1,8 @@
+import streamlit as st
+import numpy as np
+import matplotlib.pyplot as plt
+
+arr = np.random.normal(1, 1, size=100)
+plt.hist(arr, bins=20)
+
+st.pyplot()

--- a/python/api-examples-source/charts.vega_lite_chart.py
+++ b/python/api-examples-source/charts.vega_lite_chart.py
@@ -1,0 +1,19 @@
+import streamlit as st
+import pandas as pd
+import numpy as np
+
+df = pd.DataFrame(np.random.randn(200, 3), columns=["a", "b", "c"])
+
+st.vega_lite_chart(
+    df,
+    {
+        "mark": {"type": "circle", "tooltip": True},
+        "encoding": {
+            "x": {"field": "a", "type": "quantitative"},
+            "y": {"field": "b", "type": "quantitative"},
+            "size": {"field": "c", "type": "quantitative"},
+            "color": {"field": "c", "type": "quantitative"},
+        },
+    },
+    use_container_width=True,
+)

--- a/python/api-examples-source/charts.video.py
+++ b/python/api-examples-source/charts.video.py
@@ -1,0 +1,20 @@
+import streamlit as st
+
+VIDEO_URL = "https://static.streamlit.io/examples/star.mp4"
+
+st.video(VIDEO_URL)
+
+st.write(
+    """
+    #### Video credit:
+
+    Creator: User _fxxu_ from _Pixabay_.
+
+    License: Free for commercial use. No attribution required.
+    https://pixabay.com/en/service/license/
+
+    URL:
+    https://pixabay.com/en/videos/star-long-exposure-starry-sky-sky-6962/
+
+"""
+)

--- a/python/api-examples-source/data.dataframe.py
+++ b/python/api-examples-source/data.dataframe.py
@@ -1,0 +1,7 @@
+import streamlit as st
+import pandas as pd
+import numpy as np
+
+df = pd.DataFrame(np.random.randn(50, 20), columns=("col %d" % i for i in range(20)))
+
+st.dataframe(df)  # Same as st.write(df)

--- a/python/api-examples-source/data.json.py
+++ b/python/api-examples-source/data.json.py
@@ -1,0 +1,5 @@
+import streamlit as st
+
+st.json(
+    {"foo": "bar", "baz": "boz", "stuff": ["stuff 1", "stuff 2", "stuff 3", "stuff 5"]}
+)

--- a/python/api-examples-source/data.table.py
+++ b/python/api-examples-source/data.table.py
@@ -1,0 +1,7 @@
+import streamlit as st
+import pandas as pd
+import numpy as np
+
+df = pd.DataFrame(np.random.randn(10, 5), columns=("col %d" % i for i in range(5)))
+
+st.table(df)

--- a/python/api-examples-source/forms.form1.py
+++ b/python/api-examples-source/forms.form1.py
@@ -1,0 +1,13 @@
+import streamlit as st
+
+with st.form("my_form"):
+    st.write("Inside the form")
+    slider_val = st.slider("Form slider")
+    checkbox_val = st.checkbox("Form checkbox")
+
+    # Every form must have a submit button.
+    submitted = st.form_submit_button("Submit")
+    if submitted:
+        st.write("slider", slider_val, "checkbox", checkbox_val)
+
+st.write("Outside the form")

--- a/python/api-examples-source/forms.form2.py
+++ b/python/api-examples-source/forms.form2.py
@@ -1,0 +1,8 @@
+import streamlit as st
+
+form = st.form("my_form")
+form.slider("Inside the form")
+st.slider("Outside the form")
+
+# Now add a submit button to the form:
+form.form_submit_button("Submit")

--- a/python/api-examples-source/layout.columns1.py
+++ b/python/api-examples-source/layout.columns1.py
@@ -1,0 +1,20 @@
+import streamlit as st
+
+col1, col2, col3 = st.columns(3)
+
+with col1:
+    st.header("A cat")
+    st.image("https://static.streamlit.io/examples/cat.jpg")
+    st.markdown("By [@phonvanna](https://unsplash.com/photos/0g7BJEXq7sU)")
+
+
+with col2:
+    st.header("A dog")
+    st.image("https://static.streamlit.io/examples/dog.jpg")
+    st.markdown("By [@shotbyrain](https://unsplash.com/photos/rmkIqi_C3cA)")
+
+
+with col3:
+    st.header("An owl")
+    st.image("https://static.streamlit.io/examples/owl.jpg")
+    st.markdown("By [@zmachacek](https://unsplash.com/photos/ZN4CzqizIyI)")

--- a/python/api-examples-source/layout.columns2.py
+++ b/python/api-examples-source/layout.columns2.py
@@ -1,0 +1,11 @@
+import streamlit as st
+import numpy as np
+
+col1, col2 = st.columns([3, 1])
+data = np.random.randn(10, 1)
+
+col1.subheader("A wide column with a chart")
+col1.line_chart(data)
+
+col2.subheader("A narrow column with the data")
+col2.write(data)

--- a/python/api-examples-source/layout.container1.py
+++ b/python/api-examples-source/layout.container1.py
@@ -1,0 +1,10 @@
+import streamlit as st
+import numpy as np
+import pandas as pd
+
+with st.container():
+    st.write("This is inside the container")
+
+    # You can call any Streamlit command, including custom components:
+    st.bar_chart(np.random.randn(50, 3))
+st.write("This is outside the container")

--- a/python/api-examples-source/layout.container2.py
+++ b/python/api-examples-source/layout.container2.py
@@ -1,0 +1,8 @@
+import streamlit as st
+
+container = st.container()
+container.write("This is inside the container")
+st.write("This is outside the container")
+
+# Now insert some more in the container
+container.write("This is inside too")

--- a/python/api-examples-source/layout.expander.py
+++ b/python/api-examples-source/layout.expander.py
@@ -1,0 +1,14 @@
+import streamlit as st
+
+st.bar_chart({"d6": [1, 5, 2, 6, 2, 1]})
+
+with st.expander("See explanation"):
+    st.write(
+        """
+        The chart above shows some numbers I picked for you.
+        I rolled actual dice for these, so they're *guaranteed* to
+        be random.
+        """
+    )
+    st.image("https://static.streamlit.io/examples/dice.jpg", width=200)
+    st.markdown("Photo by [@brett_jordon](https://unsplash.com/photos/4aB1nGtD_Sg)")

--- a/python/api-examples-source/metric.example1.py
+++ b/python/api-examples-source/metric.example1.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.metric(label="Temperature", value="70 °F", delta="1.2 °F", delta_color="normal")

--- a/python/api-examples-source/metric.example2.py
+++ b/python/api-examples-source/metric.example2.py
@@ -1,0 +1,6 @@
+import streamlit as st
+
+col1, col2, col3 = st.columns(3)
+col1.metric("Temperature", "70 °F", "1.2 °F")
+col2.metric("Wind", "9 mph", "-8%")
+col3.metric("Humidity", "86%", "4%")

--- a/python/api-examples-source/metric.example3.py
+++ b/python/api-examples-source/metric.example3.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.metric(label="Gas price", value=4, delta=-0.5, delta_color="inverse")
+st.metric(label="Active developers", value=123, delta=123, delta_color="off")

--- a/python/api-examples-source/text.code.py
+++ b/python/api-examples-source/text.code.py
@@ -1,0 +1,5 @@
+import streamlit as st
+
+code = """def hello():
+    print("Hello, Streamlit!")"""
+st.code(code, language="python")

--- a/python/api-examples-source/text.header.py
+++ b/python/api-examples-source/text.header.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.header("This is a header")

--- a/python/api-examples-source/text.latex.py
+++ b/python/api-examples-source/text.latex.py
@@ -1,0 +1,9 @@
+import streamlit as st
+
+st.latex(
+    r"""
+    a + ar + a r^2 + a r^3 + \cdots + a r^{n-1} =
+    \sum_{k=0}^{n-1} ar^k =
+    a \left(\frac{1-r^{n}}{1-r}\right)
+    """
+)

--- a/python/api-examples-source/text.markdown.py
+++ b/python/api-examples-source/text.markdown.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.markdown("Streamlit is **_really_ cool**.")

--- a/python/api-examples-source/text.subheader.py
+++ b/python/api-examples-source/text.subheader.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.subheader("This is a subheader")

--- a/python/api-examples-source/text.text.py
+++ b/python/api-examples-source/text.text.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.text("This is some text.")

--- a/python/api-examples-source/text.title.py
+++ b/python/api-examples-source/text.title.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.title("This is a title")

--- a/python/api-examples-source/text.write1.py
+++ b/python/api-examples-source/text.write1.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.write("Hello, *World!* :sunglasses:")

--- a/python/api-examples-source/text.write2.py
+++ b/python/api-examples-source/text.write2.py
@@ -1,0 +1,7 @@
+import streamlit as st
+import pandas as pd
+
+st.write(1234)
+st.write(
+    pd.DataFrame({"first column": [1, 2, 3, 4], "second column": [10, 20, 30, 40]})
+)

--- a/python/api-examples-source/text.write3.py
+++ b/python/api-examples-source/text.write3.py
@@ -1,0 +1,9 @@
+import streamlit as st
+import pandas as pd
+
+data_frame = pd.DataFrame(
+    {"first column": [1, 2, 3, 4], "second column": [10, 20, 30, 40]}
+)
+
+st.write("1 + 1 = ", 2)
+st.write("Below is a DataFrame:", data_frame, "Above is a dataframe.")

--- a/python/api-examples-source/widget.button.py
+++ b/python/api-examples-source/widget.button.py
@@ -1,0 +1,6 @@
+import streamlit as st
+
+if st.button("Say hello"):
+    st.write("Why hello there")
+else:
+    st.write("Goodbye")

--- a/python/api-examples-source/widget.checkbox.py
+++ b/python/api-examples-source/widget.checkbox.py
@@ -1,0 +1,5 @@
+import streamlit as st
+
+agree = st.checkbox("I agree")
+if agree:
+    st.write("Great!")

--- a/python/api-examples-source/widget.date_input.py
+++ b/python/api-examples-source/widget.date_input.py
@@ -1,0 +1,5 @@
+import streamlit as st
+import datetime
+
+d = st.date_input("When's your birthday", datetime.date(2020, 8, 11))
+st.write("Your birthday is:", d)

--- a/python/api-examples-source/widget.radio.py
+++ b/python/api-examples-source/widget.radio.py
@@ -1,0 +1,8 @@
+import streamlit as st
+
+genre = st.radio("What's your favorite movie genre", ("Comedy", "Drama", "Documentary"))
+
+if genre == "Comedy":
+    st.write("You selected comedy.")
+else:
+    st.write("You didn't select comedy.")

--- a/python/api-examples-source/widget.selectbox.py
+++ b/python/api-examples-source/widget.selectbox.py
@@ -1,0 +1,7 @@
+import streamlit as st
+
+option = st.selectbox(
+    "How would you like to be contacted?", ("Email", "Home phone", "Mobile phone")
+)
+
+st.write("You selected:", option)

--- a/python/api-examples-source/widget.slider.py
+++ b/python/api-examples-source/widget.slider.py
@@ -1,0 +1,23 @@
+import streamlit as st
+from datetime import time, datetime
+
+st.subheader("Slider")
+age = st.slider("How old are you?", 0, 130, 25)
+st.write("I'm ", age, "years old.")
+
+st.subheader("Range slider")
+values = st.slider("Select a range of values", 0.0, 100.0, (25.0, 75.0))
+st.write("Values:", values)
+
+st.subheader("Time slider")
+appointment = st.slider(
+    "Schedule your appointment:",
+    value=(time(11, 30), time(12, 45)),
+)
+st.write("You're scheduled for:", appointment)
+
+st.subheader("Datetime slider")
+start_time = st.slider(
+    "When do you start?", value=datetime(2020, 1, 1, 9, 30), format="MM/DD/YY - hh:mm"
+)
+st.write("Start time:", start_time)

--- a/python/api-examples-source/widget.text_area.py
+++ b/python/api-examples-source/widget.text_area.py
@@ -1,0 +1,17 @@
+import streamlit as st
+
+
+def run_sentiment_analysis(x):
+    return "dramatic"
+
+
+txt = st.text_area(
+    "Text to analyze",
+    """
+    It was the best of times, it was the worst of times, it was the age of
+    wisdom, it was the age of foolishness, it was the epoch of belief, it was
+    the epoch of incredulity, it was the season of Light, it was the season of
+    Darkness, it was the spring of hope, it was the winter of despair, (...)
+    """,
+)
+st.write("Sentiment:", run_sentiment_analysis(txt))

--- a/python/api-examples-source/widget.text_input.py
+++ b/python/api-examples-source/widget.text_input.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+title = st.text_input("Movie title", "Life of Brian")
+st.write("The current movie title is", title)

--- a/python/api-examples-source/widget.time_input.py
+++ b/python/api-examples-source/widget.time_input.py
@@ -1,0 +1,5 @@
+import streamlit as st
+import datetime
+
+t = st.time_input("Set an alarm for", datetime.time(8, 45))
+st.write("Alarm is set for", t)


### PR DESCRIPTION
Moving this code from the streamlit core repo to here, putting it into the `python` directory for now. We should consider another subfolder for the other Python code in this repo, since it appears to be used for generating the docs.