### PR TITLE
Fix on duplicated slugs for headings

### DIFF
--- a/components/blocks/headers.js
+++ b/components/blocks/headers.js
@@ -1,19 +1,19 @@
 import HeaderLink from "../utilities/headerLink";
 
 export const H1 = (props) => (
-  <HeaderLink level={1} name={getName(props)} className={props.className}>
+  <HeaderLink level={1} name={props.id} className={props.className}>
     {getBody(props)}
   </HeaderLink>
 );
 
 export const H2 = (props) => (
-  <HeaderLink level={2} name={getName(props)} className={props.className}>
+  <HeaderLink level={2} name={props.id} className={props.className}>
     {getBody(props)}
   </HeaderLink>
 );
 
 export const H3 = (props) => (
-  <HeaderLink level={3} name={getName(props)} className={props.className}>
+  <HeaderLink level={3} name={props.id} className={props.className}>
     {getBody(props)}
   </HeaderLink>
 );

--- a/components/blocks/headers.js
+++ b/components/blocks/headers.js
@@ -1,19 +1,19 @@
 import HeaderLink from "../utilities/headerLink";
 
 export const H1 = (props) => (
-  <HeaderLink level={1} name={props.id} className={props.className}>
+  <HeaderLink level={1} name={getName(props)} className={props.className}>
     {getBody(props)}
   </HeaderLink>
 );
 
 export const H2 = (props) => (
-  <HeaderLink level={2} name={props.id} className={props.className}>
+  <HeaderLink level={2} name={getName(props)} className={props.className}>
     {getBody(props)}
   </HeaderLink>
 );
 
 export const H3 = (props) => (
-  <HeaderLink level={3} name={props.id} className={props.className}>
+  <HeaderLink level={3} name={getName(props)} className={props.className}>
     {getBody(props)}
   </HeaderLink>
 );
@@ -48,6 +48,8 @@ export function cleanHref(name) {
 function getName(props) {
   if (props.name) {
     return props.name;
+  } else if (props.id) {
+    return props.id;
   }
 
   let nodesToTraverse = Array.isArray(props.children)


### PR DESCRIPTION
This PR fixes an issue where titles with the same content (such as `Create a new environment with Streamlit` and `Use your new environment` on [this page](https://docs.streamlit.io/library/get-started/installation)) will have the same id, resulting on issues with the floating navigation.