### PR TITLE
Replace Segment tag ID

### DIFF
--- a/components/utilities/gdpr.js
+++ b/components/utilities/gdpr.js
@@ -139,9 +139,9 @@ function insertAnalytics() {
           n.parentNode.insertBefore(t, n);
           analytics._loadOptions = e;
         };
-        analytics._writeKey = "5oR9PCgKBs3VqmQCMiiajboWKKBUa4dA";
+        analytics._writeKey = "pUoB6ihRTAFLDtLp2NWEuJvBNtiooQwE";
         analytics.SNIPPET_VERSION = "4.13.2";
-        analytics.load("5oR9PCgKBs3VqmQCMiiajboWKKBUa4dA");
+        analytics.load("pUoB6ihRTAFLDtLp2NWEuJvBNtiooQwE");
         analytics.page();
       }
   })();


### PR DESCRIPTION
Replace Segment tag ID to track events from the docs site properly. It seems like the docs’ analytics data isn’t writing to Segment properly (see below 👇)

<img width="657" alt="Screen Shot 2021-12-14 at 12 14 06 PM" src="https://user-images.githubusercontent.com/34423371/146264927-d3232662-6885-455d-a65f-5d0ea499c0e4.png">.

I checked the JS code and it seems to be working as expected (the Segment tag is getting added to the DOM when allowing the cookie banner), but the tag ID seems to be incorrect (it was the one we use on the website). The tag is now replaced to be the one from Segment's source, and my tests seem to be getting logged on the debugger:

![Screen Shot 2021-12-15 at 18 10 06](https://user-images.githubusercontent.com/34423371/146265437-bff1f1e9-50df-45bb-b54b-f1f5e9bfad5b.png)