### PR TITLE
Links to Cloud Release notes app

### DIFF
--- a/content/menu.md
+++ b/content/menu.md
@@ -240,6 +240,8 @@ site_menu:
   #   url: /streamlit-cloud/additional-features
   - category: Streamlit Cloud / Trust and Security
     url: /streamlit-cloud/trust-and-security
+  - category: Streamlit Cloud / Release notes
+    url: https://share.streamlit.io/streamlit/cloud_release_notes_app/main/main.py
   # - category: Streamlit Cloud / Troubleshooting
   #   url: /streamlit-cloud/troubleshooting
   # - category: Streamlit Cloud / Community tier


### PR DESCRIPTION
Links to @maryharges'  [Release notes app](https://share.streamlit.io/streamlit/cloud_release_notes_app/main/main.py) from the Streamlit Cloud sidebar.