### PR TITLE
Change allowlist IP addresses from 4 to 6

### DIFF
--- a/content/kb/using-streamlit/widget-updating-session-state.md
+++ b/content/kb/using-streamlit/widget-updating-session-state.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/using-streamlit/widget-updating-session-state
 
 ## Overview
 
-You are using [session state](/library/api-reference/session-state) to store page interactions in your app. When users interact with a widget in your app (e.g., click a button), you expect your app to update its widget states and reflect the new values. However, you notice that it doesn't. Instead, users have to interact with the widget twice (e.g., click a button twice) for the app to show the correct values. What do you now? 🤔 Let's walk through the solution in the section below.
+You are using [session state](/library/api-reference/session-state) to store page interactions in your app. When users interact with a widget in your app (e.g., click a button), you expect your app to update its widget states and reflect the new values. However, you notice that it doesn't. Instead, users have to interact with the widget twice (e.g., click a button twice) for the app to show the correct values. What do you do now? 🤔 Let's walk through the solution in the section below.
 
 ## Solution
 

--- a/content/streamlit-cloud/get-started/deploy-an-app/connect-data-sources/stable-outbound-ip-addresses.md
+++ b/content/streamlit-cloud/get-started/deploy-an-app/connect-data-sources/stable-outbound-ip-addresses.md
@@ -5,7 +5,7 @@ slug: /streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/stable-
 
 # Stable outbound IP address
 
-Has your IT team requested IP addresses to allowlist within your organization's internal network? Good news — we have four stable outbound IP addresses that you can share with your team! 🎉
+Has your IT team requested IP addresses to allowlist within your organization's internal network? Good news — we have six stable outbound IP addresses that you can share with your team! 🎉
 
 ## Connecting to private data sources
 


### PR DESCRIPTION
This PR fixes a typo [here](https://docs.streamlit.io/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/stable-outbound-ip-addresses) saying we have six (rather than four) stable outbound IP addresses that users can allowlist.