### PR TITLE
Add KB article on how to install from GitHub

### DIFF
--- a/content/kb/dependencies/index.md
+++ b/content/kb/dependencies/index.md
@@ -8,3 +8,4 @@ slug: /knowledge-base/dependencies
 - [ModuleNotFoundError: No module named](/knowledge-base/dependencies/module-not-found-error)
 - [ImportError: libGL.so.1: cannot open shared object file: No such file or directory](/knowledge-base/dependencies/libgl)
 - [ERROR: No matching distribution found for](/knowledge-base/dependencies/no-matching-distribution)
+- [How to install a package not on PyPI/Conda but available on GitHub](/knowledge-base/dependencies/install-package-not-pypi-conda-available-github)

--- a/content/kb/dependencies/install-package-pypi-github.md
+++ b/content/kb/dependencies/install-package-pypi-github.md
@@ -1,0 +1,48 @@
+---
+title: How to install a package not on PyPI/Conda but available on GitHub
+slug: /knowledge-base/dependencies/install-package-not-pypi-conda-available-github
+---
+
+# How to install a package not on PyPI/Conda but available on GitHub
+
+## Overview
+
+Are you trying to deploy your app to [Streamlit Cloud](/streamlit-cloud), but don't know how to specify a [Python dependency](/streamlit-cloud/get-started/deploy-an-app/app-dependencies#add-python-dependencies) in your requirements file that is available on GitHub but not any package index like PyPI or Conda? If so, continue reading to find out how!
+
+Let's suppose you want to install `SomePackage` and its Python dependencies from GitHub, a hosting service for the popular version control system (VCS) Git. And suppose `SomePackage` is found at the the following URL: `https://github.com/SomePackage.git`.
+
+pip (via `requirements.txt`) [supports](https://pip.pypa.io/en/stable/topics/vcs-support/) installing from GitHub. This support requires a working executable to be available (for Git). It is used through a URL prefix: `git+`.
+
+## Specify the GitHub web URL
+
+To install `SomePackage`, innclude the following in your `requirements.txt` file:
+
+```bash
+git+https://github.com/SomePackage#egg=SomePackage
+```
+
+You can even specify a "git ref" such as branch name, a commit hash or a tag name, as shown in the examples below.
+
+## Specify a Git branch name
+
+Install `SomePackage` by specifying a branch name such as `main`, `master`, `develop`, etc, in `requirements.txt`:
+
+```bash
+git+https://github.com/SomePackage.git@main#egg=SomePackage
+```
+
+## Specify a commit hash
+
+Install `SomePackage` by specifying a commit hash in `requirements.txt`:
+
+```bash
+git+https://github.com/SomePackage.git@eb40b4ff6f7c5c1e4366cgfg0671291bge918#egg=SomePackage
+```
+
+## Specify a tag
+
+Install `SomePackage` by specifying a tag in `requirements.txt`:
+
+```bash
+git+https://github.com/SomePackage.git@v1.1.0#egg=SomePackage
+```


### PR DESCRIPTION
This PR adds a KB article on how to install a package and its Python dependencies on Streamlit Cloud when the package isn't available on a package index but is available on GitHub. 