### PR TITLE
Fix on sidebar links overlay on small desktop resolutions

### DIFF
--- a/styles/components/navigation/sideBar.scss
+++ b/styles/components/navigation/sideBar.scss
@@ -3,7 +3,7 @@
   position: fixed;
   top: 0;
   height: calc(100vh - #{$header-height});
-  z-index: 10;
+  z-index: 0;
   width: 314px;
 
   * {
@@ -78,6 +78,8 @@
   }
 
   &.over {
+    z-index: 10;
+
     @media (max-width: 1024px) {
       display: block;
     }


### PR DESCRIPTION
This PR fixes https://github.com/streamlit/docs/issues/175 by removing the higher `z-index` value when the sidebar is collapsed, and adding it when it's expanded