### PR TITLE
Redesigns KB layout and title casing

### DIFF
--- a/components/summaryTiles.js
+++ b/components/summaryTiles.js
@@ -6,7 +6,7 @@ export default function SummaryTiles() {
     <TileContainer>
       <Tile
         icon="arrow_forward"
-        title="Get Started"
+        title="Get started"
         text="If you're new to Streamlit and don't know where to start, this is a good place."
         background="violet-70"
         link="/library/get-started"
@@ -14,7 +14,7 @@ export default function SummaryTiles() {
 
       <Tile
         icon="dvr"
-        title="API Reference"
+        title="API reference"
         text="Learn about our APIs, with actionable explanations of specific functions and features."
         background="violet-70"
         link="/library/api-reference"
@@ -22,7 +22,7 @@ export default function SummaryTiles() {
 
       <Tile
         icon="grid_view"
-        title="App Gallery"
+        title="App gallery"
         text="Try out awesome apps created by our users, and curated from our forums or Twitter."
         background="orange-70"
         link="https://streamlit.io/gallery"

--- a/content/kb/dependencies/index.md
+++ b/content/kb/dependencies/index.md
@@ -1,9 +1,9 @@
 ---
-title: Installing Dependencies
+title: Installing dependencies
 slug: /knowledge-base/dependencies
 ---
 
-# Installing Dependencies
+# Installing dependencies
 
 - [ModuleNotFoundError: No module named](/knowledge-base/dependencies/module-not-found-error)
 - [ImportError: libGL.so.1: cannot open shared object file: No such file or directory](/knowledge-base/dependencies/libgl)

--- a/content/kb/index.md
+++ b/content/kb/index.md
@@ -3,46 +3,49 @@ title: Knowledge Base
 slug: /knowledge-base
 ---
 
-# Knowledge Base
+# Knowledge base
 
 The knowledge base is a self-serve library of tips, step-by-step tutorials, and articles that answer your questions about creating and deploying Streamlit apps.
 
-<TileContainer>
-    <Tile
-        icon="local_library"
-        background="orange-80"
-        title="Tutorials"
-        text="Our tutorials include step-by-step examples of building different types of apps in Streamlit."
-        link="/knowledge-base/tutorials"
-    />
-    <Tile
-        icon="auto_awesome"
-        background="orange-80"
-        title="Using Streamlit"
-        text="Here are some frequently asked questions about using Streamlit."
-        link="/knowledge-base/using-streamlit"
-    />
-    <Tile
-        icon="build"
-        background="orange-80"
-        title="Streamlit Components"
-        text="Here are some questions we've received about Streamlit Components."
-        link="/knowledge-base/components"
-    />
-    <Tile
-        size="half"
-        icon="downloading"
-        background="orange-80"
-        title="Installing Dependencies"
-        text="If you run into problems installing depedencies for your Streamlit apps, we've got you covered."
-        link="/knowledge-base/dependencies"
-    />
-    <Tile
-        size="half"
-        icon="report"
-        background="orange-80"
-        title="Deployment Issues"
-        text="Have questions about deploying Streamlit apps to the cloud? This section covers deployment-related issues."
-        link="/knowledge-base/deploy"
-    />
-</TileContainer>
+<InlineCalloutContainer>
+  <InlineCallout
+    color="orange-80"
+    icon="local_library"
+    bold="Tutorials."
+    href="/knowledge-base/tutorials"
+  >
+    Our tutorials include step-by-step examples of building different types of apps in Streamlit.
+  </InlineCallout>
+  <InlineCallout
+    color="orange-80"
+    icon="auto_awesome"
+    bold="Using Streamlit."
+    href="/knowledge-base/using-streamlit"
+  >
+    Here are some frequently asked questions about using Streamlit.
+  </InlineCallout>
+  <InlineCallout
+    color="orange-80"
+    icon="build"
+    bold="Streamlit Components."
+    href="/knowledge-base/components"
+  >
+    Here are some questions we've received about Streamlit Components.
+  </InlineCallout>
+  <InlineCallout
+    color="orange-80"
+    icon="downloading"
+    bold="Installing dependencies."
+    href="/knowledge-base/dependencies"
+  >
+    If you run into problems installing depedencies for your Streamlit apps, we've got you covered.
+  </InlineCallout>
+  <InlineCallout
+    color="orange-80"
+    icon="report"
+    bold="Deployment issues."
+    href="/knowledge-base/deploy"
+  >
+    Have questions about deploying Streamlit apps to the cloud? This section covers deployment-related issues.
+  </InlineCallout>
+</InlineCalloutContainer>

--- a/content/library/advanced-features/index.md
+++ b/content/library/advanced-features/index.md
@@ -1,9 +1,9 @@
 ---
-title: Advanced Features
+title: Advanced features
 slug: /library/advanced-features
 ---
 
-## Advanced Features
+## Advanced features
 
 This section gives you background on how different parts of Streamlit work.
 

--- a/content/library/api-cheat-sheet.md
+++ b/content/library/api-cheat-sheet.md
@@ -1,5 +1,5 @@
 ---
-title: Cheat Sheet
+title: Cheat sheet
 slug: /library/cheatsheet
 ---
 

--- a/content/library/get-started/index.md
+++ b/content/library/get-started/index.md
@@ -3,7 +3,7 @@ title: Get started
 slug: /library/get-started
 ---
 
-# Get Started
+# Get started
 
 This Get Started guide explains how Streamlit works, how to install Streamlit on your preferred
 operating system, and how to create your first Streamlit app!
@@ -23,28 +23,3 @@ operating system, and how to create your first Streamlit app!
   </InlineCallout> */}
 </InlineCalloutContainer>
 
-<!-- ## Share your app
-
-After you’ve built a Streamlit app, it's time to share it! To show it off to the world you can use **Streamlit Cloud** to deploy, manage, and share your app for free. Streamlit Cloud is currently invitation only, so please [request an invite](https://streamlit.io/sharing-sign-up) and we'll get you one soon! -->
-
-<!-- [[we'll need to grab the gif after the video editors are done with it on Wednesday]] -->
-
-<!-- It works in 3 simple steps:
-
-1. Put your app in a public Github repo (and make sure it has a requirements.txt!)
-2. Sign into [share.streamlit.io](https://share.streamlit.io)
-3. Click 'Deploy an app' and then paste in your GitHub URL
-
-That's it! **🎈**You now have a publicly deployed app that you can share with the world. Click to learn more about [how to use Streamlit Cloud](/streamlit-cloud/community). If you're looking for private sharing for your team, check out the [Team and Enterprise tiers](https://streamlit.io/cloud-sign-up).
-
-## Get help
-
-That's it for getting started, now you can go and build your own apps! If you
-run into difficulties here are a few things you can do. -->
-
-<!-- Check out our [community forum](https://discuss.streamlit.io/) and post a question
-Quick help from command line with `$ streamlit help`
-Read more documentation! Check out:
-[Streamlit Cookbook](/library/advanced-features/cookbook) for things like caching and
-  inserting elements out of order
-[API reference](/library/api-reference/) for examples of every Streamlit command -->

--- a/content/streamlit-cloud/index.md
+++ b/content/streamlit-cloud/index.md
@@ -12,7 +12,7 @@ Cloud](https://streamlit.io/cloud) to deploy and share your app. Streamlit Cloud
   <InlineCallout
     color="l-blue-70"
     icon="description"
-    bold="Community Tier."
+    bold="Community tier."
     href="/streamlit-cloud/community"
   >
     Formerly called Streamlit sharing, this is the perfect solution if your app is hosted in a public GitHub repo and you’d like anyone in the world to be able to access it <b>for free</b>!
@@ -20,7 +20,7 @@ Cloud](https://streamlit.io/cloud) to deploy and share your app. Streamlit Cloud
   <InlineCallout
     color="l-blue-70"
     icon="description"
-    bold="Teams and Enterprise."
+    bold="Teams and enterprise."
     href="/streamlit-cloud/enterprise"
   >
     Offers access controls, the ability to securely deploy apps from private repos, customize resources, and much more.

--- a/pages/index.js
+++ b/pages/index.js
@@ -65,13 +65,13 @@ export default function Home({ window, menu, gdpr_data }) {
 
             <H2>How to use our docs</H2>
             <InlineCalloutContainer>
-              <InlineCallout color="violet-70" icon="description" bold="Streamlit Library" href="/library/get-started">
-                includes our Get Started guide, API Reference, and more advanced features of the core library including caching, theming, and Streamlit components.
+              <InlineCallout color="violet-70" icon="description" bold="Streamlit library" href="/library/get-started">
+                includes our Get started guide, API reference, and more advanced features of the core library including caching, theming, and Streamlit Components.
               </InlineCallout>
               <InlineCallout color="l-blue-70" icon="cloud" bold="Streamlit Cloud" href="/streamlit-cloud">
                 empowers your data team to directly serve the needs of the rest of the company. Quickly go from data to app, from prototype to production. Share apps in one click and collaborate instantly with live code updates.
               </InlineCallout>
-              <InlineCallout color="orange-70" icon="school" bold="Knowledge Base" href="/knowledge-base">
+              <InlineCallout color="orange-70" icon="school" bold="Knowledge base" href="/knowledge-base">
                 is a self-serve library of tips, step-by-step tutorials, and articles that answer your questions about creating and deploying Streamlit apps.
               </InlineCallout>
               {/* <InlineCallout color="green-70" icon="code" bold="Cookbook" href="/cookbook">
@@ -95,7 +95,7 @@ export default function Home({ window, menu, gdpr_data }) {
           <SocialCallouts />
 
           <ArrowLinkContainer>
-            <ArrowLink link="/library/get-started" type="next" content="Get Started" />
+            <ArrowLink link="/library/get-started" type="next" content="Get started" />
           </ArrowLinkContainer>
         </section>
       </section>


### PR DESCRIPTION
- Replaces cards on the KB landing page with `InlineCallout`s, following the same pattern as the **Get started** and **Streamlit Cloud** sections.
- Fixes casing on few page titles.