### PR TITLE
Fix on TOML code blocks

### DIFF
--- a/styles/components/blocks/autofunction.scss
+++ b/styles/components/blocks/autofunction.scss
@@ -93,6 +93,10 @@
 
     pre.line-numbers {
       margin: 0;
+
+      .table {
+        display: inline;
+      }
     }
 
     p {

--- a/styles/components/blocks/code.scss
+++ b/styles/components/blocks/code.scss
@@ -70,6 +70,9 @@
       .boolean {
         color: $green-40;
       }
+      .table {
+        display: inline;
+      }
     }
 
     .line-numbers-rows {


### PR DESCRIPTION
## Description

This PR fixes an issue with TOML code blocks not rendering as expected. For a more detailed explanation of the issue, see [this Notion page](https://www.notion.so/streamlit/Autoformatting-bug-for-TOML-code-blocks-0059196649e041a999d18a91eb152cc2)

## The Problem

This issue is caused by two conflicting dependencies that we have:
1. `prism.js` adds a `.table` class to some tokens for styling the code blocks;
2. However, that `.table` class is also inheriting styles from Tailwind CSS, causing the rendering issue.

## The Solution

For now, I've overriden the Tailwind styling for these code blocks in the SCSS code. Moving forward, as we start to move away from Sass and into CSS modules, we'll need to refactor this again.