### PR TITLE
Fix on Collapsed Sidebar

### DIFF
--- a/styles/components/navigation/sideBar.scss
+++ b/styles/components/navigation/sideBar.scss
@@ -12,6 +12,7 @@
 
     .inner-nav {
         list-style: none;
+        overscroll-behavior: contain;
     }
 
     @media(min-width: 1250px) {


### PR DESCRIPTION
Use `overscroll-behavior: contain;` to prevent parent element scrolling when nav is expanded