### PR TITLE
Update free tier docs: private repo and viewer auth

### DIFF
--- a/content/streamlit-cloud/get-started/share-your-app/index.md
+++ b/content/streamlit-cloud/get-started/share-your-app/index.md
@@ -15,11 +15,11 @@ Your app is now live at that fixed URL, so go wild and share it with whomever yo
 
 ## Sharing private apps
 
-By default all apps deployed from a Teams or Enterprise workspace are private to the developers in the workspace, which means that others in your company won't be able to view them unless you give them explicit permission. You can grant permission either in your workspace or from the app itself.
+By default all apps deployed from private source code are private to the developers in the workspace, which means that others in your company won't be able to view them unless you give them explicit permission. You can grant permission either in your workspace or from the app itself.
 
 ![Sharing private apps](/images/streamlit-cloud/sharing-private-apps.png)
 
-### What is view auth?
+### What is viewer auth?
 
 Viewer auth allows you to restrict the viewers of your app using single sign-on (SSO), which means listing out the specified Gmail, G-Suite, and SSO-enabled email addresses and specified domains that your company uses.
 

--- a/content/streamlit-cloud/get-started/share-your-app/index.md
+++ b/content/streamlit-cloud/get-started/share-your-app/index.md
@@ -15,7 +15,7 @@ Your app is now live at that fixed URL, so go wild and share it with whomever yo
 
 ## Sharing private apps
 
-By default all apps deployed from private source code are private to the developers in the workspace, which means that others in your company won't be able to view them unless you give them explicit permission. You can grant permission either in your workspace or from the app itself.
+By default all apps deployed from private source code are private to the developers in the workspace. Your apps will not be visible to anyone else unless you grant them explicit permission. You can grant permission either in your workspace or from the app itself.
 
 ![Sharing private apps](/images/streamlit-cloud/sharing-private-apps.png)
 

--- a/content/streamlit-cloud/get-started/share-your-app/single-sign-on/index.md
+++ b/content/streamlit-cloud/get-started/share-your-app/single-sign-on/index.md
@@ -5,7 +5,7 @@ slug: /streamlit-cloud/get-started/share-your-app/configuring-single-on-sso
 
 # Configuring Single Sign-on (SSO)
 
-By default all apps deployed from private source code are private to the developers in the workspace, which means that others in your company won't be able to view them unless you give them explicit permission.
+By default all apps deployed from private source code are private to the developers in the workspace. Your apps will not be visible to anyone else unless you grant them explicit permission.
 
 If your organization uses **Google OAuth**, you're all set — just click "Continue with Google" to sign into Streamlit Cloud. If your organization uses another SSO provider, check out our guides below.
 

--- a/content/streamlit-cloud/get-started/share-your-app/single-sign-on/index.md
+++ b/content/streamlit-cloud/get-started/share-your-app/single-sign-on/index.md
@@ -5,7 +5,7 @@ slug: /streamlit-cloud/get-started/share-your-app/configuring-single-on-sso
 
 # Configuring Single Sign-on (SSO)
 
-By default all apps deployed with Streamlit Cloud Teams and Enterprise are private, which means that others in your company won't be able to view them unless you give them explicit permission.
+By default all apps deployed from private source code are private to the developers in the workspace, which means that others in your company won't be able to view them unless you give them explicit permission.
 
 If your organization uses **Google OAuth**, you're all set — just click "Continue with Google" to sign into Streamlit Cloud. If your organization uses another SSO provider, check out our guides below.
 


### PR DESCRIPTION
This PR [updates the language](https://www.notion.so/streamlit/More-Free-Tier-doc-updates-c9473c3724ed43f69412bad212a04516) in our docs to reflect the below change:
- With the free tier expansion of Streamlit Cloud, all apps deployed from private repos remain private in the developers' workspace.  