### PR TITLE
Don't change the case of breadcrumb characters

### DIFF
--- a/styles/components/utilities/breadcrumbs.scss
+++ b/styles/components/utilities/breadcrumbs.scss
@@ -14,7 +14,7 @@
     }
 
     a {
-      text-transform: capitalize;
+      text-transform: none;
       margin-right: 0.5em;
     }
   }


### PR DESCRIPTION
### Don't change the case of breadcrumb characters
- [Currently](https://www.notion.so/streamlit/Docs-Inbox-ee8e809c685a476dbb2667ecb46e5c51?p=a0c58c252a004932b2e34b2add73d1b4), the first letter of each word in the breadcrumb is capitalized—a departure from our page titles and TOC.
- This PR prevents the case of all characters in the breadcrumb from being changed. i.e. the case in the breadcrumb is identical those specified in `content/menu.md`.

### Before PR:
![image](https://user-images.githubusercontent.com/20672874/140907709-3e48cf62-faa1-4e00-a454-b342bacd5a1c.png)

### After PR:
![image](https://user-images.githubusercontent.com/20672874/140908079-4220740f-07e6-4753-9e03-32a41820d87f.png)
