### PR TITLE
Fix on `/library` redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+  from = "/library"
+  to = "/library/get-started"
+  status = 301
+  force = true

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,4 @@
 
-/library/    /library/get-started
 /en/latest/    /
 /en/latest/add_state_app.html    /library/advanced-features/session-state
 /en/latest/advanced_concepts.html    /knowledge-base/using-streamlit


### PR DESCRIPTION
Move the `/library` redirect from the `_redirects` file to the `netlify.toml` config file. This allows us to use a few extra configuration rules, including the `force: true` directive to override the existing content on the `/library` path.

More information about this on [Netlify's docs](https://docs.netlify.com/routing/redirects/#syntax-for-the-netlify-configuration-file)