### PR TITLE
Add st.caption api-example

### DIFF
--- a/python/api-examples-source/text.caption.py
+++ b/python/api-examples-source/text.caption.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.caption('This is a caption')


### PR DESCRIPTION
Streamlit docs for `st.caption` currently shows how `st.title` works - fix implemented on streamlit/streamlit (PR link [here](https://github.com/streamlit/streamlit/pull/3949)). Adding static app example for `st.caption` here per Snehan's request :smile: