### PR TITLE
Redirect stale enterprise links to newer Streamlit Cloud pages

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -842,3 +842,6 @@
 /en/latest/advanced_caching.html	/library/advanced-features/caching
 /en/stable/advanced_caching.html	/library/advanced-features/caching
 /troubleshooting/caching_issues.html	/knowledge-base/using-streamlit/caching-issues
+/streamlit-cloud/enterprise/single-sign-on-sso     /streamlit-cloud/get-started/share-your-app/configuring-single-on-sso
+/streamlit-cloud/enterprise/single-sign-on-sso/streamlit-okta-sso   /streamlit-cloud/get-started/share-your-app/configuring-single-on-sso/streamlit-okta-sso
+/streamlit-cloud/enterprise     /streamlit-cloud


### PR DESCRIPTION
This PR redirects stale links (`/streamlit-cloud/enterprise/`) that have been indexed by Google to their newer versions. 

| Indexed links      | Redirect to |
| ----------- | ----------- |
| https://docs.streamlit.io/streamlit-cloud/enterprise/single-sign-on-sso  | https://docs.streamlit.io/streamlit-cloud/get-started/share-your-app/configuring-single-on-sso  |
| https://docs.streamlit.io/streamlit-cloud/enterprise/single-sign-on-sso/streamlit-okta-sso   | https://docs.streamlit.io/streamlit-cloud/get-started/share-your-app/configuring-single-on-sso/streamlit-okta-sso  |
| https://docs.streamlit.io/streamlit-cloud/enterprise   | https://docs.streamlit.io/streamlit-cloud  |