### PR TITLE
Add note about type annotations to changelog

### DIFF
--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -28,7 +28,7 @@ _Release date: Nov 11, 2021_
 - 📁 Streamlit can auto-reload when files in sub-directories change.
 - 🌈 We've upgraded Bokeh support to 2.4.1! We recommend updating your Bokeh library to 2.4.1 to maintain functionality. Going forward, we'll let you know if there's a mismatch in your Bokeh version via an error prompt.
 - 🔒 Developers can access secrets via attribute notation (e.g. `st.secrets.key` vs `st.secrets["key"]`) just like session state.
-- ✍️ Publish type annotations according to [PEP 561](https://mypy.readthedocs.io/en/stable/installed_packages.html) ([#4025](https://github.com/streamlit/streamlit/pull/4025)). Users now get type annotations for streamlit when running mypy.
+- ✍️ Publish type annotations according to [PEP 561](https://mypy.readthedocs.io/en/stable/installed_packages.html). Users now get type annotations for Streamlit when running mypy ([#4025](https://github.com/streamlit/streamlit/pull/4025)).
 
 **Other Changes**
 

--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -28,6 +28,7 @@ _Release date: Nov 11, 2021_
 - 📁 Streamlit can auto-reload when files in sub-directories change.
 - 🌈 We've upgraded Bokeh support to 2.4.1! We recommend updating your Bokeh library to 2.4.1 to maintain functionality. Going forward, we'll let you know if there's a mismatch in your Bokeh version via an error prompt.
 - 🔒 Developers can access secrets via attribute notation (e.g. `st.secrets.key` vs `st.secrets["key"]`) just like session state.
+- ✍️ Publish type annotations according to [PEP 561](https://mypy.readthedocs.io/en/stable/installed_packages.html) ([#4025](https://github.com/streamlit/streamlit/pull/4025)). Users now get type annotations for streamlit when running mypy.
 
 **Other Changes**
 


### PR DESCRIPTION
This is a potentially breaking change for anyone who was previously using mypy and streamlit (either by writing their own stubs or using `# type: ignore`).