### PR TITLE
KB article on Session State updating on 2nd click

### DIFF
--- a/content/kb/using-streamlit/index.md
+++ b/content/kb/using-streamlit/index.md
@@ -26,4 +26,4 @@ Here are some frequently asked questions about using Streamlit. If you feel some
 - [How to record a screencast?](/knowledge-base/using-streamlit/record-screencast)
 - [How do I upgrade to the latest version of Streamlit?](/knowledge-base/using-streamlit/how-upgrade-latest-version-streamlit)
 - [How do I hide the hamburger menu from my app?](/knowledge-base/using-streamlit/how-hide-hamburger-menu-app)
-- [Widget updating for every second input using session state](/knowledge-base/using-streamlit/widget-updating-session-state)
+- [Widget updating for every second input when using session state](/knowledge-base/using-streamlit/widget-updating-session-state)

--- a/content/kb/using-streamlit/index.md
+++ b/content/kb/using-streamlit/index.md
@@ -26,3 +26,4 @@ Here are some frequently asked questions about using Streamlit. If you feel some
 - [How to record a screencast?](/knowledge-base/using-streamlit/record-screencast)
 - [How do I upgrade to the latest version of Streamlit?](/knowledge-base/using-streamlit/how-upgrade-latest-version-streamlit)
 - [How do I hide the hamburger menu from my app?](/knowledge-base/using-streamlit/how-hide-hamburger-menu-app)
+- [Widget updating for every second input using session state](/knowledge-base/using-streamlit/widget-updating-session-state)

--- a/content/kb/using-streamlit/widget-updating-session-state.md
+++ b/content/kb/using-streamlit/widget-updating-session-state.md
@@ -7,15 +7,15 @@ slug: /knowledge-base/using-streamlit/widget-updating-session-state
 
 ## Overview
 
-You are using [session state](/library/api-reference/session-state) to store page interactions in your app. When users interact with a widget in your app (e.g., click on a button), you expect your app to update its widget states and reflect the new values. However, you notice that it doesn't. Instead, users have interact with the widget twice (e.g., click a button twice) for the app to show the correct values. What do you now? 🤔 Let's walk through the solution in the section below.
+You are using [session state](/library/api-reference/session-state) to store page interactions in your app. When users interact with a widget in your app (e.g., click a button), you expect your app to update its widget states and reflect the new values. However, you notice that it doesn't. Instead, users have to interact with the widget twice (e.g., click a button twice) for the app to show the correct values. What do you now? 🤔 Let's walk through the solution in the section below.
 
 ## Solution
 
-When using session state to update widgets or values in your script, you need to use the unique key you assigned to the widget, **not** the variable that you assigned to your widget. In the example code block below, the unique _key_ assigned to the slider widget is `slider`, and the _variable_ the widget is assigned to is `slide_val`.
+When using session state to update widgets or values in your script, you need to use the unique key you assigned to the widget, **not** the variable that you assigned your widget to. In the example code block below, the unique _key_ assigned to the slider widget is `slider`, and the _variable_ the widget is assigned to is `slide_val`.
 
-Let's see this in an example. Say you want a user to press a button that resets a slider.
+Let's see this in an example. Say you want a user to click a button that resets a slider.
 
-To have the slider's value update on the button press, you need to use a [callback function](/library/api-reference/session-state#use-callbacks-to-update-session-state) with the `on_click` parameter of [`st.button`](/library/api-reference/widgets/st.button):
+To have the slider's value update on the button click, you need to use a [callback function](/library/api-reference/session-state#use-callbacks-to-update-session-state) with the `on_click` parameter of [`st.button`](/library/api-reference/widgets/st.button):
 
 ```python
 # the callback function for the button will add 1 to the

--- a/content/kb/using-streamlit/widget-updating-session-state.md
+++ b/content/kb/using-streamlit/widget-updating-session-state.md
@@ -1,24 +1,24 @@
 ---
-title: Widget updating for every second input using session state
+title: Widget updating for every second input when using session state
 slug: /knowledge-base/using-streamlit/widget-updating-session-state
 ---
 
-# Widget updating for every second input using session state
+# Widget updating for every second input when using session state
 
 ## Overview
 
-You are using session state to store page interactions in your app. You expect that once the user presses a button, or interacts with a widget, your app will update and reflect the new values, but it doesn't. Instead, you have to click the button or interact with the widget twice to get the app to show the correct values.
+You are using [session state](/library/api-reference/session-state) to store page interactions in your app. When users interact with a widget in your app (e.g., click on a button), you expect your app to update its widget states and reflect the new values. However, you notice that it doesn't. Instead, users have interact with the widget twice (e.g., click a button twice) for the app to show the correct values. What do you now? 🤔 Let's walk through the solution in the section below.
 
 ## Solution
 
-When using [state](/library/api-reference/session-state) to update widgets or values in your script you need to use the actual key and value pair that you stored in state and NOT the variable that you assigned to your widget.
+When using session state to update widgets or values in your script, you need to use the unique key you assigned to the widget, **not** the variable that you assigned to your widget. In the example code block below, the unique _key_ assigned to the slider widget is `slider`, and the _variable_ the widget is assigned to is `slide_val`.
 
-Let's see this in an example, say you want a user to press a button and that would reset a slider.
+Let's see this in an example. Say you want a user to press a button that resets a slider.
 
-To have the slider's value update on the button press we need to use the [callback function](/library/api-reference/session-state#use-callbacks-to-update-session-state) of the button, `on_click`.
+To have the slider's value update on the button press, you need to use a [callback function](/library/api-reference/session-state#use-callbacks-to-update-session-state) with the `on_click` parameter of [`st.button`](/library/api-reference/widgets/st.button):
 
 ```python
