### PR TITLE
Add KB article on updating Streamlit version on Cloud

### DIFF
--- a/content/kb/deployments/index.md
+++ b/content/kb/deployments/index.md
@@ -12,3 +12,4 @@ slug: /knowledge-base/deploy
 - [Argh. This app has gone over its resource limits.](/knowledge-base/deploy/resource-limits)
 - [App is not loading when running remotely](/knowledge-base/deploy/remote-start)
 - [Authentication without SSO](/knowledge-base/deploy/authentication-without-sso)
+- [Upgrade the Streamlit version of your app on Streamlit Cloud](/knowledge-base/deploy/upgrade-streamlit-version-on-streamlit-cloud)

--- a/content/kb/deployments/upgrade-streamlit-version.md
+++ b/content/kb/deployments/upgrade-streamlit-version.md
@@ -1,0 +1,20 @@
+---
+title: Upgrade the Streamlit version of your app on Streamlit Cloud
+slug: /knowledge-base/deploy/upgrade-streamlit-version-on-streamlit-cloud
+---
+
+# Upgrade the Streamlit version of your app on Streamlit Cloud
+
+Want to use a cool new Streamlit feature but your app on Streamlit Cloud is running an old version of the Streamlit library? If that's you, don't worry! All you need to do is upgrade your app's Streamlit version. Here are four ways to do this, based on how your [app manages dependencies](https://docs.streamlit.io/streamlit-cloud/get-started/deploy-an-app/app-dependencies):
+
+## No dependency file
+
+Reboot the app. Visit the app on Streamlit Cloud, click on the **Manage app** field in the bottom right (while logged in), go into the three-dot dropdown menu, and click on **Reboot app**. After a few minutes, your app should come back running the newest version of the Streamlit library.
+
+## requirements.txt
+
+If the Streamlit version is not pinned (i.e., the requirements file contains a line with `streamlit` and nothing else), reboot the app as described above. If the Streamlit version is pinned (e.g., `streamlit==1.0.0`), adapt the pinned version in the requirements file and push it to GitHub. The app on Streamlit Cloud will reboot automatically as soon as it detects these changes. 
+
+## pipenv/poetry/conda
+
+If you use any of these dependency managers, you probably know what you need to do. 😉 On your local computer, run the command to update the Streamlit package (e.g., `pipenv update streamlit`, `poetry update streamlit`, or with activated conda environment `pip install -U streamlit` + `conda env export`), then push any changes to Pipfile.lock or poetry.lock or environment.yml to GitHub. The app on Streamlit Cloud will reboot automatically as soon as it detects these changes. 

--- a/content/kb/deployments/upgrade-streamlit-version.md
+++ b/content/kb/deployments/upgrade-streamlit-version.md
@@ -5,16 +5,34 @@ slug: /knowledge-base/deploy/upgrade-streamlit-version-on-streamlit-cloud
 
 # Upgrade the Streamlit version of your app on Streamlit Cloud
 
-Want to use a cool new Streamlit feature but your app on Streamlit Cloud is running an old version of the Streamlit library? If that's you, don't worry! All you need to do is upgrade your app's Streamlit version. Here are four ways to do this, based on how your [app manages dependencies](https://docs.streamlit.io/streamlit-cloud/get-started/deploy-an-app/app-dependencies):
+Want to use a cool new Streamlit feature but your app on Streamlit Cloud is running an old version of the Streamlit library? If that's you, don't worry! All you need to do is upgrade your app's Streamlit version. Here are five ways to do this, based on how your [app manages dependencies](/streamlit-cloud/get-started/deploy-an-app/app-dependencies):
 
 ## No dependency file
 
-Reboot the app. Visit the app on Streamlit Cloud, click on the **Manage app** field in the bottom right (while logged in), go into the three-dot dropdown menu, and click on **Reboot app**. After a few minutes, your app should come back running the newest version of the Streamlit library.
+#### Reboot the app
 
-## requirements.txt
+1. Visit the app on Streamlit Cloud.
+2. Click on the **Manage app** field in the bottom right (while logged in).
+3. Go into the three-dot dropdown menu, and click on **Reboot app**.
+4. After a few minutes, your app should come back running the newest version of the Streamlit library.
 
-If the Streamlit version is not pinned (i.e., the requirements file contains a line with `streamlit` and nothing else), reboot the app as described above. If the Streamlit version is pinned (e.g., `streamlit==1.0.0`), adapt the pinned version in the requirements file and push it to GitHub. The app on Streamlit Cloud will reboot automatically as soon as it detects these changes. 
+## `requirements.txt`
+
+1. If the Streamlit version is not pinned (i.e., the requirements file contains a line with `streamlit` and nothing else):
+   - Reboot the app as described above.
+2. If the Streamlit version is pinned (e.g., `streamlit==1.0.0`):
+   - Adapt the pinned version in the requirements file and push it to GitHub.
+   - The app on Streamlit Cloud will reboot automatically as soon as it detects these changes.
 
 ## pipenv/poetry/conda
 
-If you use any of these dependency managers, you probably know what you need to do. 😉 On your local computer, run the command to update the Streamlit package (e.g., `pipenv update streamlit`, `poetry update streamlit`, or with activated conda environment `pip install -U streamlit` + `conda env export`), then push any changes to Pipfile.lock or poetry.lock or environment.yml to GitHub. The app on Streamlit Cloud will reboot automatically as soon as it detects these changes. 
+If you use any of these dependency managers, you probably know what you need to do. 😉
+
+1. On your local computer, run the command to update the Streamlit package:
+   - `pipenv update streamlit` or
+   - `poetry update streamlit` or
+   - With an activated conda environment, run:
+     - `pip install -U streamlit` **and**
+     - `conda env export`
+2. Then push any changes to Pipfile.lock or poetry.lock or environment.yml to GitHub.
+3. The app on Streamlit Cloud will reboot automatically as soon as it detects these changes.


### PR DESCRIPTION
Adds a small article to the Deployment Issues section of the knowledge base, explaining how to upgrade the Streamlit version of an app deployed on Streamlit Cloud. We will link to this article from the redesigned Argh / over resource limits error page.

Feel free to adapt formatting as you like. Note that I did not test this (no clue how to build the docs).