### PR TITLE
Add KB article: How to deploy to Google App Engine

### DIFF
--- a/content/kb/deployments/deploy-streamlit-heroku-aws-google-cloud.md
+++ b/content/kb/deployments/deploy-streamlit-heroku-aws-google-cloud.md
@@ -13,6 +13,7 @@ You want to deploy your Streamlit app on a cloud service other than [Streamlit C
 
 Here are some user-submitted tutorials for different cloud services:
 
+- [How to deploy Streamlit apps to Google App Engine](https://dev.to/whitphx/how-to-deploy-streamlit-apps-to-google-app-engine-407o), by [Yuichiro Tachibana (Tsuchiya)](https://discuss.streamlit.io/u/whitphx/summary)
 - [How to Deploy Streamlit to a Free Amazon EC2 instance](https://towardsdatascience.com/how-to-deploy-a-streamlit-app-using-an-amazon-free-ec2-instance-416a41f69dc3), by Rahul Agarwal
 - [Host Streamlit on Heroku](https://towardsdatascience.com/quickly-build-and-deploy-an-application-with-streamlit-988ca08c7e83), by Maarten Grootendorst
 - [Host Streamlit on Azure](https://towardsdatascience.com/deploying-a-streamlit-web-app-with-azure-app-service-1f09a2159743), by Richard Peterson


### PR DESCRIPTION
This PR adds to the KB Yuichiro's article on how to deploy Streamlit apps to Google App Engine.