### PR TITLE
Add dark mode for docutils class

### DIFF
--- a/styles/global/dark.scss
+++ b/styles/global/dark.scss
@@ -261,6 +261,9 @@ body[data-theme="dark-mode"] {
         .code-desc {
             color: $white;
         }
+        .docutils {
+            color: $white;
+        }
         .code-header .title-with-select .version-select { 
             select {
                 color: $white;


### PR DESCRIPTION
@mesmith027 [noticed](https://www.notion.so/streamlit/st-columns-api-page-text-not-converting-to-white-on-dark-mode-0b53cc5c489b4b18a87b4d2983c62d8f) when helping someone that the parameter explanation for `st.columns` is being lost in dark mode. They are not automatically turning white. See screenshots below for before/after comparison:

### Before PR
![image](https://user-images.githubusercontent.com/20672874/140725810-644dd223-6672-408e-bbd8-05f9144b802c.png)

### After PR
![image](https://user-images.githubusercontent.com/20672874/140726035-cd80619e-ad61-41f1-8eff-019a33d1cb05.png)
