### PR TITLE
Adds 1.1.0 notes to changelog

### DIFF
--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -17,17 +17,36 @@ $ pip install --upgrade streamlit
 
 </Tip>
 
+## Version 1.1.0
+
+_Release date: Oct 21, 2021_
+
+**Highlights**
+
+- 🧠 Memory improvements: Streamlit apps allocate way less memory over time now.
+
+**Notable Changes**
+
+- ♻️ Apps automatically rerun now when the content of `secrets.toml` changes (before this you had to refresh the page manually).
+
+**Other Changes**
+
+- 🔗 Redirected some links to our [brand-new docs site](https://docs.streamlit.io/), e.g. in exceptions.
+- 🪲 Bug fix: Allow initialization of range slider with session state ([#3586](https://github.com/streamlit/streamlit/issues/3586)).
+- 🐞 Bug fix: Refresh chart when using `add_rows` with `datetime` index ([#3653](https://github.com/streamlit/streamlit/issues/3653)).
+- ✍️ Added some more type annotation in our codebase ([#3908](https://github.com/streamlit/streamlit/issues/3908)).
+
 ## Version 1.0.0
 
 _Release date: Oct 5, 2021_
 
 **Highlights**
 
-- 🎈Announcing Streamlit 1.0! To read more about check out our [1.0 blog post](https://blog.streamlit.io/announcing-streamlit-1-0/)
+- 🎈Announcing Streamlit 1.0! To read more about check out our [1.0 blog post](https://blog.streamlit.io/announcing-streamlit-1-0/).
 
 **Other Changes**
 
-- 🐞 Fixed an issue where using `df.dtypes` to show datatypes for a DF fails while using Arrow ([#3709](https://github.com/streamlit/streamlit/issues/3709)), Image captions stay within image width and are readable ([#3530](https://github.com/streamlit/streamlit/issues/3530))
+- 🐞 Fixed an issue where using `df.dtypes` to show datatypes for a DF fails while using Arrow ([#3709](https://github.com/streamlit/streamlit/issues/3709)), Image captions stay within image width and are readable ([#3530](https://github.com/streamlit/streamlit/issues/3530)).
 
 ## Version 0.89.0
 
@@ -35,8 +54,8 @@ _Release date: Sep 22, 2021_
 
 **Highlights**
 
-- 💰 Introducing `st.experimental_memo` and `experimental_singleton`, a new primitive for caching! See [our blog post](https://blog.streamlit.io/new-experimental-primitives-for-caching/)
-- 🍔 Streamlit allows developers to configure their hamburger menu to be more user-centric
+- 💰 Introducing `st.experimental_memo` and `experimental_singleton`, a new primitive for caching! See [our blog post](https://blog.streamlit.io/new-experimental-primitives-for-caching/).
+- 🍔 Streamlit allows developers to configure their hamburger menu to be more user-centric.
 
 **Notable Changes**
 
@@ -47,7 +66,7 @@ _Release date: Sep 22, 2021_
 
 **Other Changes**
 
-- 🐞 Bug fixes: Support svgs from a URL ([#3809](https://github.com/streamlit/streamlit/pull/3809)) and that do not start with `<svg>` tag ([#3789](https://github.com/streamlit/streamlit/pull/3789))
+- 🐞 Bug fixes: Support svgs from a URL ([#3809](https://github.com/streamlit/streamlit/pull/3809)) and that do not start with `<svg>` tag ([#3789](https://github.com/streamlit/streamlit/pull/3789)).
 
 ## Version 0.88.0
 
@@ -55,7 +74,7 @@ _Release date: Sep 2, 2021_
 
 **Highlights**
 
-- ⬇️ Introducing `st.download_button`, a new button widget for easily downloading files
+- ⬇️ Introducing `st.download_button`, a new button widget for easily downloading files.
 
 **Notable Changes**
 
@@ -67,11 +86,11 @@ _Release date: Aug 19, 2021_
 
 **Highlights**
 
-- 🔢 Introducing `st.metric`, an API for displaying KPIs. Check out the [demo app](https://share.streamlit.io/streamlit/release-demos/0.87/0.87) showcasing the functionality
+- 🔢 Introducing `st.metric`, an API for displaying KPIs. Check out the [demo app](https://share.streamlit.io/streamlit/release-demos/0.87/0.87) showcasing the functionality.
 
 **Other Changes**
 
-- 🐞 **Bug Fixes**: File uploader retains state upon expander closing ([#3557](https://github.com/streamlit/streamlit/issues/3557)), setIn Error with `st.empty` ([#3659](https://github.com/streamlit/streamlit/issues/3659)), Missing IFrame embeds in docs ([#3706](https://github.com/streamlit/streamlit/issues/3706)), Fix error writing certain PNG files ([#3597](https://github.com/streamlit/streamlit/issues/3597))
+- 🐞 **Bug Fixes**: File uploader retains state upon expander closing ([#3557](https://github.com/streamlit/streamlit/issues/3557)), setIn Error with `st.empty` ([#3659](https://github.com/streamlit/streamlit/issues/3659)), Missing IFrame embeds in docs ([#3706](https://github.com/streamlit/streamlit/issues/3706)), Fix error writing certain PNG files ([#3597](https://github.com/streamlit/streamlit/issues/3597)).
 
 ## Version 0.86.0
 
@@ -83,11 +102,11 @@ _Release date: Aug 5, 2021_
 
 **Notable Changes**
 
-- 📱 When using `st.columns`, columns will stack vertically when viewport size <640px so that column layout on smaller viewports is consistent and cleaner. ([#3594](https://github.com/streamlit/streamlit/issues/3594))
+- 📱 When using `st.columns`, columns will stack vertically when viewport size <640px so that column layout on smaller viewports is consistent and cleaner. ([#3594](https://github.com/streamlit/streamlit/issues/3594)).
 
 **Other Changes**
 
-- 🐞 **Bug fixes**: Fixed `st.date_input` crashes if its empty ([#3194](https://github.com/streamlit/streamlit/issues/3194)), Opening files with utf-8([#3022](https://github.com/streamlit/streamlit/issues/3022)), `st.select_slider` resets its state upon interaction ([#3600](https://github.com/streamlit/streamlit/issues/3600))
+- 🐞 **Bug fixes**: Fixed `st.date_input` crashes if its empty ([#3194](https://github.com/streamlit/streamlit/issues/3194)), Opening files with utf-8([#3022](https://github.com/streamlit/streamlit/issues/3022)), `st.select_slider` resets its state upon interaction ([#3600](https://github.com/streamlit/streamlit/issues/3600)).
 
 ## Version 0.85.0
 
@@ -95,12 +114,12 @@ _Release date: Jul 22, 2021_
 
 **Highlights**
 
-- 🏹 Streamlit now uses [Apache Arrow](https://arrow.apache.org) for serializing data frames when they are sent from Streamlit server to the front end. See our [blog post](https://blog.streamlit.io/)
-  - (Users who wish to continue using the legacy data frame serialization can do so by setting the `dataFrameSerialization` config option to `"legacy"` in their `config.toml`)
+- 🏹 Streamlit now uses [Apache Arrow](https://arrow.apache.org) for serializing data frames when they are sent from Streamlit server to the front end. See our [blog post](https://blog.streamlit.io/).
+  - (Users who wish to continue using the legacy data frame serialization can do so by setting the `dataFrameSerialization` config option to `"legacy"` in their `config.toml`).
 
 **Other Changes**
 
-- 🐞 Bug fixes: Unresponsive pydeck example ([#3395](https://github.com/streamlit/streamlit/issues/3395)), JSON parse error message ([#2324](https://github.com/streamlit/streamlit/issues/2324)), Tooltips rendering ([#3300](https://github.com/streamlit/streamlit/issues/3300)), Colorpicker not working on Streamlit Sharing ([#2689](https://github.com/streamlit/streamlit/issues/2689))
+- 🐞 Bug fixes: Unresponsive pydeck example ([#3395](https://github.com/streamlit/streamlit/issues/3395)), JSON parse error message ([#2324](https://github.com/streamlit/streamlit/issues/2324)), Tooltips rendering ([#3300](https://github.com/streamlit/streamlit/issues/3300)), Colorpicker not working on Streamlit Sharing ([#2689](https://github.com/streamlit/streamlit/issues/2689)).
 
 ## Version 0.84.0
 


### PR DESCRIPTION
Adds 1.1.0 release notes to changelog in Core.

TODO: Run `make docstrings` once the 1.1.0 release is available on PyPi to update the API versions of all docstrings.