### PR TITLE
Sanity Checks - Update Streamlit version # to latest

### DIFF
--- a/content/kb/using-streamlit/sanity-checks.md
+++ b/content/kb/using-streamlit/sanity-checks.md
@@ -39,7 +39,7 @@ pip install --upgrade streamlit
 streamlit version
 ```
 
-...and then verify that the version number printed is `0.84.0`.
+...and then verify that the version number printed is `1.2.0`.
 
 **Try reproducing the issue now.** If not fixed, keep reading on.
 


### PR DESCRIPTION
Came across [this page](https://docs.streamlit.io/knowledge-base/using-streamlit/sanity-checks) in docs and noticed old version number in Check 2. This PR updates it, but perhaps manually updating for each release isn't very practical?

<img width="500" alt="Screen Shot 2021-11-16 at 10 09 31 AM" src="https://user-images.githubusercontent.com/63436329/142042012-8978eba6-378a-4cc3-a260-ab55ccd9916b.png">



