### PR TITLE
Left Navigation fix

### DIFF
--- a/components/navigation/navChild.js
+++ b/components/navigation/navChild.js
@@ -87,12 +87,10 @@ function NavChild(props) {
 
   link = (
     <span className={`child-item ${active ? "active" : ""}`}>
-      <Link href={url}>
-        <a className="not-link" target={target}>
-          <span className={`colored-ball bg-${props.color}`} />
-          <span>{props.page.name}</span> {icon}
-        </a>
-      </Link>
+      <a className="not-link" target={target} href={url}>
+        <span className={`colored-ball bg-${props.color}`} />
+        <span>{props.page.name}</span> {icon}
+      </a>
       {accordion}
     </span>
   );

--- a/components/navigation/navChild.js
+++ b/components/navigation/navChild.js
@@ -89,7 +89,7 @@ function NavChild(props) {
     <span className={`child-item ${active ? "active" : ""}`}>
       <Link href={url}>
         <a className="not-link" target={target}>
-          {active && <span className={`colored-ball bg-${props.color}`} />}
+          <span className={`colored-ball bg-${props.color}`} />
           <span>{props.page.name}</span> {icon}
         </a>
       </Link>

--- a/components/navigation/navChild.js
+++ b/components/navigation/navChild.js
@@ -1,102 +1,114 @@
-import findIndex from "lodash/findIndex"
+import findIndex from "lodash/findIndex";
 import React, { useState } from "react";
-import Link from 'next/link'
-import { useRouter } from 'next/router'
+import Link from "next/link";
+import { useRouter } from "next/router";
 
 function NavChild(props) {
-    const router = useRouter();
-    const slugStr = router.asPath
-    const shouldAutoOpen = slugStr.startsWith(props.page.url)
-    const [manualState, setManualState] = useState(null)
-    const opened = manualState ?? shouldAutoOpen
+  const router = useRouter();
+  const slugStr = router.asPath;
+  const shouldAutoOpen = slugStr.startsWith(props.page.url);
+  const [manualState, setManualState] = useState(null);
+  const opened = manualState ?? shouldAutoOpen;
 
-    const active = (slugStr === props.page.url) ? true : false
+  const active = slugStr === props.page.url ? true : false;
 
-    let subNav
+  let subNav;
 
-    const isnum = /^[\d\.]+$/.test(props.slug[0])
+  const isnum = /^[\d\.]+$/.test(props.slug[0]);
 
-    const toggleAccordion = () => {
-        setManualState(!opened)
+  const toggleAccordion = () => {
+    setManualState(!opened);
+  };
+
+  if (props.page.children?.length > 0 && opened) {
+    subNav = (
+      <ul className="child-sub-nav">
+        {props.page.children.map((child, index) => (
+          <NavChild
+            slug={props.slug}
+            key={child.menu_key}
+            page={child}
+            color={props.color}
+            depth={child.depth + 1}
+            paths={props.paths}
+            version={props.version}
+            maxVersion={props.maxVersion}
+          />
+        ))}
+      </ul>
+    );
+  }
+
+  let accordion;
+
+  if (isnum) {
+    props.slug.shift();
+  }
+
+  if (props.page.children?.length > 0) {
+    accordion = (
+      <i
+        className={`accordion ${opened ? "close" : "open"}`}
+        onClick={toggleAccordion}
+      >
+        {opened ? "remove" : "add"}
+      </i>
+    );
+  }
+
+  let link;
+  let icon;
+  let target;
+
+  if (!props.page.url.startsWith("/")) {
+    icon = <i className="external">open_in_new</i>;
+    target = "_blank";
+  }
+
+  let coloredBall;
+
+  if (active) {
+    coloredBall = <span className={`colored-ball bg-${props.color}`} />;
+  }
+
+  let url = props.page.url;
+
+  if (
+    props.version &&
+    props.version !== props.maxVersion &&
+    props.page.url.startsWith("/")
+  ) {
+    // We need to version this URL, Check if the URL has a version for this version
+    const newSlug = props.page.url.split("/");
+    newSlug[0] = props.version;
+    const newUrl = `/${newSlug.join("/")}`;
+    const index = findIndex(
+      props.paths.paths,
+      (path) => path.params.location === newUrl
+    );
+    if (index >= 0) {
+      url = props.paths.paths[index].params.location;
     }
+  }
 
-    if (props.page.children?.length > 0 && opened) {
-        subNav = (
-            <ul className="child-sub-nav">
-                {props.page.children.map((child, index) => (
-                    <NavChild
-                        slug={props.slug}
-                        key={child.menu_key}
-                        page={child}
-                        color={props.color}
-                        depth={child.depth + 1}
-                        paths={props.paths}
-                        version={props.version}
-                        maxVersion={props.maxVersion}
-                    />
-                ))}
-            </ul>
-        )
-    }
+  link = (
+    <span className={`child-item ${active ? "active" : ""}`}>
+      <Link href={url}>
+        <a className="not-link" target={target}>
+          {coloredBall}
+          <span>{props.page.name}</span> {icon}
+        </a>
+      </Link>
+      {accordion}
+    </span>
+  );
 
-    let accordion
-
-    if (isnum) {
-        props.slug.shift()
-    }
-
-    if (props.page.children?.length > 0) {
-        accordion = <i className={`accordion ${opened ? 'close' : 'open'}`} onClick={toggleAccordion}>{opened ? 'remove' : 'add'}</i>
-    }
-
-    let link
-    let icon
-    let target
-
-    if (!props.page.url.startsWith('/')) {
-        icon = (
-            <i className="external">open_in_new</i>
-        )
-        target = '_blank'
-    }
-
-    let coloredBall;
-
-    if (active) {
-        coloredBall = <span className={`colored-ball bg-${props.color}`}></span>
-    }
-
-    let url = props.page.url;
-
-    if (props.version && props.version !== props.maxVersion && props.page.url.startsWith('/')) {
-        // We need to version this URL, Check if the URL has a version for this version
-        const newSlug = props.page.url.split('/')
-        newSlug[0] = props.version
-        const newUrl = `/${newSlug.join('/')}`
-        const index = findIndex(props.paths.paths, (path) => path.params.location === newUrl)
-        if (index >= 0) {
-            url = props.paths.paths[index].params.location
-        }
-    }
-
-    link = (
-        <span className={`child-item ${active ? 'active' : ''}`}>
-            <Link href={url}>
-                <a className="not-link" target={target}>
-                    {coloredBall}
-                    <span>{props.page.name}</span> {icon}
-                </a>
-            </Link>
-            {accordion}
-        </span>
-    )
-
-    return (
-        <li className="child">
-            {link}
-            {subNav}
-        </li >
-    )
+  return (
+    <li className="child">
+      {link}
+      {subNav}
+    </li>
+  );
 }
 
 export default NavChild;

--- a/components/navigation/navChild.js
+++ b/components/navigation/navChild.js
@@ -65,12 +65,6 @@ function NavChild(props) {
     target = "_blank";
   }
 
-  let coloredBall;
-
-  if (active) {
-    coloredBall = <span className={`colored-ball bg-${props.color}`} />;
-  }
-
   let url = props.page.url;
 
   if (
@@ -95,7 +89,7 @@ function NavChild(props) {
     <span className={`child-item ${active ? "active" : ""}`}>
       <Link href={url}>
         <a className="not-link" target={target}>
-          {coloredBall}
+          {active && <span className={`colored-ball bg-${props.color}`} />}
           <span>{props.page.name}</span> {icon}
         </a>
       </Link>

--- a/components/navigation/navItem.js
+++ b/components/navigation/navItem.js
@@ -1,99 +1,89 @@
 import React from "react";
 
-import Link from 'next/link'
-import { urlInChildren } from '../../lib/utils.cjs'
+import Link from "next/link";
+import { urlInChildren } from "../../lib/utils.cjs";
 
-import NavChild from './navChild'
-
+import NavChild from "./navChild";
 
 export default class NavItem extends React.Component {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
+  }
+
+  trueName() {
+    return this.props.page.path.split("/").pop();
+  }
+  cleanName() {
+    return this.trueName().replaceAll("-", " ");
+  }
+  shouldHaveID() {
+    return this.offScreen ? this.page.name : false;
+  }
+
+  render() {
+    const props = this.props;
+
+    let subNav;
+    let url_in_child = false;
+
+    let navItem;
+
+    let navBox;
+    let active = urlInChildren(props.page, `/${props.slug.join("/")}`);
+    let condensed = props.condensed ? props.condensed : false;
+
+    // We only want the color to show when we're either active, or the menu is condensed.
+    let color = props.page.color ? `color-${props.page.color}` : "";
+    color = condensed || active ? color : "";
+
+    navBox = (
+      <section className={`head ${active ? "active" : ""}`}>
+        <div className={`icon-box bg-${props.page.color}`}>
+          <i>{props.page.icon}</i>
+        </div>
+        <p className={`bold large ${color}`}>{props.page.name}</p>
+      </section>
+    );
+
+    if (props.page.children && props.page.children.length > 0) {
+      subNav = (
+        <ul className="sub-nav">
+          {props.page.children.map((child, index) => (
+            <NavChild
+              slug={props.slug}
+              page={child}
+              color={props.page.color}
+              key={child.menu_key}
+              depth={child.depth + 1}
+              paths={props.paths}
+              version={props.version}
+              maxVersion={props.maxVersion}
+            />
+          ))}
+        </ul>
+      );
     }
 
-    trueName() {
-        return this.props.page.path.split('/').pop();
+    if (props.page.url.startsWith("/")) {
+      navItem = (
+        <li className="nav-item small" id={props.page.menu_key}>
+          <a className="not-link" href={props.page.url}>
+            {navBox}
+          </a>
+          {subNav}
+        </li>
+      );
+    } else {
+      navItem = (
+        <li className="nav-item small" id={props.page.menu_key}>
+          <a className="not-link" href={props.page.url} target="_blank">
+            {navBox}
+          </a>
+          {subNav}
+        </li>
+      );
     }
-    cleanName() {
-        return this.trueName().replaceAll('-', ' ');
-    }
-    shouldHaveID() {
-        return (this.offScreen ? this.page.name : false)
-    }
 
-    render() {
-        const props = this.props;
-
-        let subNav;
-        let url_in_child = false
-
-        let navItem;
-
-        let navBox;
-        let active = urlInChildren(props.page, `/${props.slug.join('/')}`)
-        let condensed = props.condensed ? props.condensed : false
-
-        // We only want the color to show when we're either active, or the menu is condensed.
-        let color = props.page.color ? `color-${props.page.color}` : ''
-        color = condensed || active ? color : ''
-
-        navBox = (
-            <section className={`head ${active ? 'active' : ''}`}>
-                <div className={`icon-box bg-${props.page.color}`}>
-                    <i>{props.page.icon}</i>
-                </div>
-                <p className={`bold large ${color}`}>{props.page.name}</p>
-            </section >
-        )
-
-        if (props.page.children && props.page.children.length > 0) {
-            subNav = (
-                <ul className="sub-nav">
-                    {props.page.children.map((child, index) => (
-                        <NavChild
-                            slug={props.slug}
-                            page={child}
-                            color={props.page.color}
-                            key={child.menu_key}
-                            depth={child.depth + 1}
-                            paths={props.paths}
-                            version={props.version}
-                            maxVersion={props.maxVersion}
-                        />
-                    ))}
-                </ul>
-            )
-        }
-
-        if (props.page.url.startsWith('/')) {
-            navItem = (
-                <li className="nav-item small" id={props.page.menu_key}>
-                    {/* TBD: Removed the <Link> component for now on the `/library` URL, to trigger a page refresh and redirect to `/library/get-started` until we have the `/library` page populated */}
-                    {props.page.url === '/library' ?
-                        <a className="not-link" href={props.page.url}>
-                            {navBox}
-                        </a>
-                        :
-                        <Link href={props.page.url}>
-                            <a className="not-link">
-                                {navBox}
-                            </a>
-                        </Link>
-                    }
-                    {subNav}
-                </li>
-            )
-        } else {
-            navItem = (
-                <li className="nav-item small" id={props.page.menu_key}>
-                    <a className="not-link" href={props.page.url} target="_blank">
-                        {navBox}
-                    </a>
-                    {subNav}
-                </li>
-            )
-        }
-
-        return navItem
-    }
+    return navItem;
+  }
 }


### PR DESCRIPTION
This PR fixes an issue where URLs using query params break the layout on the side navigation, but ended up being slightly deeper and more complex than just that. For more context and screenshots of the issue see [here](https://www.notion.so/streamlit/Fix-design-quirks-in-the-new-docs-left-navbar-11d1f0d23d864d858da12f60b537334c).

# The Problem

The `.active` class, which adds the bullet point to the nav item, gets added on the server side (when the page is generated) to the corresponding item. When using a query param on the URL, the `.active` class does not get added correctly to the element (because the URL is slightly different than its server-side counterpart), causing the rendering issue explained in the Notion page above:

* Example of a nav item with the [wrong HTML structure](https://share.getcloudapp.com/RBuE9Q9E);
* Example with the [correct HTML structure](https://share.getcloudapp.com/RBuE9Q9E)

Another issue derived from this  is that you could have [multiple active tags](https://share.getcloudapp.com/GGu42Gjw) when moving across child items from the same parent, because the `.active` tag was added on the server side, and never removed because the parent URL is the same on both items, and clicking through the `<Link>` components don't cause a full page refresh.

# The Solution

Adjusting the way the colored ball `<span>` gets rendered, and swapping the `<Link>` components to regular `<a>` tags fixed the issue, as clicking on the link refreshes the page, and effectively relocates the `.active` class.