### PR TITLE
Updates redirects and links to Streamlit Cloud

### DIFF
--- a/content/kb/dependencies/module-not-found-error.md
+++ b/content/kb/dependencies/module-not-found-error.md
@@ -11,7 +11,7 @@ You receive the error `ModuleNotFoundError: No module named` when you deploy an 
 
 ## Solution
 
-This error occurs when you import a module on Streamlit Cloud that isn’t included in your requirements file. Any external [Python dependencies](/streamlit-cloud/community#add-python-dependencies) that are not distributed with a [standard Python installation](https://docs.python.org/3/py-modindex.html) should be included in your requirements file. 
+This error occurs when you import a module on Streamlit Cloud that isn’t included in your requirements file. Any external [Python dependencies](/streamlit-cloud/get-started/deploy-an-app/app-dependencies#add-python-dependencies) that are not distributed with a [standard Python installation](https://docs.python.org/3/py-modindex.html) should be included in your requirements file. 
 
 E.g. You will see `ModuleNotFoundError: No module named 'sklearn'` if you don’t include `scikit-learn` in your requirements file and `import sklearn` in your app.
 

--- a/content/kb/dependencies/no-matching-distribution.md
+++ b/content/kb/dependencies/no-matching-distribution.md
@@ -11,7 +11,7 @@ You receive the error `ERROR: No matching distribution found for` when you deplo
 
 ## Solution
 
-This error occurs when you deploy an app on Streamlit Cloud and have one or more of the following issues with your [Python dependencies](/streamlit-cloud/community#add-python-dependencies) in your requirements file:
+This error occurs when you deploy an app on Streamlit Cloud and have one or more of the following issues with your [Python dependencies](/streamlit-cloud/get-started/deploy-an-app/app-dependencies#add-python-dependencies) in your requirements file:
 
 1. The package is part of the [Python Standard Library](https://docs.python.org/3/py-modindex.html). E.g. You will see **`ERROR: No matching distribution found for base64`** if you include [`base64`](https://docs.python.org/3/library/base64.html) in your requirements file, as it is part of the Python Standard Library. The solution is to not include the package in your requirements file. Only include packages in your requirements file that are not distributed with a standard Python installation.
 2. The package name in your requirements file is misspelled. Double-check the package name before including it in your requirements file.

--- a/content/kb/tutorials/databases/aws-s3.md
+++ b/content/kb/tutorials/databases/aws-s3.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/aws-s3
 
 ## Introduction
 
-This guide explains how to securely access files on AWS S3 from Streamlit Cloud. It uses the [s3fs](https://github.com/dask/s3fs) library and Streamlit's [secrets management](/streamlit-cloud/community#secrets-management).
+This guide explains how to securely access files on AWS S3 from Streamlit Cloud. It uses the [s3fs](https://github.com/dask/s3fs) library and Streamlit's [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ## Create an S3 bucket and add a file
 
@@ -71,7 +71,7 @@ Add this file to `.gitignore` and don't commit it to your Github repo!
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/community#secrets-management).
+As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/bigquery.md
+++ b/content/kb/tutorials/databases/bigquery.md
@@ -9,7 +9,7 @@ slug: /knowledge-base/tutorials/databases/bigquery
 
 This guide explains how to securely access a BigQuery database from Streamlit Cloud. It uses the
 [google-cloud-bigquery](https://googleapis.dev/python/bigquery/latest/index.html) library and
-Streamlit's [secrets management](/streamlit-cloud/community#secrets-management).
+Streamlit's [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ## Create a BigQuery database
 
@@ -87,7 +87,7 @@ Add this file to `.gitignore` and don't commit it to your Github repo!
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/community#secrets-management).
+As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/index.md
+++ b/content/kb/tutorials/databases/index.md
@@ -6,7 +6,7 @@ slug: /knowledge-base/tutorials/databases
 # Connect Streamlit to data sources
 
 These step-by-step guides demonstrate how to connect Streamlit apps to various databases & APIs.
-They use Streamlit's [secrets management](/streamlit-cloud/community#secrets-management) and
+They use Streamlit's [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management) and
 [caching](/library/advanced-features/caching) to provide secure and fast data access.
 
 - [AWS S3](databases/aws-s3)

--- a/content/kb/tutorials/databases/mongodb.md
+++ b/content/kb/tutorials/databases/mongodb.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/mongodb
 
 ## Introduction
 
-This guide explains how to securely access a MongoDB database from Streamlit Cloud. It uses the [PyMongo](https://github.com/mongodb/mongo-python-driver) library and Streamlit's [secrets management](/streamlit-cloud/community#secrets-management).
+This guide explains how to securely access a MongoDB database from Streamlit Cloud. It uses the [PyMongo](https://github.com/mongodb/mongo-python-driver) library and Streamlit's [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ## Create a MongoDB Database
 
@@ -47,7 +47,7 @@ Add this file to `.gitignore` and don't commit it to your Github repo!
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/community#secrets-management).
+As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/mysql.md
+++ b/content/kb/tutorials/databases/mysql.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/mysql
 
 ## Introduction
 
-This guide explains how to securely access a MySQL database from Streamlit Cloud. It uses the [mysql-connector-python](https://github.com/mysql/mysql-connector-python) library and Streamlit's [secrets management](/streamlit-cloud/community#secrets-management).
+This guide explains how to securely access a MySQL database from Streamlit Cloud. It uses the [mysql-connector-python](https://github.com/mysql/mysql-connector-python) library and Streamlit's [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ## Create a MySQL database
 
@@ -56,7 +56,7 @@ Add this file to `.gitignore` and don't commit it to your Github repo!
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/community#secrets-management).
+As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/postgresql.md
+++ b/content/kb/tutorials/databases/postgresql.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/postgresql
 
 ## Introduction
 
-This guide explains how to securely access a PostgreSQL database from Streamlit Cloud. It uses the [psycopg2](https://www.psycopg.org/) library and Streamlit's [secrets management](/streamlit-cloud/community#secrets-management).
+This guide explains how to securely access a PostgreSQL database from Streamlit Cloud. It uses the [psycopg2](https://www.psycopg.org/) library and Streamlit's [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ## Create a PostgreSQL database
 
@@ -52,7 +52,7 @@ Add this file to `.gitignore` and don't commit it to your Github repo!
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/community#secrets-management).
+As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/private-gsheet.md
+++ b/content/kb/tutorials/databases/private-gsheet.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/private-gsheet
 
 ## Introduction
 
-This guide explains how to securely access a private Google Sheet from Streamlit Cloud. It uses the [gsheetsdb](https://github.com/betodealmeida/gsheets-db-api) library and Streamlit's [secrets management](/streamlit-cloud/community#secrets-management).
+This guide explains how to securely access a private Google Sheet from Streamlit Cloud. It uses the [gsheetsdb](https://github.com/betodealmeida/gsheets-db-api) library and Streamlit's [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 If you are fine with enabling link sharing for your Google Sheet (i.e. everyone with the link can view it), the guide [Connect Streamlit to a public Google Sheet](/knowledge-base/tutorials/databases/public-gsheet) shows a simpler method of doing this. If your Sheet contains sensitive information and you cannot enable link sharing, keep on reading.
 
@@ -95,7 +95,7 @@ Add this file to `.gitignore` and don't commit it to your Github repo!
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/community#secrets-management).
+As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/public-gsheet.md
+++ b/content/kb/tutorials/databases/public-gsheet.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/public-gsheet
 
 ## Introduction
 
-This guide explains how to securely access a public Google Sheet from Streamlit Cloud. It uses the [gsheetsdb](https://github.com/betodealmeida/gsheets-db-api) library and Streamlit's [secrets management](/streamlit-cloud/community#secrets-management).
+This guide explains how to securely access a public Google Sheet from Streamlit Cloud. It uses the [gsheetsdb](https://github.com/betodealmeida/gsheets-db-api) library and Streamlit's [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 This method requires you to enable link sharing for your Google Sheet. While the sharing link will not appear in your code (and actually acts as sort of a password!), someone with the link can get all the data in the Sheet. If you don't want this, follow the (more complicated) guide [Connect Streamlit to a private Google Sheet](private-gsheet).
 
@@ -43,7 +43,7 @@ Add this file to `.gitignore` and don't commit it to your Github repo!
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/community#secrets-management).
+As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/snowflake.md
+++ b/content/kb/tutorials/databases/snowflake.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/snowflake
 
 ## Introduction
 
-This guide explains how to securely access a Snowflake database from Streamlit Cloud. It uses the [snowflake-connector-python](https://docs.snowflake.com/en/user-guide/python-connector.html) library and Streamlit's [secrets management](/streamlit-cloud/community#secrets-management).
+This guide explains how to securely access a Snowflake database from Streamlit Cloud. It uses the [snowflake-connector-python](https://docs.snowflake.com/en/user-guide/python-connector.html) library and Streamlit's [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ## Create a Snowflake database
 
@@ -69,7 +69,7 @@ Add this file to `.gitignore` and don't commit it to your Github repo!
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/community#secrets-management).
+As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/tableau.md
+++ b/content/kb/tutorials/databases/tableau.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/tableau
 
 ## Introduction
 
-This guide explains how to securely access data on Tableau from Streamlit Cloud. It uses the [tableauserverclient](https://tableau.github.io/server-client-python/#) library and Streamlit's [secrets management](/streamlit-cloud/community#secrets-management).
+This guide explains how to securely access data on Tableau from Streamlit Cloud. It uses the [tableauserverclient](https://tableau.github.io/server-client-python/#) library and Streamlit's [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ## Create a Tableau site
 
@@ -61,7 +61,7 @@ Add this file to `.gitignore` and don't commit it to your Github repo!
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/community#secrets-management).
+As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/tigergraph.md
+++ b/content/kb/tutorials/databases/tigergraph.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/tigergraph
 
 ## Introduction
 
-This guide explains how to securely access a TigerGraph database from Streamlit Cloud. It uses the [pyTigerGraph](https://pytigergraph.github.io/pyTigerGraph/GettingStarted/) library and Streamlit's [secrets management](https://docs.streamlit.io/streamlit-cloud/community#secrets-management).
+This guide explains how to securely access a TigerGraph database from Streamlit Cloud. It uses the [pyTigerGraph](https://pytigergraph.github.io/pyTigerGraph/GettingStarted/) library and Streamlit's [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ## Create a TigerGraph Cloud Database
 
@@ -43,7 +43,7 @@ Add this file to `.gitignore` and don't commit it to your Github repo!
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on Edit Secrets. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](https://docs.streamlit.io/streamlit-cloud/community#secrets-management).
+As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on Edit Secrets. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/library/get-started/create-an-app.md
+++ b/content/library/get-started/create-an-app.md
@@ -399,7 +399,7 @@ It works in 3 simple steps:
 2. Sign into [share.streamlit.io](https://share.streamlit.io)
 3. Click 'Deploy an app' and then paste in your GitHub URL
 
-That's it! **🎈**You now have a publicly deployed app that you can share with the world. Click to learn more about [how to use Streamlit Cloud](/streamlit-cloud/community). If you're looking for private sharing for your team, check out the [Team and Enterprise tiers](https://streamlit.io/cloud-sign-up).
+That's it! **🎈**You now have a publicly deployed app that you can share with the world. Click to learn more about [how to use Streamlit Cloud](/streamlit-cloud). If you're looking for private sharing for your team, check out the [Team and Enterprise tiers](https://streamlit.io/cloud-sign-up).
 
 ## Get help
 

--- a/public/_redirects
+++ b/public/_redirects
@@ -5,7 +5,7 @@
 /en/latest/api.html    /library/api-reference
 /en/latest/caching.html    /library/api-reference/performance/st.cache
 /en/latest/changelog.html    /library/changelog
-/en/latest/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/latest/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/latest/develop_streamlit_components.html    /library/components
 /en/latest/getting_started.html    /library/get-started
 /en/latest/index.html    /
@@ -41,7 +41,7 @@
 /en/stable/api.html    /library/api-reference
 /en/stable/caching.html    /library/advanced-features/caching
 /en/stable/changelog.html    /library/changelog
-/en/stable/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/stable/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/stable/develop_streamlit_components.html    /library/components/components-api
 /en/stable/getting_started.html    /library/get-started
 /en/stable/index.html    /
@@ -212,7 +212,7 @@
 /en/0.68.0/api.md    /library/get-started
 /en/0.68.0/caching.html    /library/advanced-features/caching
 /en/0.68.0/changelog.html    /library/changelog
-/en/0.68.0/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/0.68.0/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/0.68.0/develop_streamlit_components.html    /library/components/components-api
 /en/0.68.0/getting_started.html    /library/get-started
 /en/0.68.0/getting_started.md    /library/get-started
@@ -235,7 +235,7 @@
 /en/0.69.0/api.md    /library/get-started
 /en/0.69.0/caching.html    /library/advanced-features/caching
 /en/0.69.0/changelog.html    /library/changelog
-/en/0.69.0/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/0.69.0/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/0.69.0/develop_streamlit_components.html    /library/components/components-api
 /en/0.69.0/getting_started.html    /library/get-started
 /en/0.69.0/getting_started.md    /library/get-started
@@ -258,7 +258,7 @@
 /en/0.70.0/api.md    /library/get-started
 /en/0.70.0/caching.html    /library/advanced-features/caching
 /en/0.70.0/changelog.html    /library/changelog
-/en/0.70.0/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/0.70.0/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/0.70.0/develop_streamlit_components.html    /library/components/components-api
 /en/0.70.0/getting_started.html    /library/get-started
 /en/0.70.0/getting_started.md    /library/get-started
@@ -281,7 +281,7 @@
 /en/0.71.0/api.md    /library/get-started
 /en/0.71.0/caching.html    /library/advanced-features/caching
 /en/0.71.0/changelog.html    /library/changelog
-/en/0.71.0/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/0.71.0/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/0.71.0/develop_streamlit_components.html    /library/components/components-api
 /en/0.71.0/getting_started.html    /library/get-started
 /en/0.71.0/getting_started.md    /library/get-started
@@ -304,7 +304,7 @@
 /en/0.72.0/api.md    /library/get-started
 /en/0.72.0/caching.html    /library/advanced-features/caching
 /en/0.72.0/changelog.html    /library/changelog
-/en/0.72.0/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/0.72.0/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/0.72.0/develop_streamlit_components.html    /library/components/components-api
 /en/0.72.0/getting_started.html    /library/get-started
 /en/0.72.0/getting_started.md    /library/get-started
@@ -327,7 +327,7 @@
 /en/0.73.0/api.md    /library/get-started
 /en/0.73.0/caching.html    /library/advanced-features/caching
 /en/0.73.0/changelog.html    /library/changelog
-/en/0.73.0/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/0.73.0/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/0.73.0/develop_streamlit_components.html    /library/components/components-api
 /en/0.73.0/getting_started.html    /library/get-started
 /en/0.73.0/getting_started.md    /library/get-started
@@ -350,7 +350,7 @@
 /en/0.74.0/api.md    /library/get-started
 /en/0.74.0/caching.html    /library/advanced-features/caching
 /en/0.74.0/changelog.html    /library/changelog
-/en/0.74.0/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/0.74.0/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/0.74.0/develop_streamlit_components.html    /library/components/components-api
 /en/0.74.0/getting_started.html    /library/get-started
 /en/0.74.0/getting_started.md    /library/get-started
@@ -373,7 +373,7 @@
 /en/0.75.0/api.md    /library/get-started
 /en/0.75.0/caching.html    /library/advanced-features/caching
 /en/0.75.0/changelog.html    /library/changelog
-/en/0.75.0/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/0.75.0/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/0.75.0/develop_streamlit_components.html    /library/components/components-api
 /en/0.75.0/getting_started.html    /library/get-started
 /en/0.75.0/getting_started.md    /library/get-started
@@ -396,7 +396,7 @@
 /en/0.76.0/api.md    /library/get-started
 /en/0.76.0/caching.html    /library/advanced-features/caching
 /en/0.76.0/changelog.html    /library/changelog
-/en/0.76.0/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/0.76.0/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/0.76.0/develop_streamlit_components.html    /library/components/components-api
 /en/0.76.0/getting_started.html    /library/get-started
 /en/0.76.0/getting_started.md    /library/get-started
@@ -419,7 +419,7 @@
 /en/0.77.0/api.md    /library/get-started
 /en/0.77.0/caching.html    /library/advanced-features/caching
 /en/0.77.0/changelog.html    /library/changelog
-/en/0.77.0/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/0.77.0/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/0.77.0/develop_streamlit_components.html    /library/components/components-api
 /en/0.77.0/getting_started.html    /library/get-started
 /en/0.77.0/getting_started.md    /library/get-started
@@ -442,7 +442,7 @@
 /en/0.78.0/api.md    /library/get-started
 /en/0.78.0/caching.html    /library/advanced-features/caching
 /en/0.78.0/changelog.html    /library/changelog
-/en/0.78.0/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/0.78.0/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/0.78.0/develop_streamlit_components.html    /library/components/components-api
 /en/0.78.0/getting_started.html    /library/get-started
 /en/0.78.0/getting_started.md    /library/get-started
@@ -464,7 +464,7 @@
 /en/0.79.0/api.html    /library/api-reference
 /en/0.79.0/caching.html    /library/advanced-features/caching
 /en/0.79.0/changelog.html    /library/changelog
-/en/0.79.0/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/0.79.0/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/0.79.0/develop_streamlit_components.html    /library/components/components-api
 /en/0.79.0/getting_started.html    /library/get-started
 /en/0.79.0/index.html    /
@@ -486,7 +486,7 @@
 /en/0.80.0/api.html    /library/api-reference
 /en/0.80.0/caching.html    /library/advanced-features/caching
 /en/0.80.0/changelog.html    /library/changelog
-/en/0.80.0/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/0.80.0/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/0.80.0/develop_streamlit_components.html    /library/components/components-api
 /en/0.80.0/getting_started.html    /library/get-started
 /en/0.80.0/index.html    /
@@ -508,7 +508,7 @@
 /en/0.81.0/api.html    /library/api-reference
 /en/0.81.0/caching.html    /library/advanced-features/caching
 /en/0.81.0/changelog.html    /library/changelog
-/en/0.81.0/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/0.81.0/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/0.81.0/develop_streamlit_components.html    /library/components/components-api
 /en/0.81.0/getting_started.html    /library/get-started
 /en/0.81.0/index.html    /
@@ -530,7 +530,7 @@
 /en/0.81.1/api.html    /library/api-reference
 /en/0.81.1/caching.html    /library/advanced-features/caching
 /en/0.81.1/changelog.html    /library/changelog
-/en/0.81.1/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/0.81.1/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/0.81.1/develop_streamlit_components.html    /library/components/components-api
 /en/0.81.1/getting_started.html    /library/get-started
 /en/0.81.1/index.html    /
@@ -552,7 +552,7 @@
 /en/0.82.0/api.html    /library/api-reference
 /en/0.82.0/caching.html    /library/advanced-features/caching
 /en/0.82.0/changelog.html    /library/changelog
-/en/0.82.0/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/0.82.0/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/0.82.0/develop_streamlit_components.html    /library/components/components-api
 /en/0.82.0/getting_started.html    /library/get-started
 /en/0.82.0/index.html    /
@@ -574,7 +574,7 @@
 /en/0.83.0/api.html    /library/api-reference
 /en/0.83.0/caching.html    /library/advanced-features/caching
 /en/0.83.0/changelog.html    /library/changelog
-/en/0.83.0/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/0.83.0/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/0.83.0/develop_streamlit_components.html    /library/components/components-api
 /en/0.83.0/getting_started.html    /library/get-started
 /en/0.83.0/index.html    /
@@ -605,7 +605,7 @@
 /en/0.84.0/api.html    /library/api-reference
 /en/0.84.0/caching.html    /library/advanced-features/caching
 /en/0.84.0/changelog.html    /library/changelog
-/en/0.84.0/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/0.84.0/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/0.84.0/develop_streamlit_components.html    /library/components/components-api
 /en/0.84.0/getting_started.html    /library/get-started
 /en/0.84.0/index.html    /
@@ -637,7 +637,7 @@
 /en/0.85.0/api.html    /library/api-reference
 /en/0.85.0/caching.html    /library/advanced-features/caching
 /en/0.85.0/changelog.html    /library/changelog
-/en/0.85.0/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/0.85.0/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/0.85.0/develop_streamlit_components.html    /library/components/components-api
 /en/0.85.0/getting_started.html    /library/get-started
 /en/0.85.0/index.html    /
@@ -670,7 +670,7 @@
 /en/0.86.0/api.html    /library/api-reference
 /en/0.86.0/caching.html    /library/advanced-features/caching
 /en/0.86.0/changelog.html    /library/changelog
-/en/0.86.0/deploy_streamlit_app.html    /streamlit-cloud/community
+/en/0.86.0/deploy_streamlit_app.html    /streamlit-cloud/get-started/deploy-an-app
 /en/0.86.0/develop_streamlit_components.html    /library/components/components-api
 /en/0.86.0/getting_started.html    /library/get-started
 /en/0.86.0/index.html    /
@@ -703,7 +703,7 @@
 /en/0.87.0/api.html		/library/api-reference
 /en/0.87.0/caching.html		/library/advanced-features/caching
 /en/0.87.0/changelog.html		/library/changelog
-/en/0.87.0/deploy_streamlit_app.html		/streamlit-cloud/community
+/en/0.87.0/deploy_streamlit_app.html		/streamlit-cloud/get-started/deploy-an-app
 /en/0.87.0/develop_streamlit_components.html		/library/components/components-api
 /en/0.87.0/getting_started.html		/library/get-started
 /en/0.87.0/index.html		/
@@ -736,7 +736,7 @@
 /en/0.88.0/api.html		/library/api-reference
 /en/0.88.0/caching.html		/library/advanced-features/caching
 /en/0.88.0/changelog.html		/library/changelog
-/en/0.88.0/deploy_streamlit_app.html		/streamlit-cloud/community
+/en/0.88.0/deploy_streamlit_app.html		/streamlit-cloud/get-started/deploy-an-app
 /en/0.88.0/develop_streamlit_components.html		/library/components/components-api
 /en/0.88.0/getting_started.html		/library/get-started
 /en/0.88.0/index.html		/
@@ -769,7 +769,7 @@
 /en/0.89.0/api.html		/library/api-reference
 /en/0.89.0/caching.html		/library/advanced-features/caching
 /en/0.89.0/changelog.html		/library/changelog
-/en/0.89.0/deploy_streamlit_app.html		/streamlit-cloud/community
+/en/0.89.0/deploy_streamlit_app.html		/streamlit-cloud/get-started/deploy-an-app
 /en/0.89.0/develop_streamlit_components.html		/library/components/components-api
 /en/0.89.0/getting_started.html		/library/get-started
 /en/0.89.0/index.html		/
@@ -802,7 +802,7 @@
 /en/1.0.0/api.html		/library/api-reference
 /en/1.0.0/caching.html		/library/advanced-features/caching
 /en/1.0.0/changelog.html		/library/changelog
-/en/1.0.0/deploy_streamlit_app.html		/streamlit-cloud/community
+/en/1.0.0/deploy_streamlit_app.html		/streamlit-cloud/get-started/deploy-an-app
 /en/1.0.0/develop_streamlit_components.html		/library/components/components-api
 /en/1.0.0/getting_started.html		/library/get-started
 /en/1.0.0/index.html		/
@@ -829,7 +829,7 @@
 /en/1.0.0/tutorial/private_gsheet.html		/knowledge-base/tutorials/databases/private-gsheet
 /en/1.0.0/tutorial/public_gsheet.html		/knowledge-base/tutorials/databases/public-gsheet
 /en/1.0.0/tutorial/tableau.html		/knowledge-base/tutorials/databases/tableau
-/deploy_streamlit_app.html	/streamlit-cloud/community
+/deploy_streamlit_app.html	/streamlit-cloud/get-started/deploy-an-app
 /tutorial/create_a_data_explorer_app.html	/library/get-started/create-an-app
 /getting_started.html	/library/get-started
 /develop_streamlit_components.html	/library/components/create


### PR DESCRIPTION
Replaces `/streamlit-cloud/community/*` links in `public/_redirects` and elsewhere in the docs with their new counterparts, as a result of restructuring the Streamlit Cloud section in #136. 