### PR TITLE
Adjust mobile heading size

### DIFF
--- a/styles/global/fonts.scss
+++ b/styles/global/fonts.scss
@@ -39,6 +39,10 @@ h2 {
     letter-spacing: -0.02em;
     margin-bottom: 0.5em;
     margin-top: 1.25em;
+
+    @media screen and (max-width: 767px) {
+        font-size: 1.5rem;
+    }
 }
 
 h3 {


### PR DESCRIPTION
This PR fixes an issue on mobile about `h2` sizes: When you have a long word, such as a variable name, and since the font size is too big, it's causing the screen width to be larger than a standard mobile size (375px). See below 👇

<img width="392" alt="Screen Shot 2021-10-20 at 11 27 40" src="https://user-images.githubusercontent.com/34423371/138296798-dc696560-547f-4fd5-be6f-537cc23547d8.png">

