### PR TITLE
Fix small typo, add library imports in examples

### DIFF
--- a/content/library/get-started/main-concepts.md
+++ b/content/library/get-started/main-concepts.md
@@ -92,11 +92,9 @@ specifically for visualizing data.
 
 ### Use magic
 
-You can also write to your app without calling any
-Streamlit methods. Streamlit supports "[magic
-commands](/library/api-reference/write-magic/magic)," which means you don't have to use
-[`st.write()`](/library/api-reference/write-magic/st.write) at all! Try replacing the code above
-with this snippet:
+You can also write to your app without calling any Streamlit methods. 
+Streamlit supports "[magic commands](/library/api-reference/write-magic/magic)," which means you don't have to use
+[`st.write()`](/library/api-reference/write-magic/st.write) at all! To see this in action try this snippet:
 
 ```python
 """


### PR DESCRIPTION
Thank you for this amazing project 👍 

I just spotted a small typo while working through the Getting Started materials and thought the most direct way to communicate this is probably via a PR. I also added imports for pandas, streamlit & numpy the first time they are referenced in the examples. I believe this adds clarity for newcomers.