### PR TITLE
Add Auth0 to configuring SSO page

### DIFF
--- a/content/menu.md
+++ b/content/menu.md
@@ -231,6 +231,8 @@ site_menu:
     url: /streamlit-cloud/get-started/share-your-app/configuring-single-on-sso/streamlit-azure-active-directory
   - category: Streamlit Cloud / Get started / Share your app / Configuring Single Sign-on (SSO) / Okta
     url: /streamlit-cloud/get-started/share-your-app/configuring-single-on-sso/streamlit-okta-sso
+  - category: Streamlit Cloud / Get started / Share your app / Configuring Single Sign-on (SSO) / Auth0
+    url: /streamlit-cloud/get-started/share-your-app/configuring-single-on-sso/streamlit-auth0-sso
   - category: Streamlit Cloud / Get started / Share your app / Configuring Single Sign-on (SSO) / Generic SAML
     url: /streamlit-cloud/get-started/share-your-app/configuring-single-on-sso/streamlit-general-saml-authentication
   - category: Streamlit Cloud / Get started / Manage your app

--- a/content/streamlit-cloud/get-started/share-your-app/single-sign-on/index.md
+++ b/content/streamlit-cloud/get-started/share-your-app/single-sign-on/index.md
@@ -15,6 +15,8 @@ If your organization uses **Google OAuth**, you're all set — just click "Conti
 
 - [Okta](/streamlit-cloud/get-started/share-your-app/configuring-single-on-sso/streamlit-okta-sso)
 
+- [Auth0](/streamlit-cloud/get-started/share-your-app/configuring-single-on-sso/streamlit-auth0-sso)
+
 - [Generic SAML](/streamlit-cloud/get-started/share-your-app/configuring-single-on-sso/streamlit-general-saml-authentication)
 
 

