### PR TITLE
Fixes missing imports in example code blocks (#89)

### DIFF
--- a/content/library/advanced-features/experimental-cache-primitives.md
+++ b/content/library/advanced-features/experimental-cache-primitives.md
@@ -36,6 +36,8 @@ While `@st.cache` tries to solve two very different problems simultaneously (cac
 Use [`@st.experimental_memo`](/library/api-reference/performance/st.experimental_memo) to store expensive computation which can be "cached" or "memoized" in the traditional sense. It has almost the exact same API as the existing `@st.cache`, so you can often blindly replace one for the other:
 
 ```python
+import streamlit as st
+
 @st.experimental_memo
 def factorial(n):
 	if n < 1:
@@ -54,6 +56,10 @@ f9 = factorial(9)  # Returns instantly!
 For example:
 
 ```python
+import streamlit as st
+import pandas as pd
+from sqlalchemy.orm import sessionmaker
+
 @st.experimental_memo
 def get_page(_sessionmaker, page_size, page):
 	"""Retrieve rows from the RNA database, and cache them.
@@ -90,6 +96,7 @@ def get_page(_sessionmaker, page_size, page):
 Example usage:
 
 ```python
+import streamlit as st
 from sqlalchemy.orm import sessionmaker
 
 @st.experimental_singleton

--- a/content/library/advanced-features/session-state.md
+++ b/content/library/advanced-features/session-state.md
@@ -46,6 +46,8 @@ Let's learn more about the API to use Session State.
 The Session State API follows a field-based API, which is very similar to Python dictionaries:
 
 ```python
+import streamlit as st
+
 # Check if 'key' already exists in session_state
 # If not, then initialize it
 if 'key' not in st.session_state:
@@ -61,6 +63,11 @@ if 'key' not in st.session_state:
 Read the value of an item in Session State by passing the item to `st.write` :
 
 ```python
+import streamlit as st
+
+if 'key' not in st.session_state:
+    st.session_state['key'] = 'value'
+
 # Reads
 st.write(st.session_state.key)
 
@@ -70,6 +77,11 @@ st.write(st.session_state.key)
 Update an item in Session State by assigning it a value:
 
 ```python
+import streamlit as st
+
+if 'key' not in st.session_state:
+    st.session_state['key'] = 'value'
+
 # Updates
 st.session_state.key = 'value2'     # Attribute API
 st.session_state['key'] = 'value2'  # Dictionary like API
@@ -78,6 +90,8 @@ st.session_state['key'] = 'value2'  # Dictionary like API
 Streamlit throws an exception if an uninitialized variable is accessed:
 
 ```python
+import streamlit as st
+
 st.write(st.session_state['value'])
 
 # Throws an exception!
@@ -241,6 +255,8 @@ Streamlit **does not allow** setting widget values via the Session State API for
 The following example will raise a `StreamlitAPIException` on trying to set the state of `st.button` via the Session State API:
 
 ```python
+import streamlit as st
+
 if 'my_button' not in st.session_state:
     st.session_state.my_button = True
     # Streamlit will raise an Exception on trying to set the state of button

--- a/content/library/get-started/main-concepts.md
+++ b/content/library/get-started/main-concepts.md
@@ -102,6 +102,7 @@ Streamlit supports "[magic commands](/library/api-reference/write-magic/magic),"
 Here's our first attempt at using data to create a table:
 """
 
+import streamlit as st
 import pandas as pd
 df = pd.DataFrame({
   'first column': [1, 2, 3, 4],
@@ -126,6 +127,7 @@ will figure it out and render things the right way.
 
 ```python
 import streamlit as st
+import pandas as pd
 
 st.write("Here's our first attempt at using data to create a table:")
 st.write(pd.DataFrame({
@@ -165,6 +167,7 @@ DataFrames, Numpy arrays, or plain Python arrays.
 </Note>
 
 ```python
+import streamlit as st
 import numpy as np
 
 dataframe = np.random.randn(10, 20)
@@ -175,6 +178,10 @@ Let's expand on the first example using the Pandas `Styler` object to highlight
 some elements in the interactive table.
 
 ```python
+import streamlit as st
+import numpy as np
+import pandas as pd
+
 dataframe = pd.DataFrame(
     np.random.randn(10, 20),
     columns=('col %d' % i for i in range(20)))
@@ -186,6 +193,10 @@ Streamlit also has a method for static table generation:
 [`st.table()`](/library/api-reference/data/st.table).
 
 ```python
+import streamlit as st
+import numpy as np
+import pandas as pd
+
 dataframe = pd.DataFrame(
     np.random.randn(10, 20),
     columns=('col %d' % i for i in range(20)))
@@ -205,6 +216,10 @@ You can easily add a line chart to your app with
 sample using Numpy and then chart it.
 
 ```python
+import streamlit as st
+import numpy as np
+import pandas as pd
+
 chart_data = pd.DataFrame(
      np.random.randn(20, 3),
      columns=['a', 'b', 'c'])
@@ -219,6 +234,10 @@ Let's use Numpy to generate some sample data and plot it on a map of
 San Francisco.
 
 ```python
+import streamlit as st
+import numpy as np
+import pandas as pd
+
 map_data = pd.DataFrame(
     np.random.randn(1000, 2) / [50, 50] + [37.76, -122.4],
     columns=['lat', 'lon'])
@@ -269,6 +288,10 @@ which is the widget label. In this sample, the checkbox is used to toggle a
 conditional statement.
 
 ```python
+import streamlit as st
+import numpy as np
+import pandas as pd
+
 if st.checkbox('Show dataframe'):
     chart_data = pd.DataFrame(
        np.random.randn(20, 3),
@@ -286,6 +309,14 @@ column.
 Let's use the `df` data frame we created earlier.
 
 ```python
+import streamlit as st
+import pandas as pd
+
+df = pd.DataFrame({
+    'first column': [1, 2, 3, 4],
+    'second column': [10, 20, 30, 40]
+    })
+
 option = st.selectbox(
     'Which number do you like best?',
      df['first column'])
@@ -362,6 +393,9 @@ import time
 Now, let's create a progress bar:
 
 ```python
+import streamlit as st
+import time
+
 'Starting a long computation...'
 
 # Add a placeholder
@@ -434,6 +468,8 @@ To use the cache, wrap functions with the
 [`@st.cache`](/library/api-reference/performance/st.cache) decorator:
 
 ```python
+import streamlit as st
+
 @st.cache  # 👈 This function will be cached
 def my_slow_function(arg1, arg2):
     # Do something really slow in here!


### PR DESCRIPTION
### Fixes (#89) missing imports in example code blocks
- Adds missing imports to several code blocks in our documentation. This change will allow users to directly copy and execute those code blocks, without additional imports.
- Fixes #89.