-# the call back function for the button will add 1 to the
+# the callback function for the button will add 1 to the
 # slider value up to 10
 def plus_one():
     if st.session_state["slider"] < 10:
@@ -27,8 +27,8 @@ def plus_one():
         pass
     return
 
-# on calling the button, add the on_click parameter and pass
-# the name of your callback function
+# when creating the button, assign the name of your callback
+# function to the on_click parameter
 add_one = st.button("Add one to the slider", on_click=plus_one, key="add_one")
 
 # create the slider

--- a/content/kb/using-streamlit/widget-updating-session-state.md
+++ b/content/kb/using-streamlit/widget-updating-session-state.md
@@ -7,15 +7,19 @@ slug: /knowledge-base/using-streamlit/widget-updating-session-state
 
 ## Overview
 
+You are using session state to store page interactions in your app. You expect that once the user presses a button, or interacts with a widget, your app will update and reflect the new values, but it doesn't. Instead, you have to click the button or interact with the widget twice to get the app to show the correct values.
+
 ## Solution
 
 When using [state](/library/api-reference/session-state) to update widgets or values in your script you need to use the actual key and value pair that you stored in state and NOT the variable that you assigned to your widget.
 
 Let's see this in an example, say you want a user to press a button and that would reset a slider.
 
-To have the slider's value update on the button press we need to use the call back function of the button, `on_click`.
+To have the slider's value update on the button press we need to use the [callback function](/library/api-reference/session-state#use-callbacks-to-update-session-state) of the button, `on_click`.
 
 ```python
+# the call back function for the button will add 1 to the
+# slider value up to 10
 def plus_one():
     if st.session_state["slider"] < 10:
         st.session_state.slider += 1
@@ -23,11 +27,15 @@ def plus_one():
         pass
     return
 
+# on calling the button, add the on_click parameter and pass
+# the name of your callback function
 add_one = st.button("Add one to the slider", on_click=plus_one, key="add_one")
 
+# create the slider
 slide_val = st.slider("Pick a number", 0, 10, key="slider")
 ```
 
 ## Relevant resources
 
-- [title](link to post)
+- [Caching Sqlite DB connection resulting in glitchy rendering of the page](https://discuss.streamlit.io/t/caching-sqlite-db-connection-resulting-in-glitchy-rendering-of-the-page/19017)
+- [Select all checkbox that is linked to selectbox of options](https://discuss.streamlit.io/t/select-all-checkbox-that-is-linked-to-selectbox-of-options/18521)

--- a/content/kb/using-streamlit/widget-updating-session-state.md
+++ b/content/kb/using-streamlit/widget-updating-session-state.md
@@ -1,0 +1,33 @@
+---
+title: Widget updating for every second input using session state
+slug: /knowledge-base/using-streamlit/widget-updating-session-state
+---
+
+# Widget updating for every second input using session state
+
+## Overview
+
+## Solution
+
+When using [state](/library/api-reference/session-state) to update widgets or values in your script you need to use the actual key and value pair that you stored in state and NOT the variable that you assigned to your widget.
+
+Let's see this in an example, say you want a user to press a button and that would reset a slider.
+
+To have the slider's value update on the button press we need to use the call back function of the button, `on_click`.
+
+```python
+def plus_one():
+    if st.session_state["slider"] < 10:
+        st.session_state.slider += 1
+    else:
+        pass
+    return
+
+add_one = st.button("Add one to the slider", on_click=plus_one, key="add_one")
+
+slide_val = st.slider("Pick a number", 0, 10, key="slider")
+```
+
+## Relevant resources
+
+- [title](link to post)


### PR DESCRIPTION
This PR adds an article to the KB on how to properly update widgets with session state and callbacks.