### PR TITLE
Various fixes on Sidebar links

### DIFF
--- a/components/navigation/navItem.js
+++ b/components/navigation/navItem.js
@@ -42,8 +42,8 @@ const NavItem = ({ page, slug, condensed }) => {
   if (page.url.startsWith("/")) {
     navItem = (
       <li className="nav-item small" id={page.menu_key}>
-        {page.url.startsWith("/library") ? (
-          <a href={page.url} className="not-link">
+        {page.url === "/library" ? (
+          <a href={page.url} className="not-link test">
             {navBox}
           </a>
         ) : (

--- a/components/navigation/navItem.js
+++ b/components/navigation/navItem.js
@@ -42,18 +42,24 @@ const NavItem = ({ page, slug, condensed }) => {
   if (page.url.startsWith("/")) {
     navItem = (
       <li className="nav-item small" id={page.menu_key}>
-        <Link className="not-link" href={page.url}>
-          {navBox}
-        </Link>
+        {page.url.startsWith("/library") ? (
+          <a href={page.url} className="not-link">
+            {navBox}
+          </a>
+        ) : (
+          <Link href={page.url}>
+            <a className="not-link">{navBox}</a>
+          </Link>
+        )}
         {subNav}
       </li>
     );
   } else {
     navItem = (
       <li className="nav-item small" id={page.menu_key}>
-        <Link className="not-link" href={page.url} target="_blank">
+        <a className="not-link" href={page.url} target="_blank">
           {navBox}
-        </Link>
+        </a>
         {subNav}
       </li>
     );


### PR DESCRIPTION
# The Problem

When navigating the docs site using the sidebar, the `/library` URL should redirect folks to `/library/get-started`, but it isn't. Seems like using Next’s `<Link />` component on the sidebar is preventing the page from redirecting, since there’s no full page refresh.

# The Solution

This PR adds a condition to check the page URL, and if it's `/library`, we replace Next's `<Link />` component, and use an `<a>` tag instead.