### PR TITLE
Make `/library` URL refresh the page

### DIFF
--- a/components/navigation/navItem.js
+++ b/components/navigation/navItem.js
@@ -68,11 +68,18 @@ export default class NavItem extends React.Component {
         if (props.page.url.startsWith('/')) {
             navItem = (
                 <li className="nav-item small" id={props.page.menu_key}>
-                    <Link href={props.page.url}>
-                        <a className="not-link">
+                    {/* TBD: Removed the <Link> component for now on the `/library` URL, to trigger a page refresh and redirect to `/library/get-started` until we have the `/library` page populated */}
+                    {props.page.url === '/library' ?
+                        <a className="not-link" href={props.page.url}>
                             {navBox}
                         </a>
-                    </Link>
+                        :
+                        <Link href={props.page.url}>
+                            <a className="not-link">
+                                {navBox}
+                            </a>
+                        </Link>
+                    }
                     {subNav}
                 </li>
             )


### PR DESCRIPTION
# The Problem:

The redirect from `/library` to `/library/get-started` isn’t working when clicking on the sidebar link because there’s no page reload. We’re using `next/link` for internal links, which is great because it does the rendering on the client-side and it’s really fast for the user, but in this case, it’s not causing the redirect we want.

# The Solution

Removing the `<Link>` component for the `/library` URL in the sidebar, and use regular `<a>` tags for it. That should cause the page refresh, and trigger the redirect