### PR TITLE
Fix spacing in frontend note

### DIFF
--- a/content/library/components/components-api.md
+++ b/content/library/components/components-api.md
@@ -145,6 +145,7 @@ The example app from the template shows how bi-directional communication is impl
 Because each Streamlit Component is its own webpage that gets rendered into an `iframe`, you can use just about any web tech you'd like to create that web page. We provide two templates to get started with in the Streamlit [Components-template GitHub repo](https://github.com/streamlit/component-template/); one of those templates uses [React](https://reactjs.org/) and the other does not.
 
 <Note>
+
 Even if you're not already familiar with React, you may still want to check out the React-based
 template. It handles most of the boilerplate required to send and receive data from Streamlit, and
 you can learn the bits of React you need as you go.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2762787/141497633-3fabd1a9-0c25-411c-ac75-bda81208488a.png)

Adding a line break should fix this on the bi-directional components section