### PR TITLE
Fix docstrings: show return type info

### DIFF
--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -238,6 +238,7 @@ const Autofunction = ({
       }
       footRows={returns.length ? returns : null}
       additionalClass="full-width"
+      footers={footers}
     />
   );
 

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -98,7 +98,6 @@ const Autofunction = ({
   let functionDescription;
   let header;
   let body;
-  let returnBody;
 
   if (streamlitFunction in streamlit) {
     functionObject = streamlit[streamlitFunction];
@@ -229,24 +228,16 @@ const Autofunction = ({
             }
           : null
       }
-      rows={args.length ? args : null}
-      additionalClass="full-width"
-    />
-  );
-
-  returnBody = (
-    <Table
-      head={null}
-      body={
+      bodyRows={args.length ? args : null}
+      foot={
         returns.length
           ? {
               title: "Returns",
             }
           : null
       }
-      rows={returns.length ? returns : null}
+      footRows={returns.length ? returns : null}
       additionalClass="full-width"
-      footers={footers}
     />
   );
 
@@ -254,7 +245,6 @@ const Autofunction = ({
     <section className="autofunction" ref={blockRef}>
       {header}
       {body}
-      {returnBody}
     </section>
   );
 };

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -230,7 +230,7 @@ const Autofunction = ({
           : null
       }
       rows={args.length ? args : null}
-      addtionalClass="full-width"
+      additionalClass="full-width"
     />
   );
 
@@ -245,7 +245,7 @@ const Autofunction = ({
           : null
       }
       rows={returns.length ? returns : null}
-      addtionalClass="full-width"
+      additionalClass="full-width"
       footers={footers}
     />
   );

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -92,11 +92,13 @@ const Autofunction = ({
 
   const footers = [];
   const args = [];
+  const returns = [];
   const versionList = reverse(versions.slice());
   let functionObject;
   let functionDescription;
   let header;
   let body;
+  let returnBody;
 
   if (streamlitFunction in streamlit) {
     functionObject = streamlit[streamlitFunction];
@@ -199,6 +201,21 @@ const Autofunction = ({
     args.push(row);
   }
 
+  for (const index in functionObject.returns) {
+    const row = {};
+    const param = functionObject.returns[index];
+    const description = param.description
+      ? param.description
+      : `<p>No description</p> `;
+
+    row[
+      "title"
+    ] = `<p><span class='italic code'>(${param.type_name})</span></p> `;
+    row["body"] = `${description} `;
+
+    returns.push(row);
+  }
+
   body = (
     <Table
       head={{
@@ -214,6 +231,21 @@ const Autofunction = ({
       }
       rows={args.length ? args : null}
       addtionalClass="full-width"
+    />
+  );
+
+  returnBody = (
+    <Table
+      head={null}
+      body={
+        returns.length
+          ? {
+              title: "Returns",
+            }
+          : null
+      }
+      rows={returns.length ? returns : null}
+      addtionalClass="full-width"
       footers={footers}
     />
   );
@@ -222,6 +254,7 @@ const Autofunction = ({
     <section className="autofunction" ref={blockRef}>
       {header}
       {body}
+      {returnBody}
     </section>
   );
 };

--- a/components/blocks/table.js
+++ b/components/blocks/table.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-const Table = ({ head, body, rows, addtionalClass, footers = [] }) => {
+const Table = ({ head, body, rows, additionalClass, footers = [] }) => {
   const createMarkup = (html) => {
     return { __html: html };
   };
@@ -56,7 +56,7 @@ const Table = ({ head, body, rows, addtionalClass, footers = [] }) => {
 
   return (
     <section className="table-parent">
-      <table className={addtionalClass}>
+      <table className={additionalClass}>
         <thead>{thead}</thead>
         <tbody>{tbody}</tbody>
       </table>

--- a/components/blocks/table.js
+++ b/components/blocks/table.js
@@ -1,6 +1,14 @@
 import React from "react";
 
-const Table = ({ head, body, rows, additionalClass, footers = [] }) => {
+const Table = ({
+  head,
+  body,
+  bodyRows,
+  foot,
+  footRows,
+  additionalClass,
+  footers = [],
+}) => {
   const createMarkup = (html) => {
     return { __html: html };
   };
@@ -9,10 +17,11 @@ const Table = ({ head, body, rows, additionalClass, footers = [] }) => {
   };
 
   let trees;
-  let tbody;
   let thead;
+  let tbody;
+  let tfoot;
 
-  trees = createTrees(rows);
+  trees = createTrees(bodyRows);
 
   if (body && body.title) {
     tbody = (
@@ -22,7 +31,7 @@ const Table = ({ head, body, rows, additionalClass, footers = [] }) => {
             {body.title}
           </td>
         </tr>
-        {rows.map((row, index) => (
+        {bodyRows.map((row, index) => (
           <tr key={`${row.title}-${index}`}>
             <td width="20%">
               <div dangerouslySetInnerHTML={createMarkup(row.title)} />{" "}
@@ -54,11 +63,34 @@ const Table = ({ head, body, rows, additionalClass, footers = [] }) => {
     );
   }
 
+  if (foot && foot.title) {
+    tfoot = (
+      <React.Fragment key="tbody">
+        <tr className="head">
+          <td className="title bold" colSpan="2">
+            {foot.title}
+          </td>
+        </tr>
+        {footRows.map((row, index) => (
+          <tr key={`${row.title}-${index}`}>
+            <td width="20%">
+              <div dangerouslySetInnerHTML={createMarkup(row.title)} />{" "}
+            </td>
+            <td width="80%">
+              <div dangerouslySetInnerHTML={createMarkup(row.body)} />
+            </td>
+          </tr>
+        ))}
+      </React.Fragment>
+    );
+  }
+
   return (
     <section className="table-parent">
       <table className={additionalClass}>
         <thead>{thead}</thead>
         <tbody>{tbody}</tbody>
+        <tfoot>{tfoot}</tfoot>
       </table>
       {footers.map((footer, index) => {
         const body = footer.jsx ? (

--- a/components/blocks/table.js
+++ b/components/blocks/table.js
@@ -10,6 +10,7 @@ const Table = ({ head, body, rows, addtionalClass, footers = [] }) => {
 
   let trees;
   let tbody;
+  let thead;
 
   trees = createTrees(rows);
 
@@ -35,22 +36,28 @@ const Table = ({ head, body, rows, addtionalClass, footers = [] }) => {
     );
   }
 
+  if (head && head.title) {
+    thead = (
+      <React.Fragment key="thead">
+        <tr className="head">
+          <th className="title bold" colSpan="2">
+            {head.title}
+          </th>
+        </tr>
+        <tr>
+          <th
+            colSpan="2"
+            dangerouslySetInnerHTML={createMarkup(head.content)}
+          />
+        </tr>
+      </React.Fragment>
+    );
+  }
+
   return (
     <section className="table-parent">
       <table className={addtionalClass}>
-        <thead>
-          <tr className="head">
-            <th className="title bold" colSpan="2">
-              {head.title}
-            </th>
-          </tr>
-          <tr>
-            <th
-              colSpan="2"
-              dangerouslySetInnerHTML={createMarkup(head.content)}
-            />
-          </tr>
-        </thead>
+        <thead>{thead}</thead>
         <tbody>{tbody}</tbody>
       </table>
       {footers.map((footer, index) => {

--- a/pages/style-guide.js
+++ b/pages/style-guide.js
@@ -288,7 +288,7 @@ https://raw.githubusercontent.com/streamlit/demo-uber-nyc-pickups/master/streaml
               content: `<p class='code'>streamlit.text(body)</p>`,
             }}
             body={{ title: "Parameters" }}
-            rows={[
+            bodyRows={[
               {
                 title: `<p><span class='bold'>body</span> <span class='italic code'>(str)</span></p>`,
                 body: `<p>The string to display</p>`,
@@ -307,7 +307,7 @@ https://raw.githubusercontent.com/streamlit/demo-uber-nyc-pickups/master/streaml
             body={{
               title: "Parameters",
             }}
-            rows={[
+            bodyRows={[
               {
                 title: `<p><span class='bold'>body</span> <span class='italic code'>(str)</span></p>`,
                 body: `<p>The string to display</p>`,

--- a/python/generate.py
+++ b/python/generate.py
@@ -90,7 +90,6 @@ def get_function_docstring_dict(func, funcname, signature_prefix):
         if type(docstring_obj.returns) is not None:
             for returns in docstring_obj.many_returns:
                 return_obj = {}
-                # arg_obj['name'] = returns.arg_name
                 return_obj['type_name'] = returns.type_name
                 return_obj['is_generator'] = returns.is_generator
                 return_obj['description'] = parse_rst(returns.description) if returns.description else ''

--- a/python/generate.py
+++ b/python/generate.py
@@ -2,7 +2,6 @@
 
 import sys
 import types
-from collections.abc import Iterable
 import json
 import inspect
 import docstring_parser

--- a/python/generate.py
+++ b/python/generate.py
@@ -2,6 +2,7 @@
 
 import sys
 import types
+from collections.abc import Iterable
 import json
 import inspect
 import docstring_parser
@@ -85,6 +86,17 @@ def get_function_docstring_dict(func, funcname, signature_prefix):
             arg_obj['description'] = parse_rst(param.description) if param.description else ''
             arg_obj['default'] = param.default
             description['args'].append(arg_obj)
+
+        description['returns'] = []    
+        if type(docstring_obj.returns) is not None:
+            for returns in docstring_obj.many_returns:
+                return_obj = {}
+                # arg_obj['name'] = returns.arg_name
+                return_obj['type_name'] = returns.type_name
+                return_obj['is_generator'] = returns.is_generator
+                return_obj['description'] = parse_rst(returns.description) if returns.description else ''
+                return_obj['return_name'] = returns.return_name
+                description['returns'].append(return_obj)
 
     return description
 

--- a/python/streamlit.json
+++ b/python/streamlit.json
@@ -20,7 +20,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -56,7 +57,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.audio": {
       "name": "audio",
@@ -85,14 +87,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.balloons": {
       "name": "balloons",
       "signature": "st.balloons()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -128,7 +132,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -143,6 +148,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.beta_columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.beta_container": {
@@ -150,7 +163,8 @@
       "signature": "st.beta_container()",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.beta_container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.beta_container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -172,7 +186,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -208,7 +223,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.button": {
       "name": "button",
@@ -236,6 +252,14 @@
           "is_optional": false,
           "description": "<p>A tooltip that gets displayed when the button is hovered over.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>If the button was clicked on the last run of the app.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -301,7 +325,8 @@
           "description": "<p>The maximum number of seconds to keep an entry in the cache, or\nNone if cache entries should not expire. The default is None.</p>\n",
           "default": "None."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.caption": {
       "name": "caption",
@@ -316,7 +341,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -352,6 +378,14 @@
           "description": "<p>A tooltip that gets displayed next to the checkbox.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.code": {
@@ -374,7 +408,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -410,6 +445,14 @@
           "description": "<p>A tooltip that gets displayed next to the color picker.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.dataframe": {
@@ -439,7 +482,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -489,6 +533,14 @@
           "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.echo": {
@@ -504,14 +556,16 @@
           "description": "<p>Whether to show the echoed code before or after the results of the\nexecuted code block.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.empty": {
       "name": "empty",
       "signature": "st.empty()",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.beta_container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.error": {
       "name": "error",
@@ -526,7 +580,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.exception": {
       "name": "exception",
@@ -541,20 +596,30 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
       "signature": "st.experimental_get_query_params()",
       "example": "<blockquote>\n<p>Let's say the user's web browser is at\n<cite>http://localhost:8501/?show_map=True&amp;selected=asia&amp;selected=america</cite>.\nThen, you can get the query parameters using the following:</p>\n<pre class=\"doctest-block\">\nst.experimental_get_query_params()\n{&quot;show_map&quot;: [&quot;True&quot;], &quot;selected&quot;: [&quot;asia&quot;, &quot;america&quot;]}\n</pre>\n<p>Note that the values in the returned dict are <em>always</em> lists. This is\nbecause we internally use Python's urllib.parse.parse_qs(), which behaves\nthis way. And this behavior makes sense when you consider that every item\nin a query string is potentially a 1-element array.</p>\n</blockquote>\n",
       "description": "Return the query parameters that is currently showing in the browser's URL bar.",
-      "args": []
+      "args": [],
+      "returns": [
+        {
+          "type_name": "dict",
+          "is_generator": false,
+          "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
+          "return_name": null
+        }
+      ]
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -569,7 +634,8 @@
           "description": "<p>The query parameters to set, as key-value pairs.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -585,7 +651,8 @@
           "description": "<p>One or many objects to debug in the App.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -628,6 +695,14 @@
           "description": "<p>A tooltip that gets displayed next to the file uploader.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.form": {
@@ -643,7 +718,8 @@
           "description": "<p>A string that identifies the form. Each form must have its own\nkey. (This key is not displayed to the user in the interface.)</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -656,6 +732,14 @@
           "is_optional": false,
           "description": "<p>A short label explaining to the user what this button is for.\nDefaults to &quot;Submit&quot;.</p>\n",
           "default": "s"
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the submit button was clicked.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -671,7 +755,8 @@
           "description": "<p>The config option key of the form &quot;section.optionName&quot;. To see all\navailable options, run <cite>streamlit config show</cite> on a terminal.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -693,7 +778,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.header": {
       "name": "header",
@@ -715,7 +801,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.help": {
       "name": "help",
@@ -730,7 +817,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.image": {
       "name": "image",
@@ -787,7 +875,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.info": {
       "name": "info",
@@ -802,7 +891,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.json": {
       "name": "json",
@@ -817,7 +907,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.latex": {
       "name": "latex",
@@ -832,7 +923,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -868,7 +960,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.map": {
       "name": "map",
@@ -890,7 +983,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -912,7 +1006,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -962,11 +1057,19 @@
           "description": "<p>A tooltip that gets displayed next to the multiselect.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "[str]",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7f4b314e34f0>, step=None, format=None, key=None, help=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7fdec97faca0>, step=None, format=None, key=None, help=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -1026,6 +1129,14 @@
           "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.object_beta_warning": {
@@ -1054,7 +1165,8 @@
           "description": "<p>A date like &quot;2020-01-01&quot;, indicating the last day we'll guarantee\nsupport for the <a href=\"#id1\"><span class=\"problematic\" id=\"id2\">beta_</span></a> prefix.</p>\n<div class=\"system-messages section\">\n<h1>Docutils System Messages</h1>\n<div class=\"system-message\" id=\"id1\">\n<p class=\"system-message-title\">System Message: ERROR/3 (<tt class=\"docutils\">&lt;string&gt;</tt>, line 1); <em><a href=\"#id2\">backlink</a></em></p>\nUnknown target name: &quot;beta&quot;.</div>\n</div>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -1104,7 +1216,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.progress": {
       "name": "progress",
@@ -1119,7 +1232,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -1134,7 +1248,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -1164,7 +1279,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.radio": {
       "name": "radio",
@@ -1213,6 +1329,14 @@
           "is_optional": false,
           "description": "<p>A tooltip that gets displayed next to the radio.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -1264,6 +1388,14 @@
           "description": "<p>A tooltip that gets displayed next to the select slider.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.selectbox": {
@@ -1314,6 +1446,14 @@
           "description": "<p>A tooltip that gets displayed next to the selectbox.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.set_option": {
@@ -1335,7 +1475,8 @@
           "description": "<p>The new value to assign to this config option.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -1371,7 +1512,8 @@
           "description": "<p>How the sidebar should start out. Defaults to &quot;auto&quot;,\nwhich hides the sidebar on mobile-sized devices, and shows it otherwise.\n&quot;expanded&quot; shows the sidebar initially; &quot;collapsed&quot; hides it.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.slider": {
       "name": "slider",
@@ -1435,6 +1577,14 @@
           "description": "<p>A tooltip that gets displayed next to the slider.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.spinner": {
@@ -1450,14 +1600,16 @@
           "description": "<p>A message to display while executing that block</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.stop": {
       "name": "stop",
       "signature": "st.stop()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -1479,7 +1631,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.success": {
       "name": "success",
@@ -1494,7 +1647,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.table": {
       "name": "table",
@@ -1509,7 +1663,8 @@
           "description": "<p>or None\nThe table data.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text": {
       "name": "text",
@@ -1524,7 +1679,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -1573,6 +1729,14 @@
           "is_optional": false,
           "description": "<p>A tooltip that gets displayed next to the textarea.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -1624,6 +1788,14 @@
           "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.time_input": {
@@ -1660,6 +1832,14 @@
           "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.title": {
@@ -1682,7 +1862,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -1718,7 +1899,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.video": {
       "name": "video",
@@ -1747,7 +1929,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.warning": {
       "name": "warning",
@@ -1762,7 +1945,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.write": {
       "name": "write",
@@ -1784,7 +1968,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -1813,7 +1998,8 @@
           "description": "<p>The named dataset to concat. Optional. You can only pass in 1\ndataset (including the one in the data parameter).</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -1835,7 +2021,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -1871,7 +2058,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -1900,14 +2088,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
       "signature": "element.balloons(self)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -1943,7 +2133,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -1958,6 +2149,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.beta_columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.beta_container": {
@@ -1965,7 +2164,8 @@
       "signature": "element.beta_container(self)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.beta_container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.beta_container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -1987,7 +2187,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -2023,7 +2224,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -2052,6 +2254,14 @@
           "description": "<p>A tooltip that gets displayed when the button is hovered over.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>If the button was clicked on the last run of the app.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.caption": {
@@ -2067,7 +2277,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -2103,6 +2314,14 @@
           "description": "<p>A tooltip that gets displayed next to the checkbox.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.code": {
@@ -2125,7 +2344,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -2161,6 +2381,14 @@
           "description": "<p>A tooltip that gets displayed next to the color picker.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.dataframe": {
@@ -2190,7 +2418,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -2240,6 +2469,14 @@
           "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.empty": {
@@ -2247,7 +2484,8 @@
       "signature": "element.empty(self)",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.beta_container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -2262,7 +2500,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -2277,7 +2516,8 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -2320,6 +2560,14 @@
           "description": "<p>A tooltip that gets displayed next to the file uploader.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.form": {
@@ -2335,7 +2583,8 @@
           "description": "<p>A string that identifies the form. Each form must have its own\nkey. (This key is not displayed to the user in the interface.)</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -2348,6 +2597,14 @@
           "is_optional": false,
           "description": "<p>A short label explaining to the user what this button is for.\nDefaults to &quot;Submit&quot;.</p>\n",
           "default": "s"
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the submit button was clicked.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -2371,7 +2628,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -2393,7 +2651,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -2408,7 +2667,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -2465,7 +2725,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -2480,7 +2741,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.json": {
       "name": "json",
@@ -2495,7 +2757,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -2510,7 +2773,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -2546,7 +2810,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -2568,7 +2833,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -2590,7 +2856,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -2640,11 +2907,19 @@
           "description": "<p>A tooltip that gets displayed next to the multiselect.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "[str]",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7f4b314e34f0>, step=None, format=None, key=None, help=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7fdec97faca0>, step=None, format=None, key=None, help=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -2704,6 +2979,14 @@
           "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.plotly_chart": {
@@ -2754,7 +3037,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -2769,7 +3053,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -2784,7 +3069,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -2814,7 +3100,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -2863,6 +3150,14 @@
           "is_optional": false,
           "description": "<p>A tooltip that gets displayed next to the radio.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -2914,6 +3209,14 @@
           "description": "<p>A tooltip that gets displayed next to the select slider.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.selectbox": {
@@ -2963,6 +3266,14 @@
           "is_optional": false,
           "description": "<p>A tooltip that gets displayed next to the selectbox.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -3028,6 +3339,14 @@
           "description": "<p>A tooltip that gets displayed next to the slider.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.subheader": {
@@ -3050,7 +3369,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -3065,7 +3385,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -3080,7 +3401,8 @@
           "description": "<p>or None\nThe table data.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -3095,7 +3417,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -3144,6 +3467,14 @@
           "is_optional": false,
           "description": "<p>A tooltip that gets displayed next to the textarea.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -3195,6 +3526,14 @@
           "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.time_input": {
@@ -3231,6 +3570,14 @@
           "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.title": {
@@ -3253,7 +3600,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -3289,7 +3637,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -3318,7 +3667,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -3333,7 +3683,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -3355,7 +3706,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -3382,6 +3734,14 @@
           "is_optional": false,
           "description": "<p>The URL that the component is served from. Either <cite>path</cite> or <cite>url</cite>\nmust be specified, but not both.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "CustomComponent",
+          "is_generator": false,
+          "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -3418,7 +3778,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -3453,7 +3814,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     }
   },
   "0.83.0": {
@@ -3477,7 +3839,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -3513,7 +3876,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.audio": {
       "name": "audio",
@@ -3542,14 +3906,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.balloons": {
       "name": "balloons",
       "signature": "st.balloons()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -3585,7 +3951,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -3600,6 +3967,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.beta_columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.beta_container": {
@@ -3607,7 +3982,8 @@
       "signature": "st.beta_container()",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.beta_container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.beta_container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -3629,7 +4005,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -3665,7 +4042,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.button": {
       "name": "button",
@@ -3693,6 +4071,14 @@
           "is_optional": false,
           "description": "<p>A tooltip that gets displayed when the button is hovered over.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>If the button was clicked on the last run of the app.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -3758,7 +4144,8 @@
           "description": "<p>The maximum number of seconds to keep an entry in the cache, or\nNone if cache entries should not expire. The default is None.</p>\n",
           "default": "None."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.caption": {
       "name": "caption",
@@ -3773,7 +4160,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -3809,6 +4197,14 @@
           "description": "<p>A tooltip that gets displayed next to the checkbox.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.code": {
@@ -3831,7 +4227,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -3867,6 +4264,14 @@
           "description": "<p>A tooltip that gets displayed next to the color picker.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.dataframe": {
@@ -3896,7 +4301,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -3946,6 +4352,14 @@
           "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.echo": {
@@ -3961,14 +4375,16 @@
           "description": "<p>Whether to show the echoed code before or after the results of the\nexecuted code block.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.empty": {
       "name": "empty",
       "signature": "st.empty()",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.beta_container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.error": {
       "name": "error",
@@ -3983,7 +4399,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.exception": {
       "name": "exception",
@@ -3998,20 +4415,30 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
       "signature": "st.experimental_get_query_params()",
       "example": "<blockquote>\n<p>Let's say the user's web browser is at\n<cite>http://localhost:8501/?show_map=True&amp;selected=asia&amp;selected=america</cite>.\nThen, you can get the query parameters using the following:</p>\n<pre class=\"doctest-block\">\nst.experimental_get_query_params()\n{&quot;show_map&quot;: [&quot;True&quot;], &quot;selected&quot;: [&quot;asia&quot;, &quot;america&quot;]}\n</pre>\n<p>Note that the values in the returned dict are <em>always</em> lists. This is\nbecause we internally use Python's urllib.parse.parse_qs(), which behaves\nthis way. And this behavior makes sense when you consider that every item\nin a query string is potentially a 1-element array.</p>\n</blockquote>\n",
       "description": "Return the query parameters that is currently showing in the browser's URL bar.",
-      "args": []
+      "args": [],
+      "returns": [
+        {
+          "type_name": "dict",
+          "is_generator": false,
+          "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
+          "return_name": null
+        }
+      ]
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -4026,7 +4453,8 @@
           "description": "<p>The query parameters to set, as key-value pairs.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -4042,7 +4470,8 @@
           "description": "<p>One or many objects to debug in the App.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -4085,6 +4514,14 @@
           "description": "<p>A tooltip that gets displayed next to the file uploader.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.form": {
@@ -4107,7 +4544,8 @@
           "description": "<p>If True, all widgets inside the form will be reset to their default\nvalues after the user presses the Submit button. Defaults to False.\n(Note that Custom Components are unaffected by this flag, and\nwill not be reset to their defaults on form submission.)</p>\n",
           "default": "values"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -4128,6 +4566,14 @@
           "description": "<p>A tooltip that gets displayed when the button is hovered over.\nDefaults to None.</p>\n",
           "default": "None."
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.get_option": {
@@ -4142,7 +4588,8 @@
           "description": "<p>The config option key of the form &quot;section.optionName&quot;. To see all\navailable options, run <cite>streamlit config show</cite> on a terminal.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -4164,7 +4611,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.header": {
       "name": "header",
@@ -4186,7 +4634,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.help": {
       "name": "help",
@@ -4201,7 +4650,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.image": {
       "name": "image",
@@ -4258,7 +4708,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.info": {
       "name": "info",
@@ -4273,7 +4724,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.json": {
       "name": "json",
@@ -4288,7 +4740,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.latex": {
       "name": "latex",
@@ -4303,7 +4756,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -4339,7 +4793,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.map": {
       "name": "map",
@@ -4361,7 +4816,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -4383,7 +4839,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -4433,11 +4890,19 @@
           "description": "<p>A tooltip that gets displayed next to the multiselect.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "[str]",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7f783006a970>, step=None, format=None, key=None, help=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7f2b1e839310>, step=None, format=None, key=None, help=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -4497,6 +4962,14 @@
           "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.object_beta_warning": {
@@ -4525,7 +4998,8 @@
           "description": "<p>A date like &quot;2020-01-01&quot;, indicating the last day we'll guarantee\nsupport for the <a href=\"#id1\"><span class=\"problematic\" id=\"id2\">beta_</span></a> prefix.</p>\n<div class=\"system-messages section\">\n<h1>Docutils System Messages</h1>\n<div class=\"system-message\" id=\"id1\">\n<p class=\"system-message-title\">System Message: ERROR/3 (<tt class=\"docutils\">&lt;string&gt;</tt>, line 1); <em><a href=\"#id2\">backlink</a></em></p>\nUnknown target name: &quot;beta&quot;.</div>\n</div>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -4575,7 +5049,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.progress": {
       "name": "progress",
@@ -4590,7 +5065,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -4605,7 +5081,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -4635,7 +5112,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.radio": {
       "name": "radio",
@@ -4684,6 +5162,14 @@
           "is_optional": false,
           "description": "<p>A tooltip that gets displayed next to the radio.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -4735,6 +5221,14 @@
           "description": "<p>A tooltip that gets displayed next to the select slider.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.selectbox": {
@@ -4785,6 +5279,14 @@
           "description": "<p>A tooltip that gets displayed next to the selectbox.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.set_option": {
@@ -4806,7 +5308,8 @@
           "description": "<p>The new value to assign to this config option.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -4842,7 +5345,8 @@
           "description": "<p>How the sidebar should start out. Defaults to &quot;auto&quot;,\nwhich hides the sidebar on mobile-sized devices, and shows it otherwise.\n&quot;expanded&quot; shows the sidebar initially; &quot;collapsed&quot; hides it.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.slider": {
       "name": "slider",
@@ -4906,6 +5410,14 @@
           "description": "<p>A tooltip that gets displayed next to the slider.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.spinner": {
@@ -4921,14 +5433,16 @@
           "description": "<p>A message to display while executing that block</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.stop": {
       "name": "stop",
       "signature": "st.stop()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -4950,7 +5464,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.success": {
       "name": "success",
@@ -4965,7 +5480,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.table": {
       "name": "table",
@@ -4980,7 +5496,8 @@
           "description": "<p>or None\nThe table data.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text": {
       "name": "text",
@@ -4995,7 +5512,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -5044,6 +5562,14 @@
           "is_optional": false,
           "description": "<p>A tooltip that gets displayed next to the textarea.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -5095,6 +5621,14 @@
           "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.time_input": {
@@ -5131,6 +5665,14 @@
           "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.title": {
@@ -5153,7 +5695,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -5189,7 +5732,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.video": {
       "name": "video",
@@ -5218,7 +5762,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.warning": {
       "name": "warning",
@@ -5233,7 +5778,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.write": {
       "name": "write",
@@ -5255,7 +5801,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -5284,7 +5831,8 @@
           "description": "<p>The named dataset to concat. Optional. You can only pass in 1\ndataset (including the one in the data parameter).</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -5306,7 +5854,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -5342,7 +5891,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -5371,14 +5921,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
       "signature": "element.balloons(self)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -5414,7 +5966,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -5429,6 +5982,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.beta_columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.beta_container": {
@@ -5436,7 +5997,8 @@
       "signature": "element.beta_container(self)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.beta_container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.beta_container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -5458,7 +6020,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -5494,7 +6057,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -5523,6 +6087,14 @@
           "description": "<p>A tooltip that gets displayed when the button is hovered over.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>If the button was clicked on the last run of the app.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.caption": {
@@ -5538,7 +6110,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -5574,6 +6147,14 @@
           "description": "<p>A tooltip that gets displayed next to the checkbox.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.code": {
@@ -5596,7 +6177,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -5632,6 +6214,14 @@
           "description": "<p>A tooltip that gets displayed next to the color picker.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.dataframe": {
@@ -5661,7 +6251,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -5711,6 +6302,14 @@
           "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.empty": {
@@ -5718,7 +6317,8 @@
       "signature": "element.empty(self)",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.beta_container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -5733,7 +6333,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -5748,7 +6349,8 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -5791,6 +6393,14 @@
           "description": "<p>A tooltip that gets displayed next to the file uploader.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.form": {
@@ -5813,7 +6423,8 @@
           "description": "<p>If True, all widgets inside the form will be reset to their default\nvalues after the user presses the Submit button. Defaults to False.\n(Note that Custom Components are unaffected by this flag, and\nwill not be reset to their defaults on form submission.)</p>\n",
           "default": "values"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -5833,6 +6444,14 @@
           "is_optional": false,
           "description": "<p>A tooltip that gets displayed when the button is hovered over.\nDefaults to None.</p>\n",
           "default": "None."
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -5856,7 +6475,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -5878,7 +6498,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -5893,7 +6514,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -5950,7 +6572,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -5965,7 +6588,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.json": {
       "name": "json",
@@ -5980,7 +6604,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -5995,7 +6620,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -6031,7 +6657,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -6053,7 +6680,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -6075,7 +6703,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -6125,11 +6754,19 @@
           "description": "<p>A tooltip that gets displayed next to the multiselect.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "[str]",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7f783006a970>, step=None, format=None, key=None, help=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7f2b1e839310>, step=None, format=None, key=None, help=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -6189,6 +6826,14 @@
           "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.plotly_chart": {
@@ -6239,7 +6884,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -6254,7 +6900,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -6269,7 +6916,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -6299,7 +6947,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -6348,6 +6997,14 @@
           "is_optional": false,
           "description": "<p>A tooltip that gets displayed next to the radio.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -6399,6 +7056,14 @@
           "description": "<p>A tooltip that gets displayed next to the select slider.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.selectbox": {
@@ -6448,6 +7113,14 @@
           "is_optional": false,
           "description": "<p>A tooltip that gets displayed next to the selectbox.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -6513,6 +7186,14 @@
           "description": "<p>A tooltip that gets displayed next to the slider.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.subheader": {
@@ -6535,7 +7216,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -6550,7 +7232,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -6565,7 +7248,8 @@
           "description": "<p>or None\nThe table data.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -6580,7 +7264,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -6629,6 +7314,14 @@
           "is_optional": false,
           "description": "<p>A tooltip that gets displayed next to the textarea.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -6680,6 +7373,14 @@
           "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.time_input": {
@@ -6716,6 +7417,14 @@
           "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.title": {
@@ -6738,7 +7447,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -6774,7 +7484,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -6803,7 +7514,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -6818,7 +7530,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -6840,7 +7553,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -6867,6 +7581,14 @@
           "is_optional": false,
           "description": "<p>The URL that the component is served from. Either <cite>path</cite> or <cite>url</cite>\nmust be specified, but not both.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "CustomComponent",
+          "is_generator": false,
+          "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -6903,7 +7625,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -6938,7 +7661,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     }
   },
   "0.84.0": {
@@ -6962,7 +7686,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -6998,7 +7723,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.audio": {
       "name": "audio",
@@ -7027,14 +7753,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.balloons": {
       "name": "balloons",
       "signature": "st.balloons()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -7070,7 +7798,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -7085,6 +7814,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.beta_columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.beta_container": {
@@ -7092,7 +7829,8 @@
       "signature": "st.beta_container()",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.beta_container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.beta_container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -7114,7 +7852,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -7150,7 +7889,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.button": {
       "name": "button",
@@ -7199,6 +7939,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>If the button was clicked on the last run of the app.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -7264,7 +8012,8 @@
           "description": "<p>The maximum number of seconds to keep an entry in the cache, or\nNone if cache entries should not expire. The default is None.</p>\n",
           "default": "None."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.caption": {
       "name": "caption",
@@ -7279,7 +8028,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -7336,6 +8086,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.code": {
@@ -7358,7 +8116,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -7415,6 +8174,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.dataframe": {
@@ -7444,7 +8211,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -7515,6 +8283,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.echo": {
@@ -7530,14 +8306,16 @@
           "description": "<p>Whether to show the echoed code before or after the results of the\nexecuted code block.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.empty": {
       "name": "empty",
       "signature": "st.empty()",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.beta_container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.error": {
       "name": "error",
@@ -7552,7 +8330,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.exception": {
       "name": "exception",
@@ -7567,20 +8346,30 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
       "signature": "st.experimental_get_query_params()",
       "example": "<blockquote>\n<p>Let's say the user's web browser is at\n<cite>http://localhost:8501/?show_map=True&amp;selected=asia&amp;selected=america</cite>.\nThen, you can get the query parameters using the following:</p>\n<pre class=\"doctest-block\">\nst.experimental_get_query_params()\n{&quot;show_map&quot;: [&quot;True&quot;], &quot;selected&quot;: [&quot;asia&quot;, &quot;america&quot;]}\n</pre>\n<p>Note that the values in the returned dict are <em>always</em> lists. This is\nbecause we internally use Python's urllib.parse.parse_qs(), which behaves\nthis way. And this behavior makes sense when you consider that every item\nin a query string is potentially a 1-element array.</p>\n</blockquote>\n",
       "description": "Return the query parameters that is currently showing in the browser's URL bar.",
-      "args": []
+      "args": [],
+      "returns": [
+        {
+          "type_name": "dict",
+          "is_generator": false,
+          "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
+          "return_name": null
+        }
+      ]
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -7595,7 +8384,8 @@
           "description": "<p>The query parameters to set, as key-value pairs.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -7611,7 +8401,8 @@
           "description": "<p>One or many objects to debug in the App.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -7675,6 +8466,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.form": {
@@ -7697,7 +8496,8 @@
           "description": "<p>If True, all widgets inside the form will be reset to their default\nvalues after the user presses the Submit button. Defaults to False.\n(Note that Custom Components are unaffected by this flag, and\nwill not be reset to their defaults on form submission.)</p>\n",
           "default": "values"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -7739,6 +8539,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.get_option": {
@@ -7753,7 +8561,8 @@
           "description": "<p>The config option key of the form &quot;section.optionName&quot;. To see all\navailable options, run <cite>streamlit config show</cite> on a terminal.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -7775,7 +8584,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.header": {
       "name": "header",
@@ -7797,7 +8607,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.help": {
       "name": "help",
@@ -7812,7 +8623,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.image": {
       "name": "image",
@@ -7869,7 +8681,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.info": {
       "name": "info",
@@ -7884,7 +8697,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.json": {
       "name": "json",
@@ -7899,7 +8713,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.latex": {
       "name": "latex",
@@ -7914,7 +8729,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -7950,7 +8766,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.map": {
       "name": "map",
@@ -7972,7 +8789,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -7994,7 +8812,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -8065,11 +8884,19 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fd2e5e11820>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fa0539b11c0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -8150,6 +8977,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.object_beta_warning": {
@@ -8178,7 +9013,8 @@
           "description": "<p>A date like &quot;2020-01-01&quot;, indicating the last day we'll guarantee\nsupport for the <a href=\"#id1\"><span class=\"problematic\" id=\"id2\">beta_</span></a> prefix.</p>\n<div class=\"system-messages section\">\n<h1>Docutils System Messages</h1>\n<div class=\"system-message\" id=\"id1\">\n<p class=\"system-message-title\">System Message: ERROR/3 (<tt class=\"docutils\">&lt;string&gt;</tt>, line 1); <em><a href=\"#id2\">backlink</a></em></p>\nUnknown target name: &quot;beta&quot;.</div>\n</div>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -8228,7 +9064,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.progress": {
       "name": "progress",
@@ -8243,7 +9080,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -8258,7 +9096,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -8288,7 +9127,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.radio": {
       "name": "radio",
@@ -8358,6 +9198,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -8430,6 +9278,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.selectbox": {
@@ -8501,6 +9357,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.set_option": {
@@ -8522,7 +9386,8 @@
           "description": "<p>The new value to assign to this config option.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -8558,7 +9423,8 @@
           "description": "<p>How the sidebar should start out. Defaults to &quot;auto&quot;,\nwhich hides the sidebar on mobile-sized devices, and shows it otherwise.\n&quot;expanded&quot; shows the sidebar initially; &quot;collapsed&quot; hides it.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.slider": {
       "name": "slider",
@@ -8643,6 +9509,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.spinner": {
@@ -8658,14 +9532,16 @@
           "description": "<p>A message to display while executing that block</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.stop": {
       "name": "stop",
       "signature": "st.stop()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -8687,7 +9563,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.success": {
       "name": "success",
@@ -8702,7 +9579,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.table": {
       "name": "table",
@@ -8717,7 +9595,8 @@
           "description": "<p>or None\nThe table data.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text": {
       "name": "text",
@@ -8732,7 +9611,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -8802,6 +9682,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -8881,6 +9769,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.time_input": {
@@ -8938,6 +9834,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.title": {
@@ -8960,7 +9864,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -8996,7 +9901,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.video": {
       "name": "video",
@@ -9025,7 +9931,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.warning": {
       "name": "warning",
@@ -9040,7 +9947,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.write": {
       "name": "write",
@@ -9062,7 +9970,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -9091,7 +10000,8 @@
           "description": "<p>The named dataset to concat. Optional. You can only pass in 1\ndataset (including the one in the data parameter).</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -9113,7 +10023,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -9149,7 +10060,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -9178,14 +10090,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
       "signature": "element.balloons(self)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -9221,7 +10135,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -9236,6 +10151,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.beta_columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.beta_container": {
@@ -9243,7 +10166,8 @@
       "signature": "element.beta_container(self)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.beta_container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.beta_container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -9265,7 +10189,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -9301,7 +10226,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -9351,6 +10277,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>If the button was clicked on the last run of the app.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.caption": {
@@ -9366,7 +10300,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -9423,6 +10358,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.code": {
@@ -9445,7 +10388,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -9502,6 +10446,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.dataframe": {
@@ -9531,7 +10483,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -9602,6 +10555,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.empty": {
@@ -9609,7 +10570,8 @@
       "signature": "element.empty(self)",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.beta_container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -9624,7 +10586,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -9639,7 +10602,8 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -9703,6 +10667,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.form": {
@@ -9725,7 +10697,8 @@
           "description": "<p>If True, all widgets inside the form will be reset to their default\nvalues after the user presses the Submit button. Defaults to False.\n(Note that Custom Components are unaffected by this flag, and\nwill not be reset to their defaults on form submission.)</p>\n",
           "default": "values"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -9767,6 +10740,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.graphviz_chart": {
@@ -9789,7 +10770,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -9811,7 +10793,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -9826,7 +10809,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -9883,7 +10867,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -9898,7 +10883,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.json": {
       "name": "json",
@@ -9913,7 +10899,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -9928,7 +10915,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -9964,7 +10952,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -9986,7 +10975,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -10008,7 +10998,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -10079,11 +11070,19 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fd2e5e11820>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fa0539b11c0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -10164,6 +11163,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.plotly_chart": {
@@ -10214,7 +11221,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -10229,7 +11237,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -10244,7 +11253,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -10274,7 +11284,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -10344,6 +11355,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -10416,6 +11435,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.selectbox": {
@@ -10486,6 +11513,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -10572,6 +11607,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.subheader": {
@@ -10594,7 +11637,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -10609,7 +11653,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -10624,7 +11669,8 @@
           "description": "<p>or None\nThe table data.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -10639,7 +11685,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -10709,6 +11756,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -10788,6 +11843,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.time_input": {
@@ -10845,6 +11908,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.title": {
@@ -10867,7 +11938,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -10903,7 +11975,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -10932,7 +12005,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -10947,7 +12021,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -10969,7 +12044,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -10996,6 +12072,14 @@
           "is_optional": false,
           "description": "<p>The URL that the component is served from. Either <cite>path</cite> or <cite>url</cite>\nmust be specified, but not both.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "CustomComponent",
+          "is_generator": false,
+          "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -11032,7 +12116,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -11067,7 +12152,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     }
   },
   "0.85.0": {
@@ -11091,7 +12177,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -11127,7 +12214,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.audio": {
       "name": "audio",
@@ -11156,14 +12244,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.balloons": {
       "name": "balloons",
       "signature": "st.balloons()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -11199,7 +12289,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -11214,6 +12305,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.beta_columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.beta_container": {
@@ -11221,7 +12320,8 @@
       "signature": "st.beta_container()",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.beta_container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.beta_container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -11243,7 +12343,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -11279,7 +12380,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.button": {
       "name": "button",
@@ -11328,6 +12430,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>If the button was clicked on the last run of the app.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -11393,7 +12503,8 @@
           "description": "<p>The maximum number of seconds to keep an entry in the cache, or\nNone if cache entries should not expire. The default is None.</p>\n",
           "default": "None."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.caption": {
       "name": "caption",
@@ -11408,7 +12519,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -11465,6 +12577,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.code": {
@@ -11487,7 +12607,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -11544,6 +12665,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.dataframe": {
@@ -11573,7 +12702,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -11644,6 +12774,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.echo": {
@@ -11659,14 +12797,16 @@
           "description": "<p>Whether to show the echoed code before or after the results of the\nexecuted code block.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.empty": {
       "name": "empty",
       "signature": "st.empty()",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.beta_container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.error": {
       "name": "error",
@@ -11681,7 +12821,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.exception": {
       "name": "exception",
@@ -11696,20 +12837,30 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
       "signature": "st.experimental_get_query_params()",
       "example": "<blockquote>\n<p>Let's say the user's web browser is at\n<cite>http://localhost:8501/?show_map=True&amp;selected=asia&amp;selected=america</cite>.\nThen, you can get the query parameters using the following:</p>\n<pre class=\"doctest-block\">\nst.experimental_get_query_params()\n{&quot;show_map&quot;: [&quot;True&quot;], &quot;selected&quot;: [&quot;asia&quot;, &quot;america&quot;]}\n</pre>\n<p>Note that the values in the returned dict are <em>always</em> lists. This is\nbecause we internally use Python's urllib.parse.parse_qs(), which behaves\nthis way. And this behavior makes sense when you consider that every item\nin a query string is potentially a 1-element array.</p>\n</blockquote>\n",
       "description": "Return the query parameters that is currently showing in the browser's URL bar.",
-      "args": []
+      "args": [],
+      "returns": [
+        {
+          "type_name": "dict",
+          "is_generator": false,
+          "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
+          "return_name": null
+        }
+      ]
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -11724,7 +12875,8 @@
           "description": "<p>The query parameters to set, as key-value pairs.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -11740,7 +12892,8 @@
           "description": "<p>One or many objects to debug in the App.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -11804,6 +12957,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.form": {
@@ -11826,7 +12987,8 @@
           "description": "<p>If True, all widgets inside the form will be reset to their default\nvalues after the user presses the Submit button. Defaults to False.\n(Note that Custom Components are unaffected by this flag, and\nwill not be reset to their defaults on form submission.)</p>\n",
           "default": "values"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -11868,6 +13030,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.get_option": {
@@ -11882,7 +13052,8 @@
           "description": "<p>The config option key of the form &quot;section.optionName&quot;. To see all\navailable options, run <cite>streamlit config show</cite> on a terminal.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -11904,7 +13075,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.header": {
       "name": "header",
@@ -11926,7 +13098,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.help": {
       "name": "help",
@@ -11941,7 +13114,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.image": {
       "name": "image",
@@ -11998,7 +13172,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.info": {
       "name": "info",
@@ -12013,7 +13188,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.json": {
       "name": "json",
@@ -12028,7 +13204,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.latex": {
       "name": "latex",
@@ -12043,7 +13220,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -12079,7 +13257,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.map": {
       "name": "map",
@@ -12101,7 +13280,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -12123,7 +13303,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -12194,11 +13375,19 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fbb4a457700>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f4529a9f250>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -12278,6 +13467,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -12307,7 +13504,8 @@
           "description": "<p>A date like &quot;2020-01-01&quot;, indicating the last day we'll guarantee\nsupport for the <a href=\"#id1\"><span class=\"problematic\" id=\"id2\">beta_</span></a> prefix.</p>\n<div class=\"system-messages section\">\n<h1>Docutils System Messages</h1>\n<div class=\"system-message\" id=\"id1\">\n<p class=\"system-message-title\">System Message: ERROR/3 (<tt class=\"docutils\">&lt;string&gt;</tt>, line 1); <em><a href=\"#id2\">backlink</a></em></p>\nUnknown target name: &quot;beta&quot;.</div>\n</div>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -12357,7 +13555,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.progress": {
       "name": "progress",
@@ -12372,7 +13571,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -12387,7 +13587,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -12417,7 +13618,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.radio": {
       "name": "radio",
@@ -12487,6 +13689,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -12559,6 +13769,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.selectbox": {
@@ -12630,6 +13848,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.set_option": {
@@ -12651,7 +13877,8 @@
           "description": "<p>The new value to assign to this config option.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -12687,7 +13914,8 @@
           "description": "<p>How the sidebar should start out. Defaults to &quot;auto&quot;,\nwhich hides the sidebar on mobile-sized devices, and shows it otherwise.\n&quot;expanded&quot; shows the sidebar initially; &quot;collapsed&quot; hides it.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.slider": {
       "name": "slider",
@@ -12772,6 +14000,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.spinner": {
@@ -12787,14 +14023,16 @@
           "description": "<p>A message to display while executing that block</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.stop": {
       "name": "stop",
       "signature": "st.stop()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -12816,7 +14054,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.success": {
       "name": "success",
@@ -12831,7 +14070,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.table": {
       "name": "table",
@@ -12846,7 +14086,8 @@
           "description": "<p>The table data.\nPyarrow tables are not supported by Streamlit's legacy DataFrame serialization\n(i.e. with <cite>config.dataFrameSerialization = &quot;legacy&quot;</cite>).\nTo use pyarrow tables, please enable pyarrow by changing the config setting,\n<cite>config.dataFrameSerialization = &quot;arrow&quot;</cite>.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text": {
       "name": "text",
@@ -12861,7 +14102,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -12931,6 +14173,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -13010,6 +14260,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.time_input": {
@@ -13067,6 +14325,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.title": {
@@ -13089,7 +14355,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -13125,7 +14392,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.video": {
       "name": "video",
@@ -13154,7 +14422,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.warning": {
       "name": "warning",
@@ -13169,7 +14438,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.write": {
       "name": "write",
@@ -13191,7 +14461,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -13213,7 +14484,8 @@
           "description": "<p>The named dataset to concat. Optional. You can only pass in 1\ndataset (including the one in the data parameter).</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -13235,7 +14507,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -13271,7 +14544,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -13300,14 +14574,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
       "signature": "element.balloons(self)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -13343,7 +14619,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -13358,6 +14635,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.beta_columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.beta_container": {
@@ -13365,7 +14650,8 @@
       "signature": "element.beta_container(self)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.beta_container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.beta_container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -13387,7 +14673,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -13423,7 +14710,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -13473,6 +14761,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>If the button was clicked on the last run of the app.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.caption": {
@@ -13488,7 +14784,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -13545,6 +14842,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.code": {
@@ -13567,7 +14872,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -13624,6 +14930,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.dataframe": {
@@ -13653,7 +14967,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -13724,6 +15039,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.empty": {
@@ -13731,7 +15054,8 @@
       "signature": "element.empty(self)",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.beta_container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -13746,7 +15070,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -13761,7 +15086,8 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -13825,6 +15151,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.form": {
@@ -13847,7 +15181,8 @@
           "description": "<p>If True, all widgets inside the form will be reset to their default\nvalues after the user presses the Submit button. Defaults to False.\n(Note that Custom Components are unaffected by this flag, and\nwill not be reset to their defaults on form submission.)</p>\n",
           "default": "values"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -13889,6 +15224,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.graphviz_chart": {
@@ -13911,7 +15254,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -13933,7 +15277,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -13948,7 +15293,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -14005,7 +15351,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -14020,7 +15367,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.json": {
       "name": "json",
@@ -14035,7 +15383,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -14050,7 +15399,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -14086,7 +15436,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -14108,7 +15459,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -14130,7 +15482,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -14201,11 +15554,19 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fbb4a457700>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f4529a9f250>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -14286,6 +15647,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.plotly_chart": {
@@ -14336,7 +15705,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -14351,7 +15721,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -14366,7 +15737,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -14396,7 +15768,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -14466,6 +15839,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -14538,6 +15919,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.selectbox": {
@@ -14608,6 +15997,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -14694,6 +16091,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.subheader": {
@@ -14716,7 +16121,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -14731,7 +16137,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -14746,7 +16153,8 @@
           "description": "<p>The table data.\nPyarrow tables are not supported by Streamlit's legacy DataFrame serialization\n(i.e. with <cite>config.dataFrameSerialization = &quot;legacy&quot;</cite>).\nTo use pyarrow tables, please enable pyarrow by changing the config setting,\n<cite>config.dataFrameSerialization = &quot;arrow&quot;</cite>.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -14761,7 +16169,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -14831,6 +16240,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -14910,6 +16327,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.time_input": {
@@ -14967,6 +16392,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.title": {
@@ -14989,7 +16422,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -15025,7 +16459,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -15054,7 +16489,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -15069,7 +16505,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -15091,7 +16528,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -15118,6 +16556,14 @@
           "is_optional": false,
           "description": "<p>The URL that the component is served from. Either <cite>path</cite> or <cite>url</cite>\nmust be specified, but not both.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "CustomComponent",
+          "is_generator": false,
+          "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -15154,7 +16600,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -15189,7 +16636,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     }
   },
   "0.86.0": {
@@ -15213,7 +16661,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -15249,7 +16698,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.audio": {
       "name": "audio",
@@ -15278,14 +16728,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.balloons": {
       "name": "balloons",
       "signature": "st.balloons()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -15321,7 +16773,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -15336,6 +16789,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.beta_container": {
@@ -15343,7 +16804,8 @@
       "signature": "st.beta_container(*args, **kwargs)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -15365,7 +16827,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -15401,7 +16864,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.button": {
       "name": "button",
@@ -15450,6 +16914,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>If the button was clicked on the last run of the app.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -15515,7 +16987,8 @@
           "description": "<p>The maximum number of seconds to keep an entry in the cache, or\nNone if cache entries should not expire. The default is None.</p>\n",
           "default": "None."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.caption": {
       "name": "caption",
@@ -15530,7 +17003,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -15587,6 +17061,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.code": {
@@ -15609,7 +17091,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -15666,6 +17149,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.columns": {
@@ -15681,6 +17172,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.container": {
@@ -15688,7 +17187,8 @@
       "signature": "st.container()",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -15717,7 +17217,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -15788,6 +17289,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.echo": {
@@ -15803,14 +17312,16 @@
           "description": "<p>Whether to show the echoed code before or after the results of the\nexecuted code block.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.empty": {
       "name": "empty",
       "signature": "st.empty()",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.error": {
       "name": "error",
@@ -15825,7 +17336,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.exception": {
       "name": "exception",
@@ -15840,7 +17352,8 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.expander": {
       "name": "expander",
@@ -15862,20 +17375,30 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
       "signature": "st.experimental_get_query_params()",
       "example": "<blockquote>\n<p>Let's say the user's web browser is at\n<cite>http://localhost:8501/?show_map=True&amp;selected=asia&amp;selected=america</cite>.\nThen, you can get the query parameters using the following:</p>\n<pre class=\"doctest-block\">\nst.experimental_get_query_params()\n{&quot;show_map&quot;: [&quot;True&quot;], &quot;selected&quot;: [&quot;asia&quot;, &quot;america&quot;]}\n</pre>\n<p>Note that the values in the returned dict are <em>always</em> lists. This is\nbecause we internally use Python's urllib.parse.parse_qs(), which behaves\nthis way. And this behavior makes sense when you consider that every item\nin a query string is potentially a 1-element array.</p>\n</blockquote>\n",
       "description": "Return the query parameters that is currently showing in the browser's URL bar.",
-      "args": []
+      "args": [],
+      "returns": [
+        {
+          "type_name": "dict",
+          "is_generator": false,
+          "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
+          "return_name": null
+        }
+      ]
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -15890,7 +17413,8 @@
           "description": "<p>The query parameters to set, as key-value pairs.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -15906,7 +17430,8 @@
           "description": "<p>One or many objects to debug in the App.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -15970,6 +17495,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.form": {
@@ -15992,7 +17525,8 @@
           "description": "<p>If True, all widgets inside the form will be reset to their default\nvalues after the user presses the Submit button. Defaults to False.\n(Note that Custom Components are unaffected by this flag, and\nwill not be reset to their defaults on form submission.)</p>\n",
           "default": "values"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -16034,6 +17568,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.get_option": {
@@ -16048,7 +17590,8 @@
           "description": "<p>The config option key of the form &quot;section.optionName&quot;. To see all\navailable options, run <cite>streamlit config show</cite> on a terminal.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -16070,7 +17613,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.header": {
       "name": "header",
@@ -16092,7 +17636,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.help": {
       "name": "help",
@@ -16107,7 +17652,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.image": {
       "name": "image",
@@ -16164,7 +17710,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.info": {
       "name": "info",
@@ -16179,7 +17726,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.json": {
       "name": "json",
@@ -16194,7 +17742,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.latex": {
       "name": "latex",
@@ -16209,7 +17758,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -16245,7 +17795,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.map": {
       "name": "map",
@@ -16267,7 +17818,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -16289,7 +17841,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -16360,11 +17913,19 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f2357a501f0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f0b9c28bcd0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -16445,6 +18006,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.plotly_chart": {
@@ -16495,7 +18064,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.progress": {
       "name": "progress",
@@ -16510,7 +18080,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -16525,7 +18096,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -16555,7 +18127,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.radio": {
       "name": "radio",
@@ -16625,6 +18198,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -16697,6 +18278,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.selectbox": {
@@ -16768,6 +18357,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.set_option": {
@@ -16789,7 +18386,8 @@
           "description": "<p>The new value to assign to this config option.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -16825,7 +18423,8 @@
           "description": "<p>How the sidebar should start out. Defaults to &quot;auto&quot;,\nwhich hides the sidebar on mobile-sized devices, and shows it otherwise.\n&quot;expanded&quot; shows the sidebar initially; &quot;collapsed&quot; hides it.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.slider": {
       "name": "slider",
@@ -16910,6 +18509,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.spinner": {
@@ -16925,14 +18532,16 @@
           "description": "<p>A message to display while executing that block</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.stop": {
       "name": "stop",
       "signature": "st.stop()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -16954,7 +18563,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.success": {
       "name": "success",
@@ -16969,7 +18579,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.table": {
       "name": "table",
@@ -16984,7 +18595,8 @@
           "description": "<p>The table data.\nPyarrow tables are not supported by Streamlit's legacy DataFrame serialization\n(i.e. with <cite>config.dataFrameSerialization = &quot;legacy&quot;</cite>).\nTo use pyarrow tables, please enable pyarrow by changing the config setting,\n<cite>config.dataFrameSerialization = &quot;arrow&quot;</cite>.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text": {
       "name": "text",
@@ -16999,7 +18611,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -17069,6 +18682,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -17148,6 +18769,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.time_input": {
@@ -17205,6 +18834,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.title": {
@@ -17227,7 +18864,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -17263,7 +18901,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.video": {
       "name": "video",
@@ -17292,7 +18931,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.warning": {
       "name": "warning",
@@ -17307,7 +18947,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.write": {
       "name": "write",
@@ -17329,7 +18970,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -17351,7 +18993,8 @@
           "description": "<p>The named dataset to concat. Optional. You can only pass in 1\ndataset (including the one in the data parameter).</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -17373,7 +19016,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -17409,7 +19053,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -17438,14 +19083,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
       "signature": "element.balloons(self)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -17481,7 +19128,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -17496,6 +19144,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.beta_container": {
@@ -17503,7 +19159,8 @@
       "signature": "element.beta_container(*args, **kwargs)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -17525,7 +19182,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -17561,7 +19219,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -17611,6 +19270,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>If the button was clicked on the last run of the app.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.caption": {
@@ -17626,7 +19293,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -17683,6 +19351,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.code": {
@@ -17705,7 +19381,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -17762,6 +19439,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.columns": {
@@ -17777,6 +19462,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.container": {
@@ -17784,7 +19477,8 @@
       "signature": "element.container(self)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -17813,7 +19507,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -17884,6 +19579,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.empty": {
@@ -17891,7 +19594,8 @@
       "signature": "element.empty(self)",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -17906,7 +19610,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -17921,7 +19626,8 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -17943,7 +19649,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -18007,6 +19714,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.form": {
@@ -18029,7 +19744,8 @@
           "description": "<p>If True, all widgets inside the form will be reset to their default\nvalues after the user presses the Submit button. Defaults to False.\n(Note that Custom Components are unaffected by this flag, and\nwill not be reset to their defaults on form submission.)</p>\n",
           "default": "values"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -18071,6 +19787,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.graphviz_chart": {
@@ -18093,7 +19817,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -18115,7 +19840,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -18130,7 +19856,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -18187,7 +19914,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -18202,7 +19930,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.json": {
       "name": "json",
@@ -18217,7 +19946,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -18232,7 +19962,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -18268,7 +19999,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -18290,7 +20022,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -18312,7 +20045,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -18383,11 +20117,19 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f2357a501f0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f0b9c28bcd0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -18468,6 +20210,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.plotly_chart": {
@@ -18518,7 +20268,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -18533,7 +20284,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -18548,7 +20300,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -18578,7 +20331,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -18648,6 +20402,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -18720,6 +20482,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.selectbox": {
@@ -18790,6 +20560,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -18876,6 +20654,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.subheader": {
@@ -18898,7 +20684,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -18913,7 +20700,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -18928,7 +20716,8 @@
           "description": "<p>The table data.\nPyarrow tables are not supported by Streamlit's legacy DataFrame serialization\n(i.e. with <cite>config.dataFrameSerialization = &quot;legacy&quot;</cite>).\nTo use pyarrow tables, please enable pyarrow by changing the config setting,\n<cite>config.dataFrameSerialization = &quot;arrow&quot;</cite>.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -18943,7 +20732,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -19013,6 +20803,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -19092,6 +20890,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.time_input": {
@@ -19149,6 +20955,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.title": {
@@ -19171,7 +20985,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -19207,7 +21022,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -19236,7 +21052,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -19251,7 +21068,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -19273,7 +21091,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -19300,6 +21119,14 @@
           "is_optional": false,
           "description": "<p>The URL that the component is served from. Either <cite>path</cite> or <cite>url</cite>\nmust be specified, but not both.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "CustomComponent",
+          "is_generator": false,
+          "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -19336,7 +21163,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -19371,7 +21199,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     }
   },
   "0.87.0": {
@@ -19395,7 +21224,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -19431,7 +21261,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.audio": {
       "name": "audio",
@@ -19460,14 +21291,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.balloons": {
       "name": "balloons",
       "signature": "st.balloons()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -19503,7 +21336,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -19518,6 +21352,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.beta_container": {
@@ -19525,7 +21367,8 @@
       "signature": "st.beta_container(*args, **kwargs)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -19547,7 +21390,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -19583,7 +21427,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.button": {
       "name": "button",
@@ -19632,6 +21477,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>If the button was clicked on the last run of the app.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -19697,7 +21550,8 @@
           "description": "<p>The maximum number of seconds to keep an entry in the cache, or\nNone if cache entries should not expire. The default is None.</p>\n",
           "default": "None."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.caption": {
       "name": "caption",
@@ -19712,7 +21566,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -19769,6 +21624,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.code": {
@@ -19791,7 +21654,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -19848,6 +21712,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.columns": {
@@ -19863,6 +21735,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.container": {
@@ -19870,7 +21750,8 @@
       "signature": "st.container()",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -19899,7 +21780,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -19970,6 +21852,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.echo": {
@@ -19985,14 +21875,16 @@
           "description": "<p>Whether to show the echoed code before or after the results of the\nexecuted code block.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.empty": {
       "name": "empty",
       "signature": "st.empty()",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.error": {
       "name": "error",
@@ -20007,7 +21899,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.exception": {
       "name": "exception",
@@ -20022,7 +21915,8 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.expander": {
       "name": "expander",
@@ -20044,20 +21938,30 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
       "signature": "st.experimental_get_query_params()",
       "example": "<blockquote>\n<p>Let's say the user's web browser is at\n<cite>http://localhost:8501/?show_map=True&amp;selected=asia&amp;selected=america</cite>.\nThen, you can get the query parameters using the following:</p>\n<pre class=\"doctest-block\">\nst.experimental_get_query_params()\n{&quot;show_map&quot;: [&quot;True&quot;], &quot;selected&quot;: [&quot;asia&quot;, &quot;america&quot;]}\n</pre>\n<p>Note that the values in the returned dict are <em>always</em> lists. This is\nbecause we internally use Python's urllib.parse.parse_qs(), which behaves\nthis way. And this behavior makes sense when you consider that every item\nin a query string is potentially a 1-element array.</p>\n</blockquote>\n",
       "description": "Return the query parameters that is currently showing in the browser's URL bar.",
-      "args": []
+      "args": [],
+      "returns": [
+        {
+          "type_name": "dict",
+          "is_generator": false,
+          "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
+          "return_name": null
+        }
+      ]
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -20072,7 +21976,8 @@
           "description": "<p>The query parameters to set, as key-value pairs.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -20088,7 +21993,8 @@
           "description": "<p>One or many objects to debug in the App.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -20152,6 +22058,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.form": {
@@ -20174,7 +22088,8 @@
           "description": "<p>If True, all widgets inside the form will be reset to their default\nvalues after the user presses the Submit button. Defaults to False.\n(Note that Custom Components are unaffected by this flag, and\nwill not be reset to their defaults on form submission.)</p>\n",
           "default": "values"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -20216,6 +22131,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.get_option": {
@@ -20230,7 +22153,8 @@
           "description": "<p>The config option key of the form &quot;section.optionName&quot;. To see all\navailable options, run <cite>streamlit config show</cite> on a terminal.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -20252,7 +22176,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.header": {
       "name": "header",
@@ -20274,7 +22199,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.help": {
       "name": "help",
@@ -20289,7 +22215,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.image": {
       "name": "image",
@@ -20346,7 +22273,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.info": {
       "name": "info",
@@ -20361,7 +22289,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.json": {
       "name": "json",
@@ -20376,7 +22305,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.latex": {
       "name": "latex",
@@ -20391,7 +22321,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -20427,7 +22358,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.map": {
       "name": "map",
@@ -20449,7 +22381,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -20471,7 +22404,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.metric": {
       "name": "metric",
@@ -20507,7 +22441,8 @@
           "description": "<p>If &quot;normal&quot; (default), the delta indicator is shown as described\nabove. If &quot;inverse&quot;, it is red when positive and green when\nnegative. This is useful when a negative change is considered\ngood, e.g. if cost decreased. If &quot;off&quot;, delta is  shown in gray\nregardless of its value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -20578,11 +22513,19 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f7e91be9910>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f249a521490>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -20663,6 +22606,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.plotly_chart": {
@@ -20713,7 +22664,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.progress": {
       "name": "progress",
@@ -20728,7 +22680,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -20743,7 +22696,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -20773,7 +22727,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.radio": {
       "name": "radio",
@@ -20843,6 +22798,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -20915,6 +22878,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.selectbox": {
@@ -20986,6 +22957,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.set_option": {
@@ -21007,7 +22986,8 @@
           "description": "<p>The new value to assign to this config option.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -21043,7 +23023,8 @@
           "description": "<p>How the sidebar should start out. Defaults to &quot;auto&quot;,\nwhich hides the sidebar on mobile-sized devices, and shows it otherwise.\n&quot;expanded&quot; shows the sidebar initially; &quot;collapsed&quot; hides it.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.slider": {
       "name": "slider",
@@ -21128,6 +23109,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.spinner": {
@@ -21143,14 +23132,16 @@
           "description": "<p>A message to display while executing that block</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.stop": {
       "name": "stop",
       "signature": "st.stop()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -21172,7 +23163,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.success": {
       "name": "success",
@@ -21187,7 +23179,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.table": {
       "name": "table",
@@ -21202,7 +23195,8 @@
           "description": "<p>The table data.\nPyarrow tables are not supported by Streamlit's legacy DataFrame serialization\n(i.e. with <cite>config.dataFrameSerialization = &quot;legacy&quot;</cite>).\nTo use pyarrow tables, please enable pyarrow by changing the config setting,\n<cite>config.dataFrameSerialization = &quot;arrow&quot;</cite>.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text": {
       "name": "text",
@@ -21217,7 +23211,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -21287,6 +23282,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -21366,6 +23369,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.time_input": {
@@ -21423,6 +23434,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.title": {
@@ -21445,7 +23464,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -21481,7 +23501,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.video": {
       "name": "video",
@@ -21510,7 +23531,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.warning": {
       "name": "warning",
@@ -21525,7 +23547,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.write": {
       "name": "write",
@@ -21547,7 +23570,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -21569,7 +23593,8 @@
           "description": "<p>The named dataset to concat. Optional. You can only pass in 1\ndataset (including the one in the data parameter).</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -21591,7 +23616,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -21627,7 +23653,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -21656,14 +23683,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
       "signature": "element.balloons(self)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -21699,7 +23728,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -21714,6 +23744,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.beta_container": {
@@ -21721,7 +23759,8 @@
       "signature": "element.beta_container(*args, **kwargs)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -21743,7 +23782,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -21779,7 +23819,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -21829,6 +23870,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>If the button was clicked on the last run of the app.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.caption": {
@@ -21844,7 +23893,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -21901,6 +23951,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.code": {
@@ -21923,7 +23981,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -21980,6 +24039,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.columns": {
@@ -21995,6 +24062,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.container": {
@@ -22002,7 +24077,8 @@
       "signature": "element.container(self)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -22031,7 +24107,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -22102,6 +24179,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.determine_delta_color_and_direction": {
@@ -22113,7 +24198,8 @@
       "signature": "element.empty(self)",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -22128,7 +24214,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -22143,7 +24230,8 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -22165,7 +24253,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -22229,6 +24318,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.form": {
@@ -22251,7 +24348,8 @@
           "description": "<p>If True, all widgets inside the form will be reset to their default\nvalues after the user presses the Submit button. Defaults to False.\n(Note that Custom Components are unaffected by this flag, and\nwill not be reset to their defaults on form submission.)</p>\n",
           "default": "values"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -22293,6 +24391,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.graphviz_chart": {
@@ -22315,7 +24421,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -22337,7 +24444,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -22352,7 +24460,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -22409,7 +24518,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -22424,7 +24534,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.is_negative": {
       "name": "is_negative",
@@ -22443,7 +24554,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -22458,7 +24570,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -22494,7 +24607,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -22516,7 +24630,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -22538,7 +24653,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.metric": {
       "name": "metric",
@@ -22574,7 +24690,8 @@
           "description": "<p>If &quot;normal&quot; (default), the delta indicator is shown as described\nabove. If &quot;inverse&quot;, it is red when positive and green when\nnegative. This is useful when a negative change is considered\ngood, e.g. if cost decreased. If &quot;off&quot;, delta is  shown in gray\nregardless of its value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -22645,11 +24762,19 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f7e91be9910>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f249a521490>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -22730,6 +24855,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.parse_delta": {
@@ -22792,7 +24925,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -22807,7 +24941,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -22822,7 +24957,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -22852,7 +24988,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -22922,6 +25059,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -22994,6 +25139,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.selectbox": {
@@ -23064,6 +25217,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -23150,6 +25311,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.subheader": {
@@ -23172,7 +25341,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -23187,7 +25357,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -23202,7 +25373,8 @@
           "description": "<p>The table data.\nPyarrow tables are not supported by Streamlit's legacy DataFrame serialization\n(i.e. with <cite>config.dataFrameSerialization = &quot;legacy&quot;</cite>).\nTo use pyarrow tables, please enable pyarrow by changing the config setting,\n<cite>config.dataFrameSerialization = &quot;arrow&quot;</cite>.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -23217,7 +25389,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -23287,6 +25460,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -23366,6 +25547,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.time_input": {
@@ -23423,6 +25612,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.title": {
@@ -23445,7 +25642,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -23481,7 +25679,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -23510,7 +25709,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -23525,7 +25725,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -23547,7 +25748,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -23574,6 +25776,14 @@
           "is_optional": false,
           "description": "<p>The URL that the component is served from. Either <cite>path</cite> or <cite>url</cite>\nmust be specified, but not both.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "CustomComponent",
+          "is_generator": false,
+          "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -23610,7 +25820,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -23645,7 +25856,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     }
   },
   "0.88.0": {
@@ -23669,7 +25881,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -23705,7 +25918,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.audio": {
       "name": "audio",
@@ -23734,14 +25948,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.balloons": {
       "name": "balloons",
       "signature": "st.balloons()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -23777,7 +25993,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -23792,6 +26009,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.beta_container": {
@@ -23799,7 +26024,8 @@
       "signature": "st.beta_container(*args, **kwargs)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -23821,7 +26047,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -23857,7 +26084,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.button": {
       "name": "button",
@@ -23906,6 +26134,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>If the button was clicked on the last run of the app.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -23971,7 +26207,8 @@
           "description": "<p>The maximum number of seconds to keep an entry in the cache, or\nNone if cache entries should not expire. The default is None.</p>\n",
           "default": "None."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.caption": {
       "name": "caption",
@@ -23986,7 +26223,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -24043,6 +26281,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.code": {
@@ -24065,7 +26311,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -24122,6 +26369,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.columns": {
@@ -24137,6 +26392,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.container": {
@@ -24144,7 +26407,8 @@
       "signature": "st.container()",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -24173,7 +26437,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -24243,6 +26508,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -24315,6 +26588,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>If the button was clicked on the last run of the app.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.echo": {
@@ -24330,14 +26611,16 @@
           "description": "<p>Whether to show the echoed code before or after the results of the\nexecuted code block.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.empty": {
       "name": "empty",
       "signature": "st.empty()",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.error": {
       "name": "error",
@@ -24352,7 +26635,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.exception": {
       "name": "exception",
@@ -24367,7 +26651,8 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.expander": {
       "name": "expander",
@@ -24389,20 +26674,30 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
       "signature": "st.experimental_get_query_params()",
       "example": "<blockquote>\n<p>Let's say the user's web browser is at\n<cite>http://localhost:8501/?show_map=True&amp;selected=asia&amp;selected=america</cite>.\nThen, you can get the query parameters using the following:</p>\n<pre class=\"doctest-block\">\nst.experimental_get_query_params()\n{&quot;show_map&quot;: [&quot;True&quot;], &quot;selected&quot;: [&quot;asia&quot;, &quot;america&quot;]}\n</pre>\n<p>Note that the values in the returned dict are <em>always</em> lists. This is\nbecause we internally use Python's urllib.parse.parse_qs(), which behaves\nthis way. And this behavior makes sense when you consider that every item\nin a query string is potentially a 1-element array.</p>\n</blockquote>\n",
       "description": "Return the query parameters that is currently showing in the browser's URL bar.",
-      "args": []
+      "args": [],
+      "returns": [
+        {
+          "type_name": "dict",
+          "is_generator": false,
+          "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
+          "return_name": null
+        }
+      ]
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -24417,7 +26712,8 @@
           "description": "<p>The query parameters to set, as key-value pairs.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -24433,7 +26729,8 @@
           "description": "<p>One or many objects to debug in the App.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -24497,6 +26794,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.form": {
@@ -24519,7 +26824,8 @@
           "description": "<p>If True, all widgets inside the form will be reset to their default\nvalues after the user presses the Submit button. Defaults to False.\n(Note that Custom Components are unaffected by this flag, and\nwill not be reset to their defaults on form submission.)</p>\n",
           "default": "values"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -24561,6 +26867,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.get_option": {
@@ -24575,7 +26889,8 @@
           "description": "<p>The config option key of the form &quot;section.optionName&quot;. To see all\navailable options, run <cite>streamlit config show</cite> on a terminal.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -24597,7 +26912,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.header": {
       "name": "header",
@@ -24619,7 +26935,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.help": {
       "name": "help",
@@ -24634,7 +26951,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.image": {
       "name": "image",
@@ -24691,7 +27009,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.info": {
       "name": "info",
@@ -24706,7 +27025,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.json": {
       "name": "json",
@@ -24721,7 +27041,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.latex": {
       "name": "latex",
@@ -24736,7 +27057,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -24772,7 +27094,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.map": {
       "name": "map",
@@ -24794,7 +27117,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -24816,7 +27140,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.metric": {
       "name": "metric",
@@ -24852,7 +27177,8 @@
           "description": "<p>If &quot;normal&quot; (default), the delta indicator is shown as described\nabove. If &quot;inverse&quot;, it is red when positive and green when\nnegative. This is useful when a negative change is considered\ngood, e.g. if cost decreased. If &quot;off&quot;, delta is  shown in gray\nregardless of its value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -24923,11 +27249,19 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f62b98fb040>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fa24ec70a90>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -25008,6 +27342,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.plotly_chart": {
@@ -25058,7 +27400,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.progress": {
       "name": "progress",
@@ -25073,7 +27416,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -25088,7 +27432,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -25118,7 +27463,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.radio": {
       "name": "radio",
@@ -25188,6 +27534,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -25260,6 +27614,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.selectbox": {
@@ -25331,6 +27693,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.set_option": {
@@ -25352,7 +27722,8 @@
           "description": "<p>The new value to assign to this config option.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -25388,7 +27759,8 @@
           "description": "<p>How the sidebar should start out. Defaults to &quot;auto&quot;,\nwhich hides the sidebar on mobile-sized devices, and shows it otherwise.\n&quot;expanded&quot; shows the sidebar initially; &quot;collapsed&quot; hides it.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.slider": {
       "name": "slider",
@@ -25473,6 +27845,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.spinner": {
@@ -25488,14 +27868,16 @@
           "description": "<p>A message to display while executing that block</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.stop": {
       "name": "stop",
       "signature": "st.stop()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -25517,7 +27899,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.success": {
       "name": "success",
@@ -25532,7 +27915,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.table": {
       "name": "table",
@@ -25547,7 +27931,8 @@
           "description": "<p>The table data.\nPyarrow tables are not supported by Streamlit's legacy DataFrame serialization\n(i.e. with <cite>config.dataFrameSerialization = &quot;legacy&quot;</cite>).\nTo use pyarrow tables, please enable pyarrow by changing the config setting,\n<cite>config.dataFrameSerialization = &quot;arrow&quot;</cite>.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text": {
       "name": "text",
@@ -25562,7 +27947,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -25632,6 +28018,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -25711,6 +28105,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.time_input": {
@@ -25768,6 +28170,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.title": {
@@ -25790,7 +28200,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -25826,7 +28237,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.video": {
       "name": "video",
@@ -25855,7 +28267,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.warning": {
       "name": "warning",
@@ -25870,7 +28283,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.write": {
       "name": "write",
@@ -25892,7 +28306,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -25914,7 +28329,8 @@
           "description": "<p>The named dataset to concat. Optional. You can only pass in 1\ndataset (including the one in the data parameter).</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -25936,7 +28352,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -25972,7 +28389,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -26001,14 +28419,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
       "signature": "element.balloons(self)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -26044,7 +28464,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -26059,6 +28480,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.beta_container": {
@@ -26066,7 +28495,8 @@
       "signature": "element.beta_container(*args, **kwargs)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -26088,7 +28518,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -26124,7 +28555,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -26174,6 +28606,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>If the button was clicked on the last run of the app.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.caption": {
@@ -26189,7 +28629,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -26246,6 +28687,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.code": {
@@ -26268,7 +28717,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -26325,6 +28775,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.columns": {
@@ -26340,6 +28798,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.container": {
@@ -26347,7 +28813,8 @@
       "signature": "element.container(self)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -26376,7 +28843,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -26446,6 +28914,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -26522,6 +28998,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>If the button was clicked on the last run of the app.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.empty": {
@@ -26529,7 +29013,8 @@
       "signature": "element.empty(self)",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -26544,7 +29029,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -26559,7 +29045,8 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -26581,7 +29068,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -26645,6 +29133,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.form": {
@@ -26667,7 +29163,8 @@
           "description": "<p>If True, all widgets inside the form will be reset to their default\nvalues after the user presses the Submit button. Defaults to False.\n(Note that Custom Components are unaffected by this flag, and\nwill not be reset to their defaults on form submission.)</p>\n",
           "default": "values"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -26709,6 +29206,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.graphviz_chart": {
@@ -26731,7 +29236,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -26753,7 +29259,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -26768,7 +29275,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -26825,7 +29333,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -26840,7 +29349,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.is_negative": {
       "name": "is_negative",
@@ -26859,7 +29369,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -26874,7 +29385,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -26910,7 +29422,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -26932,7 +29445,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -26954,7 +29468,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.metric": {
       "name": "metric",
@@ -26990,7 +29505,8 @@
           "description": "<p>If &quot;normal&quot; (default), the delta indicator is shown as described\nabove. If &quot;inverse&quot;, it is red when positive and green when\nnegative. This is useful when a negative change is considered\ngood, e.g. if cost decreased. If &quot;off&quot;, delta is  shown in gray\nregardless of its value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -27061,11 +29577,19 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f62b98fb040>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fa24ec70a90>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -27146,6 +29670,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.parse_delta": {
@@ -27208,7 +29740,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -27223,7 +29756,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -27238,7 +29772,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -27268,7 +29803,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -27338,6 +29874,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -27410,6 +29954,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.selectbox": {
@@ -27480,6 +30032,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -27566,6 +30126,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.subheader": {
@@ -27588,7 +30156,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -27603,7 +30172,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -27618,7 +30188,8 @@
           "description": "<p>The table data.\nPyarrow tables are not supported by Streamlit's legacy DataFrame serialization\n(i.e. with <cite>config.dataFrameSerialization = &quot;legacy&quot;</cite>).\nTo use pyarrow tables, please enable pyarrow by changing the config setting,\n<cite>config.dataFrameSerialization = &quot;arrow&quot;</cite>.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -27633,7 +30204,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -27703,6 +30275,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -27782,6 +30362,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.time_input": {
@@ -27839,6 +30427,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.title": {
@@ -27861,7 +30457,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -27897,7 +30494,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -27926,7 +30524,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -27941,7 +30540,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -27963,7 +30563,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -27990,6 +30591,14 @@
           "is_optional": false,
           "description": "<p>The URL that the component is served from. Either <cite>path</cite> or <cite>url</cite>\nmust be specified, but not both.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "CustomComponent",
+          "is_generator": false,
+          "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -28026,7 +30635,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -28061,7 +30671,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     }
   },
   "0.89.0": {
@@ -28085,7 +30696,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -28121,7 +30733,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.audio": {
       "name": "audio",
@@ -28150,14 +30763,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.balloons": {
       "name": "balloons",
       "signature": "st.balloons()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -28193,7 +30808,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -28208,6 +30824,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.beta_container": {
@@ -28215,7 +30839,8 @@
       "signature": "st.beta_container(*args, **kwargs)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -28237,7 +30862,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -28273,7 +30899,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.button": {
       "name": "button",
@@ -28322,6 +30949,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -28387,7 +31022,8 @@
           "description": "<p>The maximum number of seconds to keep an entry in the cache, or\nNone if cache entries should not expire. The default is None.</p>\n",
           "default": "None."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.caption": {
       "name": "caption",
@@ -28402,7 +31038,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -28459,6 +31096,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.code": {
@@ -28481,7 +31126,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -28538,6 +31184,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.columns": {
@@ -28553,6 +31207,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.container": {
@@ -28560,7 +31222,8 @@
       "signature": "st.container()",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -28589,7 +31252,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -28659,6 +31323,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date or a tuple with 0-2 dates",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -28731,6 +31403,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.echo": {
@@ -28746,14 +31426,16 @@
           "description": "<p>Whether to show the echoed code before or after the results of the\nexecuted code block.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.empty": {
       "name": "empty",
       "signature": "st.empty()",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.error": {
       "name": "error",
@@ -28768,7 +31450,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.exception": {
       "name": "exception",
@@ -28783,7 +31466,8 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.expander": {
       "name": "expander",
@@ -28805,14 +31489,23 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
       "signature": "st.experimental_get_query_params()",
       "example": "<blockquote>\n<p>Let's say the user's web browser is at\n<cite>http://localhost:8501/?show_map=True&amp;selected=asia&amp;selected=america</cite>.\nThen, you can get the query parameters using the following:</p>\n<pre class=\"doctest-block\">\nst.experimental_get_query_params()\n{&quot;show_map&quot;: [&quot;True&quot;], &quot;selected&quot;: [&quot;asia&quot;, &quot;america&quot;]}\n</pre>\n<p>Note that the values in the returned dict are <em>always</em> lists. This is\nbecause we internally use Python's urllib.parse.parse_qs(), which behaves\nthis way. And this behavior makes sense when you consider that every item\nin a query string is potentially a 1-element array.</p>\n</blockquote>\n",
       "description": "Return the query parameters that is currently showing in the browser's URL bar.",
-      "args": []
+      "args": [],
+      "returns": [
+        {
+          "type_name": "dict",
+          "is_generator": false,
+          "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
+          "return_name": null
+        }
+      ]
     },
     "streamlit.experimental_memo": {
       "name": "experimental_memo",
@@ -28862,13 +31555,15 @@
           "description": "<p>The maximum number of seconds to keep an entry in the cache, or\nNone if cache entries should not expire. The default is None.</p>\n",
           "default": "None."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -28883,7 +31578,8 @@
           "description": "<p>The query parameters to set, as key-value pairs.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -28899,7 +31595,8 @@
           "description": "<p>One or many objects to debug in the App.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_singleton": {
       "name": "experimental_singleton",
@@ -28928,7 +31625,8 @@
           "description": "<p>Suppress warnings about calling Streamlit functions from within\nthe singleton function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -28992,6 +31690,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.form": {
@@ -29014,7 +31720,8 @@
           "description": "<p>If True, all widgets inside the form will be reset to their default\nvalues after the user presses the Submit button. Defaults to False.\n(Note that Custom Components are unaffected by this flag, and\nwill not be reset to their defaults on form submission.)</p>\n",
           "default": "values"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -29056,6 +31763,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.get_option": {
@@ -29070,7 +31785,8 @@
           "description": "<p>The config option key of the form &quot;section.optionName&quot;. To see all\navailable options, run <cite>streamlit config show</cite> on a terminal.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -29092,7 +31808,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.header": {
       "name": "header",
@@ -29114,7 +31831,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.help": {
       "name": "help",
@@ -29129,7 +31847,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.image": {
       "name": "image",
@@ -29186,7 +31905,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.info": {
       "name": "info",
@@ -29201,7 +31921,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.json": {
       "name": "json",
@@ -29216,7 +31937,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.latex": {
       "name": "latex",
@@ -29231,7 +31953,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -29267,7 +31990,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.map": {
       "name": "map",
@@ -29289,7 +32013,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -29311,7 +32036,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.metric": {
       "name": "metric",
@@ -29347,7 +32073,8 @@
           "description": "<p>If &quot;normal&quot; (default), the delta indicator is shown as described\nabove. If &quot;inverse&quot;, it is red when positive and green when\nnegative. This is useful when a negative change is considered\ngood, e.g. if cost decreased. If &quot;off&quot;, delta is  shown in gray\nregardless of its value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -29418,11 +32145,19 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f5c61ef5bb0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fa13c8c6700>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -29503,6 +32238,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.plotly_chart": {
@@ -29553,7 +32296,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.progress": {
       "name": "progress",
@@ -29568,7 +32312,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -29583,7 +32328,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -29613,7 +32359,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.radio": {
       "name": "radio",
@@ -29683,6 +32430,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -29755,6 +32510,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.selectbox": {
@@ -29826,6 +32589,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.set_option": {
@@ -29847,7 +32618,8 @@
           "description": "<p>The new value to assign to this config option.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -29890,7 +32662,8 @@
           "description": "<p>Configure the menu that appears on the top-right side of this app.\nThe keys in this dict denote the menu item you'd like to configure:</p>\n<div class=\"system-message\">\n<p class=\"system-message-title\">System Message: ERROR/3 (<tt class=\"docutils\">&lt;string&gt;</tt>, line 3)</p>\nUnexpected indentation.</div>\n<blockquote>\n<ul class=\"simple\">\n<li><dl class=\"first docutils\">\n<dt>&quot;Get help&quot;: str or None</dt>\n<dd>The URL this menu item should point to.\nIf None, hides this menu item.</dd>\n</dl>\n</li>\n<li><dl class=\"first docutils\">\n<dt>&quot;Report a Bug&quot;: str or None</dt>\n<dd>The URL this menu item should point to.\nIf None, hides this menu item.</dd>\n</dl>\n</li>\n<li><dl class=\"first docutils\">\n<dt>&quot;About&quot;: str or None</dt>\n<dd>A markdown string to show in the About dialog.\nIf None, only shows Streamlit's default About text.</dd>\n</dl>\n</li>\n</ul>\n</blockquote>\n",
           "default": "About"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.slider": {
       "name": "slider",
@@ -29975,6 +32748,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.spinner": {
@@ -29990,14 +32771,16 @@
           "description": "<p>A message to display while executing that block</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.stop": {
       "name": "stop",
       "signature": "st.stop()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -30019,7 +32802,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.success": {
       "name": "success",
@@ -30034,7 +32818,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.table": {
       "name": "table",
@@ -30049,7 +32834,8 @@
           "description": "<p>The table data.\nPyarrow tables are not supported by Streamlit's legacy DataFrame serialization\n(i.e. with <cite>config.dataFrameSerialization = &quot;legacy&quot;</cite>).\nTo use pyarrow tables, please enable pyarrow by changing the config setting,\n<cite>config.dataFrameSerialization = &quot;arrow&quot;</cite>.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text": {
       "name": "text",
@@ -30064,7 +32850,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -30134,6 +32921,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -30213,6 +33008,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.time_input": {
@@ -30270,6 +33073,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.title": {
@@ -30292,7 +33103,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -30328,7 +33140,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.video": {
       "name": "video",
@@ -30357,7 +33170,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.warning": {
       "name": "warning",
@@ -30372,7 +33186,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.write": {
       "name": "write",
@@ -30394,7 +33209,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -30416,7 +33232,8 @@
           "description": "<p>The named dataset to concat. Optional. You can only pass in 1\ndataset (including the one in the data parameter).</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -30438,7 +33255,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -30474,7 +33292,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -30503,14 +33322,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
       "signature": "element.balloons(self)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -30546,7 +33367,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -30561,6 +33383,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.beta_container": {
@@ -30568,7 +33398,8 @@
       "signature": "element.beta_container(*args, **kwargs)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -30590,7 +33421,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -30626,7 +33458,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -30676,6 +33509,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.caption": {
@@ -30691,7 +33532,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -30748,6 +33590,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.code": {
@@ -30770,7 +33620,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -30827,6 +33678,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.columns": {
@@ -30842,6 +33701,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.container": {
@@ -30849,7 +33716,8 @@
       "signature": "element.container(self)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -30878,7 +33746,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -30948,6 +33817,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date or a tuple with 0-2 dates",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -31024,6 +33901,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.empty": {
@@ -31031,7 +33916,8 @@
       "signature": "element.empty(self)",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -31046,7 +33932,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -31061,7 +33948,8 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -31083,7 +33971,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -31147,6 +34036,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.form": {
@@ -31169,7 +34066,8 @@
           "description": "<p>If True, all widgets inside the form will be reset to their default\nvalues after the user presses the Submit button. Defaults to False.\n(Note that Custom Components are unaffected by this flag, and\nwill not be reset to their defaults on form submission.)</p>\n",
           "default": "values"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -31211,6 +34109,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.graphviz_chart": {
@@ -31233,7 +34139,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -31255,7 +34162,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -31270,7 +34178,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -31327,7 +34236,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -31342,7 +34252,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.is_negative": {
       "name": "is_negative",
@@ -31361,7 +34272,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -31376,7 +34288,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -31412,7 +34325,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -31434,7 +34348,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -31456,7 +34371,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.metric": {
       "name": "metric",
@@ -31492,7 +34408,8 @@
           "description": "<p>If &quot;normal&quot; (default), the delta indicator is shown as described\nabove. If &quot;inverse&quot;, it is red when positive and green when\nnegative. This is useful when a negative change is considered\ngood, e.g. if cost decreased. If &quot;off&quot;, delta is  shown in gray\nregardless of its value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -31563,11 +34480,19 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f5c61ef5bb0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fa13c8c6700>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -31648,6 +34573,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.parse_delta": {
@@ -31710,7 +34643,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -31725,7 +34659,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -31740,7 +34675,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -31770,7 +34706,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -31840,6 +34777,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -31912,6 +34857,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.selectbox": {
@@ -31982,6 +34935,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -32068,6 +35029,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.subheader": {
@@ -32090,7 +35059,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -32105,7 +35075,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -32120,7 +35091,8 @@
           "description": "<p>The table data.\nPyarrow tables are not supported by Streamlit's legacy DataFrame serialization\n(i.e. with <cite>config.dataFrameSerialization = &quot;legacy&quot;</cite>).\nTo use pyarrow tables, please enable pyarrow by changing the config setting,\n<cite>config.dataFrameSerialization = &quot;arrow&quot;</cite>.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -32135,7 +35107,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -32205,6 +35178,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -32284,6 +35265,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.time_input": {
@@ -32341,6 +35330,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.title": {
@@ -32363,7 +35360,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -32399,7 +35397,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -32428,7 +35427,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -32443,7 +35443,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -32465,7 +35466,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -32492,6 +35494,14 @@
           "is_optional": false,
           "description": "<p>The URL that the component is served from. Either <cite>path</cite> or <cite>url</cite>\nmust be specified, but not both.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "CustomComponent",
+          "is_generator": false,
+          "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -32528,7 +35538,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -32563,7 +35574,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     }
   },
   "1.0.0": {
@@ -32587,7 +35599,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -32623,7 +35636,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.audio": {
       "name": "audio",
@@ -32652,14 +35666,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.balloons": {
       "name": "balloons",
       "signature": "st.balloons()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -32695,7 +35711,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -32710,6 +35727,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.beta_container": {
@@ -32717,7 +35742,8 @@
       "signature": "st.beta_container(*args, **kwargs)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -32739,7 +35765,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -32775,7 +35802,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.button": {
       "name": "button",
@@ -32824,6 +35852,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -32889,7 +35925,8 @@
           "description": "<p>The maximum number of seconds to keep an entry in the cache, or\nNone if cache entries should not expire. The default is None.</p>\n",
           "default": "None."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.caption": {
       "name": "caption",
@@ -32904,7 +35941,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -32961,6 +35999,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.code": {
@@ -32983,7 +36029,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -33040,6 +36087,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.columns": {
@@ -33055,6 +36110,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.container": {
@@ -33062,7 +36125,8 @@
       "signature": "st.container()",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -33091,7 +36155,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -33161,6 +36226,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date or a tuple with 0-2 dates",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -33233,6 +36306,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.echo": {
@@ -33248,14 +36329,16 @@
           "description": "<p>Whether to show the echoed code before or after the results of the\nexecuted code block.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.empty": {
       "name": "empty",
       "signature": "st.empty()",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.error": {
       "name": "error",
@@ -33270,7 +36353,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.exception": {
       "name": "exception",
@@ -33285,7 +36369,8 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.expander": {
       "name": "expander",
@@ -33307,14 +36392,23 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
       "signature": "st.experimental_get_query_params()",
       "example": "<blockquote>\n<p>Let's say the user's web browser is at\n<cite>http://localhost:8501/?show_map=True&amp;selected=asia&amp;selected=america</cite>.\nThen, you can get the query parameters using the following:</p>\n<pre class=\"doctest-block\">\nst.experimental_get_query_params()\n{&quot;show_map&quot;: [&quot;True&quot;], &quot;selected&quot;: [&quot;asia&quot;, &quot;america&quot;]}\n</pre>\n<p>Note that the values in the returned dict are <em>always</em> lists. This is\nbecause we internally use Python's urllib.parse.parse_qs(), which behaves\nthis way. And this behavior makes sense when you consider that every item\nin a query string is potentially a 1-element array.</p>\n</blockquote>\n",
       "description": "Return the query parameters that is currently showing in the browser's URL bar.",
-      "args": []
+      "args": [],
+      "returns": [
+        {
+          "type_name": "dict",
+          "is_generator": false,
+          "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
+          "return_name": null
+        }
+      ]
     },
     "streamlit.experimental_memo": {
       "name": "experimental_memo",
@@ -33364,13 +36458,15 @@
           "description": "<p>The maximum number of seconds to keep an entry in the cache, or\nNone if cache entries should not expire. The default is None.</p>\n",
           "default": "None."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -33385,7 +36481,8 @@
           "description": "<p>The query parameters to set, as key-value pairs.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -33401,7 +36498,8 @@
           "description": "<p>One or many objects to debug in the App.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_singleton": {
       "name": "experimental_singleton",
@@ -33430,7 +36528,8 @@
           "description": "<p>Suppress warnings about calling Streamlit functions from within\nthe singleton function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -33494,6 +36593,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.form": {
@@ -33516,7 +36623,8 @@
           "description": "<p>If True, all widgets inside the form will be reset to their default\nvalues after the user presses the Submit button. Defaults to False.\n(Note that Custom Components are unaffected by this flag, and\nwill not be reset to their defaults on form submission.)</p>\n",
           "default": "values"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -33558,6 +36666,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.get_option": {
@@ -33572,7 +36688,8 @@
           "description": "<p>The config option key of the form &quot;section.optionName&quot;. To see all\navailable options, run <cite>streamlit config show</cite> on a terminal.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -33594,7 +36711,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.header": {
       "name": "header",
@@ -33616,7 +36734,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.help": {
       "name": "help",
@@ -33631,7 +36750,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.image": {
       "name": "image",
@@ -33688,7 +36808,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.info": {
       "name": "info",
@@ -33703,7 +36824,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.json": {
       "name": "json",
@@ -33718,7 +36840,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.latex": {
       "name": "latex",
@@ -33733,7 +36856,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -33769,7 +36893,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.map": {
       "name": "map",
@@ -33791,7 +36916,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -33813,7 +36939,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.metric": {
       "name": "metric",
@@ -33849,7 +36976,8 @@
           "description": "<p>If &quot;normal&quot; (default), the delta indicator is shown as described\nabove. If &quot;inverse&quot;, it is red when positive and green when\nnegative. This is useful when a negative change is considered\ngood, e.g. if cost decreased. If &quot;off&quot;, delta is  shown in gray\nregardless of its value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -33920,11 +37048,19 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fa0fd27aa30>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f84b6f78550>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -34005,6 +37141,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.plotly_chart": {
@@ -34055,7 +37199,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.progress": {
       "name": "progress",
@@ -34070,7 +37215,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -34085,7 +37231,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -34115,7 +37262,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.radio": {
       "name": "radio",
@@ -34185,6 +37333,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -34257,6 +37413,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.selectbox": {
@@ -34328,6 +37492,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.set_option": {
@@ -34349,7 +37521,8 @@
           "description": "<p>The new value to assign to this config option.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -34392,7 +37565,8 @@
           "description": "<p>Configure the menu that appears on the top-right side of this app.\nThe keys in this dict denote the menu item you'd like to configure:</p>\n<div class=\"system-message\">\n<p class=\"system-message-title\">System Message: ERROR/3 (<tt class=\"docutils\">&lt;string&gt;</tt>, line 3)</p>\nUnexpected indentation.</div>\n<blockquote>\n<ul class=\"simple\">\n<li><dl class=\"first docutils\">\n<dt>&quot;Get help&quot;: str or None</dt>\n<dd>The URL this menu item should point to.\nIf None, hides this menu item.</dd>\n</dl>\n</li>\n<li><dl class=\"first docutils\">\n<dt>&quot;Report a Bug&quot;: str or None</dt>\n<dd>The URL this menu item should point to.\nIf None, hides this menu item.</dd>\n</dl>\n</li>\n<li><dl class=\"first docutils\">\n<dt>&quot;About&quot;: str or None</dt>\n<dd>A markdown string to show in the About dialog.\nIf None, only shows Streamlit's default About text.</dd>\n</dl>\n</li>\n</ul>\n</blockquote>\n",
           "default": "About"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.slider": {
       "name": "slider",
@@ -34477,6 +37651,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.spinner": {
@@ -34492,14 +37674,16 @@
           "description": "<p>A message to display while executing that block</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.stop": {
       "name": "stop",
       "signature": "st.stop()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -34521,7 +37705,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.success": {
       "name": "success",
@@ -34536,7 +37721,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.table": {
       "name": "table",
@@ -34551,7 +37737,8 @@
           "description": "<p>The table data.\nPyarrow tables are not supported by Streamlit's legacy DataFrame serialization\n(i.e. with <cite>config.dataFrameSerialization = &quot;legacy&quot;</cite>).\nTo use pyarrow tables, please enable pyarrow by changing the config setting,\n<cite>config.dataFrameSerialization = &quot;arrow&quot;</cite>.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text": {
       "name": "text",
@@ -34566,7 +37753,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -34636,6 +37824,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -34715,6 +37911,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.time_input": {
@@ -34772,6 +37976,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.title": {
@@ -34794,7 +38006,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -34830,7 +38043,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.video": {
       "name": "video",
@@ -34859,7 +38073,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.warning": {
       "name": "warning",
@@ -34874,7 +38089,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.write": {
       "name": "write",
@@ -34896,7 +38112,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -34918,7 +38135,8 @@
           "description": "<p>The named dataset to concat. Optional. You can only pass in 1\ndataset (including the one in the data parameter).</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -34940,7 +38158,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -34976,7 +38195,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -35005,14 +38225,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
       "signature": "element.balloons(self)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -35048,7 +38270,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -35063,6 +38286,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.beta_container": {
@@ -35070,7 +38301,8 @@
       "signature": "element.beta_container(*args, **kwargs)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -35092,7 +38324,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -35128,7 +38361,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -35178,6 +38412,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.caption": {
@@ -35193,7 +38435,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -35250,6 +38493,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.code": {
@@ -35272,7 +38523,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -35329,6 +38581,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.columns": {
@@ -35344,6 +38604,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.container": {
@@ -35351,7 +38619,8 @@
       "signature": "element.container(self)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -35380,7 +38649,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -35450,6 +38720,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date or a tuple with 0-2 dates",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -35526,6 +38804,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.empty": {
@@ -35533,7 +38819,8 @@
       "signature": "element.empty(self)",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -35548,7 +38835,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -35563,7 +38851,8 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -35585,7 +38874,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -35649,6 +38939,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.form": {
@@ -35671,7 +38969,8 @@
           "description": "<p>If True, all widgets inside the form will be reset to their default\nvalues after the user presses the Submit button. Defaults to False.\n(Note that Custom Components are unaffected by this flag, and\nwill not be reset to their defaults on form submission.)</p>\n",
           "default": "values"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -35713,6 +39012,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.graphviz_chart": {
@@ -35735,7 +39042,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -35757,7 +39065,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -35772,7 +39081,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -35829,7 +39139,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -35844,7 +39155,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.is_negative": {
       "name": "is_negative",
@@ -35863,7 +39175,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -35878,7 +39191,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -35914,7 +39228,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -35936,7 +39251,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -35958,7 +39274,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.metric": {
       "name": "metric",
@@ -35994,7 +39311,8 @@
           "description": "<p>If &quot;normal&quot; (default), the delta indicator is shown as described\nabove. If &quot;inverse&quot;, it is red when positive and green when\nnegative. This is useful when a negative change is considered\ngood, e.g. if cost decreased. If &quot;off&quot;, delta is  shown in gray\nregardless of its value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -36065,11 +39383,19 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fa0fd27aa30>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f84b6f78550>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -36150,6 +39476,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.parse_delta": {
@@ -36212,7 +39546,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -36227,7 +39562,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -36242,7 +39578,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -36272,7 +39609,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -36342,6 +39680,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -36414,6 +39760,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.selectbox": {
@@ -36484,6 +39838,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -36570,6 +39932,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.subheader": {
@@ -36592,7 +39962,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -36607,7 +39978,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -36622,7 +39994,8 @@
           "description": "<p>The table data.\nPyarrow tables are not supported by Streamlit's legacy DataFrame serialization\n(i.e. with <cite>config.dataFrameSerialization = &quot;legacy&quot;</cite>).\nTo use pyarrow tables, please enable pyarrow by changing the config setting,\n<cite>config.dataFrameSerialization = &quot;arrow&quot;</cite>.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -36637,7 +40010,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -36707,6 +40081,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -36786,6 +40168,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.time_input": {
@@ -36843,6 +40233,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.title": {
@@ -36865,7 +40263,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -36901,7 +40300,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -36930,7 +40330,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -36945,7 +40346,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -36967,7 +40369,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -36994,6 +40397,14 @@
           "is_optional": false,
           "description": "<p>The URL that the component is served from. Either <cite>path</cite> or <cite>url</cite>\nmust be specified, but not both.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "CustomComponent",
+          "is_generator": false,
+          "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -37030,7 +40441,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -37065,7 +40477,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     }
   },
   "1.1.0": {
@@ -37089,7 +40502,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -37125,7 +40539,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.audio": {
       "name": "audio",
@@ -37154,14 +40569,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.balloons": {
       "name": "balloons",
       "signature": "st.balloons()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -37197,7 +40614,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -37212,6 +40630,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.beta_container": {
@@ -37219,7 +40645,8 @@
       "signature": "st.beta_container(*args, **kwargs)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -37241,7 +40668,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -37277,7 +40705,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.button": {
       "name": "button",
@@ -37326,6 +40755,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -37391,7 +40828,8 @@
           "description": "<p>The maximum number of seconds to keep an entry in the cache, or\nNone if cache entries should not expire. The default is None.</p>\n",
           "default": "None."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.caption": {
       "name": "caption",
@@ -37406,7 +40844,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -37463,6 +40902,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.code": {
@@ -37485,7 +40932,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -37542,6 +40990,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.columns": {
@@ -37557,6 +41013,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.container": {
@@ -37564,7 +41028,8 @@
       "signature": "st.container()",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -37593,7 +41058,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -37663,6 +41129,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date or a tuple with 0-2 dates",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -37735,6 +41209,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.echo": {
@@ -37750,14 +41232,16 @@
           "description": "<p>Whether to show the echoed code before or after the results of the\nexecuted code block.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.empty": {
       "name": "empty",
       "signature": "st.empty()",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.error": {
       "name": "error",
@@ -37772,7 +41256,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.exception": {
       "name": "exception",
@@ -37787,7 +41272,8 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.expander": {
       "name": "expander",
@@ -37809,14 +41295,23 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
       "signature": "st.experimental_get_query_params()",
       "example": "<blockquote>\n<p>Let's say the user's web browser is at\n<cite>http://localhost:8501/?show_map=True&amp;selected=asia&amp;selected=america</cite>.\nThen, you can get the query parameters using the following:</p>\n<pre class=\"doctest-block\">\nst.experimental_get_query_params()\n{&quot;show_map&quot;: [&quot;True&quot;], &quot;selected&quot;: [&quot;asia&quot;, &quot;america&quot;]}\n</pre>\n<p>Note that the values in the returned dict are <em>always</em> lists. This is\nbecause we internally use Python's urllib.parse.parse_qs(), which behaves\nthis way. And this behavior makes sense when you consider that every item\nin a query string is potentially a 1-element array.</p>\n</blockquote>\n",
       "description": "Return the query parameters that is currently showing in the browser's URL bar.",
-      "args": []
+      "args": [],
+      "returns": [
+        {
+          "type_name": "dict",
+          "is_generator": false,
+          "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
+          "return_name": null
+        }
+      ]
     },
     "streamlit.experimental_memo": {
       "name": "experimental_memo",
@@ -37866,13 +41361,15 @@
           "description": "<p>The maximum number of seconds to keep an entry in the cache, or\nNone if cache entries should not expire. The default is None.</p>\n",
           "default": "None."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -37887,7 +41384,8 @@
           "description": "<p>The query parameters to set, as key-value pairs.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -37903,7 +41401,8 @@
           "description": "<p>One or many objects to debug in the App.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_singleton": {
       "name": "experimental_singleton",
@@ -37932,7 +41431,8 @@
           "description": "<p>Suppress warnings about calling Streamlit functions from within\nthe singleton function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -37996,6 +41496,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.form": {
@@ -38018,7 +41526,8 @@
           "description": "<p>If True, all widgets inside the form will be reset to their default\nvalues after the user presses the Submit button. Defaults to False.\n(Note that Custom Components are unaffected by this flag, and\nwill not be reset to their defaults on form submission.)</p>\n",
           "default": "values"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -38060,6 +41569,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.get_option": {
@@ -38074,7 +41591,8 @@
           "description": "<p>The config option key of the form &quot;section.optionName&quot;. To see all\navailable options, run <cite>streamlit config show</cite> on a terminal.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -38096,7 +41614,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.header": {
       "name": "header",
@@ -38118,7 +41637,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.help": {
       "name": "help",
@@ -38133,7 +41653,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.image": {
       "name": "image",
@@ -38190,7 +41711,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.info": {
       "name": "info",
@@ -38205,7 +41727,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.json": {
       "name": "json",
@@ -38220,7 +41743,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.latex": {
       "name": "latex",
@@ -38235,7 +41759,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -38271,7 +41796,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.map": {
       "name": "map",
@@ -38293,7 +41819,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -38315,7 +41842,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.metric": {
       "name": "metric",
@@ -38351,7 +41879,8 @@
           "description": "<p>If &quot;normal&quot; (default), the delta indicator is shown as described\nabove. If &quot;inverse&quot;, it is red when positive and green when\nnegative. This is useful when a negative change is considered\ngood, e.g. if cost decreased. If &quot;off&quot;, delta is  shown in gray\nregardless of its value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -38422,11 +41951,19 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fdd57e53f10>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f63338899a0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -38507,6 +42044,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.plotly_chart": {
@@ -38557,7 +42102,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.progress": {
       "name": "progress",
@@ -38572,7 +42118,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -38587,7 +42134,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -38617,7 +42165,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.radio": {
       "name": "radio",
@@ -38687,6 +42236,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -38759,6 +42316,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.selectbox": {
@@ -38830,6 +42395,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.set_option": {
@@ -38851,7 +42424,8 @@
           "description": "<p>The new value to assign to this config option.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -38894,7 +42468,8 @@
           "description": "<p>Configure the menu that appears on the top-right side of this app.\nThe keys in this dict denote the menu item you'd like to configure:</p>\n<ul class=\"simple\">\n<li><dl class=\"first docutils\">\n<dt>&quot;Get help&quot;: str or None</dt>\n<dd>The URL this menu item should point to.\nIf None, hides this menu item.</dd>\n</dl>\n</li>\n<li><dl class=\"first docutils\">\n<dt>&quot;Report a Bug&quot;: str or None</dt>\n<dd>The URL this menu item should point to.\nIf None, hides this menu item.</dd>\n</dl>\n</li>\n<li><dl class=\"first docutils\">\n<dt>&quot;About&quot;: str or None</dt>\n<dd>A markdown string to show in the About dialog.\nIf None, only shows Streamlit's default About text.</dd>\n</dl>\n</li>\n</ul>\n",
           "default": "About"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.slider": {
       "name": "slider",
@@ -38979,6 +42554,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.spinner": {
@@ -38994,14 +42577,16 @@
           "description": "<p>A message to display while executing that block</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.stop": {
       "name": "stop",
       "signature": "st.stop()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -39023,7 +42608,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.success": {
       "name": "success",
@@ -39038,7 +42624,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.table": {
       "name": "table",
@@ -39053,7 +42640,8 @@
           "description": "<p>The table data.\nPyarrow tables are not supported by Streamlit's legacy DataFrame serialization\n(i.e. with <cite>config.dataFrameSerialization = &quot;legacy&quot;</cite>).\nTo use pyarrow tables, please enable pyarrow by changing the config setting,\n<cite>config.dataFrameSerialization = &quot;arrow&quot;</cite>.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text": {
       "name": "text",
@@ -39068,7 +42656,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -39138,6 +42727,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -39217,6 +42814,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.time_input": {
@@ -39274,6 +42879,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.title": {
@@ -39296,7 +42909,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -39332,7 +42946,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.video": {
       "name": "video",
@@ -39361,7 +42976,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.warning": {
       "name": "warning",
@@ -39376,7 +42992,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.write": {
       "name": "write",
@@ -39398,7 +43015,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -39420,7 +43038,8 @@
           "description": "<p>The named dataset to concat. Optional. You can only pass in 1\ndataset (including the one in the data parameter).</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -39442,7 +43061,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -39478,7 +43098,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -39507,14 +43128,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
       "signature": "element.balloons(self)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -39550,7 +43173,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -39565,6 +43189,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.beta_container": {
@@ -39572,7 +43204,8 @@
       "signature": "element.beta_container(*args, **kwargs)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -39594,7 +43227,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -39630,7 +43264,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -39680,6 +43315,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.caption": {
@@ -39695,7 +43338,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -39752,6 +43396,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.code": {
@@ -39774,7 +43426,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -39831,6 +43484,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.columns": {
@@ -39846,6 +43507,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.container": {
@@ -39853,7 +43522,8 @@
       "signature": "element.container(self)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -39882,7 +43552,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -39952,6 +43623,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date or a tuple with 0-2 dates",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -40028,6 +43707,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.empty": {
@@ -40035,7 +43722,8 @@
       "signature": "element.empty(self)",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -40050,7 +43738,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -40065,7 +43754,8 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -40087,7 +43777,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -40151,6 +43842,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.form": {
@@ -40173,7 +43872,8 @@
           "description": "<p>If True, all widgets inside the form will be reset to their default\nvalues after the user presses the Submit button. Defaults to False.\n(Note that Custom Components are unaffected by this flag, and\nwill not be reset to their defaults on form submission.)</p>\n",
           "default": "values"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -40215,6 +43915,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.graphviz_chart": {
@@ -40237,7 +43945,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -40259,7 +43968,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -40274,7 +43984,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -40331,7 +44042,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -40346,7 +44058,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.is_negative": {
       "name": "is_negative",
@@ -40365,7 +44078,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -40380,7 +44094,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -40416,7 +44131,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -40438,7 +44154,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -40460,7 +44177,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.metric": {
       "name": "metric",
@@ -40496,7 +44214,8 @@
           "description": "<p>If &quot;normal&quot; (default), the delta indicator is shown as described\nabove. If &quot;inverse&quot;, it is red when positive and green when\nnegative. This is useful when a negative change is considered\ngood, e.g. if cost decreased. If &quot;off&quot;, delta is  shown in gray\nregardless of its value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -40567,11 +44286,19 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fdd57e53f10>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f63338899a0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -40652,6 +44379,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.parse_delta": {
@@ -40714,7 +44449,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -40729,7 +44465,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -40744,7 +44481,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -40774,7 +44512,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -40844,6 +44583,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -40916,6 +44663,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.selectbox": {
@@ -40986,6 +44741,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -41072,6 +44835,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.subheader": {
@@ -41094,7 +44865,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -41109,7 +44881,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -41124,7 +44897,8 @@
           "description": "<p>The table data.\nPyarrow tables are not supported by Streamlit's legacy DataFrame serialization\n(i.e. with <cite>config.dataFrameSerialization = &quot;legacy&quot;</cite>).\nTo use pyarrow tables, please enable pyarrow by changing the config setting,\n<cite>config.dataFrameSerialization = &quot;arrow&quot;</cite>.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -41139,7 +44913,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -41209,6 +44984,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -41288,6 +45071,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.time_input": {
@@ -41345,6 +45136,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.title": {
@@ -41367,7 +45166,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -41403,7 +45203,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -41432,7 +45233,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -41447,7 +45249,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -41469,7 +45272,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -41496,6 +45300,14 @@
           "is_optional": false,
           "description": "<p>The URL that the component is served from. Either <cite>path</cite> or <cite>url</cite>\nmust be specified, but not both.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "CustomComponent",
+          "is_generator": false,
+          "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -41532,7 +45344,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -41567,7 +45380,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     }
   },
   "1.2.0": {
@@ -41591,7 +45405,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -41627,7 +45442,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.audio": {
       "name": "audio",
@@ -41656,14 +45472,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.balloons": {
       "name": "balloons",
       "signature": "st.balloons()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -41699,7 +45517,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -41714,6 +45533,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.beta_container": {
@@ -41721,7 +45548,8 @@
       "signature": "st.beta_container(*args, **kwargs)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -41743,7 +45571,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -41779,7 +45608,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.button": {
       "name": "button",
@@ -41828,6 +45658,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -41893,7 +45731,8 @@
           "description": "<p>The maximum number of seconds to keep an entry in the cache, or\nNone if cache entries should not expire. The default is None.</p>\n",
           "default": "None."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.caption": {
       "name": "caption",
@@ -41908,7 +45747,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -41965,6 +45805,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.code": {
@@ -41987,7 +45835,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -42044,6 +45893,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.columns": {
@@ -42059,6 +45916,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.container": {
@@ -42066,7 +45931,8 @@
       "signature": "st.container()",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -42095,7 +45961,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -42165,6 +46032,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date or a tuple with 0-2 dates",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -42237,6 +46112,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.echo": {
@@ -42252,14 +46135,16 @@
           "description": "<p>Whether to show the echoed code before or after the results of the\nexecuted code block.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.empty": {
       "name": "empty",
       "signature": "st.empty()",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.error": {
       "name": "error",
@@ -42274,7 +46159,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.exception": {
       "name": "exception",
@@ -42289,7 +46175,8 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.expander": {
       "name": "expander",
@@ -42311,14 +46198,23 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
       "signature": "st.experimental_get_query_params()",
       "example": "<blockquote>\n<p>Let's say the user's web browser is at\n<cite>http://localhost:8501/?show_map=True&amp;selected=asia&amp;selected=america</cite>.\nThen, you can get the query parameters using the following:</p>\n<pre class=\"doctest-block\">\nst.experimental_get_query_params()\n{&quot;show_map&quot;: [&quot;True&quot;], &quot;selected&quot;: [&quot;asia&quot;, &quot;america&quot;]}\n</pre>\n<p>Note that the values in the returned dict are <em>always</em> lists. This is\nbecause we internally use Python's urllib.parse.parse_qs(), which behaves\nthis way. And this behavior makes sense when you consider that every item\nin a query string is potentially a 1-element array.</p>\n</blockquote>\n",
       "description": "Return the query parameters that is currently showing in the browser's URL bar.",
-      "args": []
+      "args": [],
+      "returns": [
+        {
+          "type_name": "dict",
+          "is_generator": false,
+          "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
+          "return_name": null
+        }
+      ]
     },
     "streamlit.experimental_memo": {
       "name": "experimental_memo",
@@ -42368,13 +46264,15 @@
           "description": "<p>The maximum number of seconds to keep an entry in the cache, or\nNone if cache entries should not expire. The default is None.</p>\n",
           "default": "None."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -42389,7 +46287,8 @@
           "description": "<p>The query parameters to set, as key-value pairs.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -42405,7 +46304,8 @@
           "description": "<p>One or many objects to debug in the App.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.experimental_singleton": {
       "name": "experimental_singleton",
@@ -42434,7 +46334,8 @@
           "description": "<p>Suppress warnings about calling Streamlit functions from within\nthe singleton function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -42498,6 +46399,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.form": {
@@ -42520,7 +46429,8 @@
           "description": "<p>If True, all widgets inside the form will be reset to their default\nvalues after the user presses the Submit button. Defaults to False.\n(Note that Custom Components are unaffected by this flag, and\nwill not be reset to their defaults on form submission.)</p>\n",
           "default": "values"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -42562,6 +46472,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.get_option": {
@@ -42576,7 +46494,8 @@
           "description": "<p>The config option key of the form &quot;section.optionName&quot;. To see all\navailable options, run <cite>streamlit config show</cite> on a terminal.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -42598,7 +46517,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.header": {
       "name": "header",
@@ -42620,7 +46540,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.help": {
       "name": "help",
@@ -42635,7 +46556,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.image": {
       "name": "image",
@@ -42692,7 +46614,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.info": {
       "name": "info",
@@ -42707,7 +46630,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.json": {
       "name": "json",
@@ -42722,7 +46646,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.latex": {
       "name": "latex",
@@ -42737,7 +46662,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -42773,7 +46699,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.map": {
       "name": "map",
@@ -42795,7 +46722,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -42817,7 +46745,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.metric": {
       "name": "metric",
@@ -42853,7 +46782,8 @@
           "description": "<p>If &quot;normal&quot; (default), the delta indicator is shown as described\nabove. If &quot;inverse&quot;, it is red when positive and green when\nnegative. This is useful when a negative change is considered\ngood, e.g. if cost decreased. If &quot;off&quot;, delta is  shown in gray\nregardless of its value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -42924,11 +46854,19 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f5c03670610>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fdc58153100>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -43009,6 +46947,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.plotly_chart": {
@@ -43059,7 +47005,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.progress": {
       "name": "progress",
@@ -43074,7 +47021,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -43089,7 +47037,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -43119,7 +47068,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.radio": {
       "name": "radio",
@@ -43189,6 +47139,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -43261,6 +47219,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.selectbox": {
@@ -43332,6 +47298,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.set_option": {
@@ -43353,7 +47327,8 @@
           "description": "<p>The new value to assign to this config option.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -43396,7 +47371,8 @@
           "description": "<p>Configure the menu that appears on the top-right side of this app.\nThe keys in this dict denote the menu item you'd like to configure:</p>\n<ul class=\"simple\">\n<li><dl class=\"first docutils\">\n<dt>&quot;Get help&quot;: str or None</dt>\n<dd>The URL this menu item should point to.\nIf None, hides this menu item.</dd>\n</dl>\n</li>\n<li><dl class=\"first docutils\">\n<dt>&quot;Report a Bug&quot;: str or None</dt>\n<dd>The URL this menu item should point to.\nIf None, hides this menu item.</dd>\n</dl>\n</li>\n<li><dl class=\"first docutils\">\n<dt>&quot;About&quot;: str or None</dt>\n<dd>A markdown string to show in the About dialog.\nIf None, only shows Streamlit's default About text.</dd>\n</dl>\n</li>\n</ul>\n",
           "default": "About"
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.slider": {
       "name": "slider",
@@ -43481,6 +47457,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.spinner": {
@@ -43496,14 +47480,16 @@
           "description": "<p>A message to display while executing that block</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.stop": {
       "name": "stop",
       "signature": "st.stop()",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -43525,7 +47511,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.success": {
       "name": "success",
@@ -43540,7 +47527,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.table": {
       "name": "table",
@@ -43555,7 +47543,8 @@
           "description": "<p>The table data.\nPyarrow tables are not supported by Streamlit's legacy DataFrame serialization\n(i.e. with <cite>config.dataFrameSerialization = &quot;legacy&quot;</cite>).\nTo use pyarrow tables, please enable pyarrow by changing the config setting,\n<cite>config.dataFrameSerialization = &quot;arrow&quot;</cite>.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text": {
       "name": "text",
@@ -43570,7 +47559,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -43647,6 +47637,14 @@
           "is_optional": false,
           "description": "<p>An optional string displayed when the text area is empty. If None,\nno text is displayed. This is a keyword only argument.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -43733,6 +47731,14 @@
           "description": "<p>An optional string displayed when the text input is empty. If None,\nno text is displayed. This is a keyword only argument.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.time_input": {
@@ -43790,6 +47796,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "streamlit.title": {
@@ -43812,7 +47826,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -43848,7 +47863,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.video": {
       "name": "video",
@@ -43877,7 +47893,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.warning": {
       "name": "warning",
@@ -43892,7 +47909,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.write": {
       "name": "write",
@@ -43914,7 +47932,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -43936,7 +47955,8 @@
           "description": "<p>The named dataset to concat. Optional. You can only pass in 1\ndataset (including the one in the data parameter).</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -43958,7 +47978,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -43994,7 +48015,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -44023,14 +48045,16 @@
           "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
       "signature": "element.balloons(self)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -44066,7 +48090,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -44081,6 +48106,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.beta_container": {
@@ -44088,7 +48121,8 @@
       "signature": "element.beta_container(*args, **kwargs)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -44110,7 +48144,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -44146,7 +48181,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -44196,6 +48232,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.caption": {
@@ -44211,7 +48255,8 @@
           "description": "<p>The text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -44268,6 +48313,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>Whether or not the checkbox is checked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.code": {
@@ -44290,7 +48343,8 @@
           "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -44347,6 +48401,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The selected color as a hex string.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.columns": {
@@ -44362,6 +48424,14 @@
           "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list of containers",
+          "is_generator": false,
+          "description": "<p>A list of container objects.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.container": {
@@ -44369,7 +48439,8 @@
       "signature": "element.container(self)",
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -44398,7 +48469,8 @@
           "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
           "default": "height"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -44468,6 +48540,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.date or a tuple with 0-2 dates",
+          "is_generator": false,
+          "description": "<p>The current value of the date input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -44544,6 +48624,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.empty": {
@@ -44551,7 +48639,8 @@
       "signature": "element.empty(self)",
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": []
+      "args": [],
+      "returns": []
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -44566,7 +48655,8 @@
           "description": "<p>The error text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -44581,7 +48671,8 @@
           "description": "<p>The exception to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -44603,7 +48694,8 @@
           "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -44667,6 +48759,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "None or UploadedFile or list of UploadedFile",
+          "is_generator": false,
+          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.form": {
@@ -44689,7 +48789,8 @@
           "description": "<p>If True, all widgets inside the form will be reset to their default\nvalues after the user presses the Submit button. Defaults to False.\n(Note that Custom Components are unaffected by this flag, and\nwill not be reset to their defaults on form submission.)</p>\n",
           "default": "values"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -44731,6 +48832,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "bool",
+          "is_generator": false,
+          "description": "<p>True if the button was clicked.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.graphviz_chart": {
@@ -44753,7 +48862,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -44775,7 +48885,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -44790,7 +48901,8 @@
           "description": "<p>The object whose docstring should be displayed.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -44847,7 +48959,8 @@
           "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
           "default": "s"
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -44862,7 +48975,8 @@
           "description": "<p>The info text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.is_negative": {
       "name": "is_negative",
@@ -44881,7 +48995,8 @@
           "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -44896,7 +49011,8 @@
           "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -44932,7 +49048,8 @@
           "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -44954,7 +49071,8 @@
           "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -44976,7 +49094,8 @@
           "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.metric": {
       "name": "metric",
@@ -45012,7 +49131,8 @@
           "description": "<p>If &quot;normal&quot; (default), the delta indicator is shown as described\nabove. If &quot;inverse&quot;, it is red when positive and green when\nnegative. This is useful when a negative change is considered\ngood, e.g. if cost decreased. If &quot;off&quot;, delta is  shown in gray\nregardless of its value.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -45083,11 +49203,19 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "list",
+          "is_generator": false,
+          "description": "<p>A list with the selected options</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f5c03670610>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fdc58153100>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -45168,6 +49296,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int or float",
+          "is_generator": false,
+          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.parse_delta": {
@@ -45230,7 +49366,8 @@
           "description": "",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -45245,7 +49382,8 @@
           "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -45260,7 +49398,8 @@
           "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -45290,7 +49429,8 @@
           "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -45360,6 +49500,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -45432,6 +49580,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "any value or tuple of any value",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.selectbox": {
@@ -45502,6 +49658,14 @@
           "is_optional": false,
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "any",
+          "is_generator": false,
+          "description": "<p>The selected option</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -45588,6 +49752,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
+          "is_generator": false,
+          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.subheader": {
@@ -45610,7 +49782,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -45625,7 +49798,8 @@
           "description": "<p>The success text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -45640,7 +49814,8 @@
           "description": "<p>The table data.\nPyarrow tables are not supported by Streamlit's legacy DataFrame serialization\n(i.e. with <cite>config.dataFrameSerialization = &quot;legacy&quot;</cite>).\nTo use pyarrow tables, please enable pyarrow by changing the config setting,\n<cite>config.dataFrameSerialization = &quot;arrow&quot;</cite>.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -45655,7 +49830,8 @@
           "description": "<p>The string to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -45732,6 +49908,14 @@
           "is_optional": false,
           "description": "<p>An optional string displayed when the text area is empty. If None,\nno text is displayed. This is a keyword only argument.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -45818,6 +50002,14 @@
           "description": "<p>An optional string displayed when the text input is empty. If None,\nno text is displayed. This is a keyword only argument.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "str",
+          "is_generator": false,
+          "description": "<p>The current value of the text input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.time_input": {
@@ -45875,6 +50067,14 @@
           "description": "<p>An optional dict of kwargs to pass to the callback.</p>\n",
           "default": null
         }
+      ],
+      "returns": [
+        {
+          "type_name": "datetime.time",
+          "is_generator": false,
+          "description": "<p>The current value of the time input widget.</p>\n",
+          "return_name": null
+        }
       ]
     },
     "DeltaGenerator.title": {
@@ -45897,7 +50097,8 @@
           "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -45933,7 +50134,8 @@
           "description": "<p>Same as spec, but as keywords.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -45962,7 +50164,8 @@
           "description": "<p>The time from which this element should start playing.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -45977,7 +50180,8 @@
           "description": "<p>The warning text to display.</p>\n",
           "default": null
         }
-      ]
+      ],
+      "returns": []
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -45999,7 +50203,8 @@
           "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -46026,6 +50231,14 @@
           "is_optional": false,
           "description": "<p>The URL that the component is served from. Either <cite>path</cite> or <cite>url</cite>\nmust be specified, but not both.</p>\n",
           "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "CustomComponent",
+          "is_generator": false,
+          "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
+          "return_name": null
         }
       ]
     },
@@ -46062,7 +50275,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -46097,7 +50311,8 @@
           "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
           "default": "False."
         }
-      ]
+      ],
+      "returns": []
     }
   }
 }


### PR DESCRIPTION
Fixes a bug [noticed by Johannes](https://www.notion.so/streamlit/Show-return-types-in-widget-docstrings-440762c59fc34005b88eb876b4de0178) whereby return type information in widget docstrings was not being displayed.

### Changes:
-  Updates  `python/generate.py` to obtain return type info from docstrings
- Creates a new table in `autofuncton.js` to display return type info
- Modifies `table.js` to conditionally render the new table:
  -  If docstring belongs to an input widget, display the new table with return type info
  - Else, don't display the table

### Revised
![image](https://user-images.githubusercontent.com/20672874/145989165-b731cb51-960b-44dc-a848-897eecded03c.png)

### Current
![image](https://user-images.githubusercontent.com/20672874/145989322-174b8ae0-2cad-4aad-8e59-02a0963594fd.png)