--- a/content/streamlit-cloud/get-started/share-your-app/single-sign-on/sso_auth0.md
+++ b/content/streamlit-cloud/get-started/share-your-app/single-sign-on/sso_auth0.md
@@ -1,0 +1,52 @@
+---
+title: Auth0 Single Sign-On
+slug: /streamlit-cloud/get-started/share-your-app/configuring-single-on-sso/streamlit-auth0-sso
+---
+
+## Auth0 Single Sign-On via SAML
+
+![Streamlit Single Sign-on homepage](/images/sso_homescreen.png)
+
+Auth0 via SAML is just one of the authenticators supported by Streamlit for Teams. We have already released documentation for Okta, Microsoft ADFS, Azure AD, and generic SAML.
+
+Enabling Single Sign-On via Auth0 allows members of your organization to securely sign in to Streamlit using the same email address and password they already use for Auth0.
+
+### Single Sign-On via Auth0 for developers of your organization's apps
+
+- Your developers can use Auth0 to log into Streamlit and access their app dashboard.
+- Your developers can also give access to app viewers through their Auth0 logins.
+
+### Single Sign-On via Auth0 for viewers of your organization's private apps
+
+- Viewers added to a private app can use Auth0 to authenticate their identity.
+- These viewers must be added to the app's viewer list by their Auth0-associated email address.
+
+## Configuring Auth0 SSO
+
+There are three steps your team will need to complete to create an Auth0 SSO connection:
+
+1. Please complete [this form](https://docs.google.com/forms/d/e/1FAIpQLSenELJzAZaBV8852b-HJMeecO_LAwYJ6zuYbXLK0lMVexCF4Q/viewform).
+
+    To complete steps 2 and 3, you will need an **ACS URL**, which Streamlit will provide by emailing you a private Google Drive link. Please complete [this form](https://forms.gle/5E3pUrB8vwp66ZPc9) to provide us with your email address and some basic information about your organization.
+
+2. Provide Streamlit with an Identity Provider Certificate.
+
+    - Follow [WorkOS' instructions](https://workos.com/docs/integrations/auth0-saml/obtain-identity-provider-details) to obtain the Identity Provider Certificate.
+    - Please share the Token Signature with Streamlit by uploading it [here](https://forms.gle/f6Bi1gnoHYD9ULBe7).
+
+<Note>
+
+The Token Signature is a certificate used to securely sign tokens issued by Auth0.
+
+</Note>
+
+3. Provide Streamlit with an Identity Provider Login URL and Auth0 Issuer.
+
+    - Follow [WorkOS' instructions](https://workos.com/docs/integrations/auth0-saml/obtain-identity-provider-details) to obtain the "Issuer" and Identity Provider Login URL.
+    - Please share the the "Issuer" and Identity Provider Login URL with Streamlit by pasting it [here](https://forms.gle/f6Bi1gnoHYD9ULBe7).
+
+<Note>
+
+The IdP SSO URL provides Streamlit with a login endpoint to redirect your organization's users from our login page to your Auth0 login page.
+
+</Note>

--- a/content/streamlit-cloud/get-started/share-your-app/single-sign-on/sso_azure.md
+++ b/content/streamlit-cloud/get-started/share-your-app/single-sign-on/sso_azure.md
@@ -21,7 +21,7 @@ Enabling Single Sign-On via Azure AD allows members of your organization to secu
 - Viewers added to a private app can use Azure AD SSO to authenticate their identity.
 - These viewers must be added to the app's viewer list by their Azure AD/org email address.
 
-## Configuration Microsoft Azure AD SSO
+## Configuring Microsoft Azure AD SSO
 
 There are three steps your team will need to complete to create an Azure AD connection:
 

--- a/content/streamlit-cloud/get-started/share-your-app/single-sign-on/sso_generic.md
+++ b/content/streamlit-cloud/get-started/share-your-app/single-sign-on/sso_generic.md
@@ -16,14 +16,14 @@ Enabling Single Sign-On via generic SAML allows members of your organization to 
 - Your developers can use SSO via generic SAML to log into Streamlit and access their app dashboard.
 - Your developers can also give access to app viewers through their generic SAML logins.
 
-### Single Sign-On via Okta for viewers of your organization's private apps
+### Single Sign-On via generic SAML for viewers of your organization's private apps
 
 - Viewers added to a private app can use SSO via generic SAML to authenticate their identity.
 - These viewers must be added to the app's viewer list by their generic SAML-associated email address.
 
-## Configuration Okta SSO
+## Configuring SSO via Generic SAML
 
-There are three steps your team will need to complete to create an Okta SSO connection:
+There are three steps your team will need to complete to configure SSO via generic SAML:
 
 1. Please complete [this form](https://docs.google.com/forms/d/e/1FAIpQLSenELJzAZaBV8852b-HJMeecO_LAwYJ6zuYbXLK0lMVexCF4Q/viewform)
 
@@ -31,12 +31,12 @@ There are three steps your team will need to complete to create an Okta SSO conn
 
 2. Provide Streamlit with a Token Signature (X.509 Certificate).
 
-    - Follow [WorkOS' instructions to generate the token signature](https://workos.com/docs/integrations/azure-ad-saml/overview) (see ["Obtain Identity Provider Details"](https://workos.com/docs/integrations/azure-ad-saml/obtain-identity-provider-details)).
+    - Your Token Signature comes from your Identity Provider and is often located in an admin dashboard. The exact steps to download the Token Signature will vary based on your Identity Provider.
     - Please share the Token Signature with Streamlit by uploading it [here](https://docs.google.com/forms/d/e/1FAIpQLSdtV7hdpMEgfbK4E7BqeYNTcDrT6IqjOfSvIA48SoNAeIhcgw/viewform?usp=sf_link).
 
 3. Provide Streamlit with an Identity Provider SSO URL.
 
-    - Follow [WorkOS' instructions to generate the IdP SSO URL](https://workos.com/docs/integrations/azure-ad-saml/overview) (see ["Obtain Identity Provider Details"](https://workos.com/docs/integrations/azure-ad-saml/obtain-identity-provider-details)).
+    - Your Identity Provider SSO URL comes from your Identity Provider and is often located in an admin dashboard. The exact steps to generate the Identity Provider SSO URL will vary based on your Identity Provider.
     - Please share the IdP SSO URL with Streamlit by pasting it [here](https://docs.google.com/forms/d/e/1FAIpQLSdtV7hdpMEgfbK4E7BqeYNTcDrT6IqjOfSvIA48SoNAeIhcgw/viewform?usp=sf_link).
 
 4. Provide Streamlit with an IdP URI (Entity ID)

--- a/content/streamlit-cloud/get-started/share-your-app/single-sign-on/sso_okta.md
+++ b/content/streamlit-cloud/get-started/share-your-app/single-sign-on/sso_okta.md
@@ -21,11 +21,11 @@ Enabling Single Sign-On via Okta allows members of your organization to securely
 - Viewers added to a private app can use Okta to authenticate their identity.
 - These viewers must be added to the app's viewer list by their Okta-associated email address.
 
-## Configuration Okta SSO
+## Configuring Okta SSO
 
 There are three steps your team will need to complete to create an Okta SSO connection:
 
-1. Please complete [this form](https://docs.google.com/forms/d/e/1FAIpQLSenELJzAZaBV8852b-HJMeecO_LAwYJ6zuYbXLK0lMVexCF4Q/viewform)
+1. Please complete [this form](https://docs.google.com/forms/d/e/1FAIpQLSenELJzAZaBV8852b-HJMeecO_LAwYJ6zuYbXLK0lMVexCF4Q/viewform).
 
     To complete steps 2 and 3, you will need an **ACS URL** and **Identity Provider URI (Entity ID)**, which Streamlit will provide by emailing you a private Google Drive link. Please complete [this form](https://forms.gle/5E3pUrB8vwp66ZPc9) to provide us with your email address and some basic information about your organization.
 
@@ -37,6 +37,7 @@ There are three steps your team will need to complete to create an Okta SSO conn
 <Note>
 
 The Token Signature is a certificate used to securely sign tokens issued by Okta.
+
 </Note>
 
 3. Provide Streamlit with an Identity Provider SSO URL.


### PR DESCRIPTION
Add Auth0 to configuring SSO page in Streamlit Cloud section.

- Adds [instructions](https://www.notion.so/streamlit/Add-Auth0-to-configuring-SSO-page-aaaad26b320e4bc19aa96c0ad7a4b139) on configuring Auth0 SSO via SAML 
- The `Generic SAML Single Sign-On` page contained instructions to configure Okta SSO. Replaced those incorrect instructions
- Corrected minor typos in headings