### PR TITLE
Adds support to use Tailwind `dark` modifier

### DIFF
--- a/components/utilities/themeToggle.js
+++ b/components/utilities/themeToggle.js
@@ -8,10 +8,16 @@ const ThemeToggle = () => {
 
   useEffect(() => {
     document.body.dataset.theme = activeTheme;
+    if (activeTheme === "light-mode") {
+      document.documentElement.classList.add("light");
+      document.documentElement.classList.remove("dark");
+    } else {
+      document.documentElement.classList.add("dark");
+      document.documentElement.classList.remove("light");
+    }
     window.addEventListener(
       "ChangeTheme",
       function (e) {
-        /* ... */
         window.localStorage.setItem("theme", activeTheme);
       },
       false

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -5,12 +5,16 @@ import Document, { Html, Head, Main, NextScript } from "next/document";
 export default function StreamlitDocument() {
   const setInitialTheme = `
         function getUserPreference() {
-            if(window.localStorage.getItem('theme')) {
+          if(window.localStorage.getItem('theme')) {
             return window.localStorage.getItem('theme')
-            }
-            return window.matchMedia('(prefers-color-scheme: dark)').matches
-            ? 'dark-mode'
-            : 'light-mode'
+          }
+          return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark-mode' : 'light-mode';
+        }
+
+        if(getUserPreference() === 'dark-mode') {
+          document.documentElement.classList.add('dark');
+        } else {
+          document.documentElement.classList.add('light');
         }
         document.body.dataset.theme = getUserPreference();
         window.initial = { prism: false };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,7 @@ module.exports = {
     "./pages/*.js",
     "./pages/**/*.js",
   ],
-  darkMode: false, // or 'media' or 'class'
+  darkMode: "class", // or 'media' or 'class'
 
   theme: {
     screens: {


### PR DESCRIPTION
Now that we're starting to move the docs' CSS to Tailwind, it would be good to use [Tailwind's `dark` modifier](https://tailwindcss.com/docs/dark-mode) to style things when on dark mode.

To do that without solely relying on the user's `media` preference, we need to append a `dark` class on the `<html>` tag. Currently, we also have a `data-theme` attribute on the `<body>`, which is used to style things using Sass. As we progressively move away from Sass and into Tailwind CSS we'll likely remove the data attribute, but for now, we have to support both scenarios until we've refactored the entire codebase.