### PR TITLE
Fix on sidebar height

### DIFF
--- a/styles/components/navigation/sideBar.scss
+++ b/styles/components/navigation/sideBar.scss
@@ -5,6 +5,7 @@
   height: calc(100vh - #{$header-height});
   z-index: 0;
   width: 314px;
+  z-index: 2;
 
   * {
     transition: $slow;
@@ -142,7 +143,7 @@
         position: absolute;
         top: 0;
         padding-top: $header-height;
-        height: calc(100vh - (#{$header-height} * 2));
+        height: 100vh;
         padding-bottom: $header-height;
         @media (min-width: 1249px) {
           width: 314px;

--- a/styles/components/navigation/sideBar.scss
+++ b/styles/components/navigation/sideBar.scss
@@ -3,9 +3,8 @@
   position: fixed;
   top: 0;
   height: calc(100vh - #{$header-height});
-  z-index: 0;
   width: 314px;
-  z-index: 2;
+  z-index: 11;
 
   * {
     transition: $slow;
@@ -116,7 +115,6 @@
   .side-nav {
     list-style: none;
     padding-right: 1em;
-    z-index: 11;
     margin-bottom: calc(#{$header-height} * 1.5);
 
     @media (min-width: 1024px) {


### PR DESCRIPTION
This PR fixes an issue with the sidebar doesn't extending all the way to the bottom of the screen. See image below:

<img width="1440" alt="Screen Shot 2021-12-27 at 17 07 18" src="https://user-images.githubusercontent.com/34423371/147503910-b8594447-1692-45c5-ae52-785bbb2b546e.png">

This PR also fixes an issue on mobile where some elements with higher `z-index` where showing up above the menu. See image below:

<img width="383" alt="Screen Shot 2021-12-27 at 17 00 30" src="https://user-images.githubusercontent.com/34423371/147503878-cc735992-e4fa-4733-a235-8027c7fd6fd5.png">