### PR TITLE
Add meta descriptions to few API pages

### DIFF
--- a/content/library/api/text/caption.md
+++ b/content/library/api/text/caption.md
@@ -1,6 +1,7 @@
 ---
 title: st.caption
 slug: /library/api-reference/text/st.caption
+description: st.caption displays text in small font.
 ---
 
 <Autofunction function="streamlit.caption" />

--- a/content/library/api/text/header.md
+++ b/content/library/api/text/header.md
@@ -1,6 +1,7 @@
 ---
 title: st.header
 slug: /library/api-reference/text/st.header
+description: st.header displays text in header formatting.
 ---
 
 <Autofunction function="streamlit.header" />

--- a/content/library/api/text/markdown.md
+++ b/content/library/api/text/markdown.md
@@ -1,6 +1,7 @@
 ---
 title: st.markdown
 slug: /library/api-reference/text/st.markdown
+description: st.markdown displays string formatted as Markdown.
 ---
 
 <Autofunction function="streamlit.markdown" />

--- a/content/library/api/text/subheader.md
+++ b/content/library/api/text/subheader.md
@@ -1,6 +1,7 @@
 ---
 title: st.subheader
 slug: /library/api-reference/text/st.subheader
+description: st.subheader displays text in subheader formatting.
 ---
 
 <Autofunction function="streamlit.subheader" />

--- a/content/library/api/text/title.md
+++ b/content/library/api/text/title.md
@@ -1,6 +1,7 @@
 ---
 title: st.title
 slug: /library/api-reference/text/st.title
+description: st.title displays text in title formatting.
 ---
 
 <Autofunction function="streamlit.title" />

--- a/content/library/api/write-magic/write.md
+++ b/content/library/api/write-magic/write.md
@@ -1,6 +1,7 @@
 ---
 title: st.write
 slug: /library/api-reference/write-magic/st.write
+description: st.write writes arguments to the app.
 ---
 
 <Autofunction function="streamlit.write" />


### PR DESCRIPTION
### Add meta descriptions to few API pages
- At @CharlyWargnier's request, this PR adds meta descriptions to five Streamlit API pages. The idea is to check whether search engines properly index these meta descriptions and, if so, add meta descriptions to the remaining Streamlit API pages in a future PR.
- The meta description is a small blurb that appears in search engines. It gives users the right context, helps them decide if they want to click, improves branding, UX, and click-through rates from search.

