### PR TITLE
Fix on focus ring for section headings

### DIFF
--- a/styles/components/navigation/sideBar.scss
+++ b/styles/components/navigation/sideBar.scss
@@ -173,16 +173,16 @@
             }
         }
 
-        a:focus:not(:focus-visible) {
-          outline: none;
-        }
-
         ul, ol {
             margin: 0;
         }
 
         .nav-item {
             margin-bottom: 2em;
+
+            a {
+                display: inline-block;
+            }
 
             .head {
                 display: flex;

--- a/styles/components/navigation/sideBar.scss
+++ b/styles/components/navigation/sideBar.scss
@@ -173,6 +173,10 @@
             }
         }
 
+        a:focus:not(:focus-visible) {
+            outline: none;
+        }
+
         ul, ol {
             margin: 0;
         }

--- a/styles/components/navigation/sideBar.scss
+++ b/styles/components/navigation/sideBar.scss
@@ -180,8 +180,9 @@
         .nav-item {
             margin-bottom: 2em;
 
-            a {
+            & > a {
                 display: inline-block;
+                margin: 0 .125rem;
             }
 
             .head {


### PR DESCRIPTION
This PR adds focus ring to section headings, such as `Streamlit Library`, `Streamlit Cloud` as `Knowledge Base`, so you can tab through it