### PR TITLE
Make Suggest edits button link to core repo docstring source

### DIFF
--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -1,7 +1,6 @@
 import reverse from "lodash/reverse";
 import React, { useEffect, useState, useRef } from "react";
 import Table from "./table";
-import Helpful from "../utilities/helpful";
 import { H2 } from "./headers";
 import Warning from "./warning";
 import { withRouter, useRouter } from "next/router";
@@ -13,6 +12,8 @@ import "prismjs/plugins/line-highlight/prism-line-highlight.css";
 import "prismjs/plugins/toolbar/prism-toolbar";
 import "prismjs/plugins/copy-to-clipboard/prism-copy-to-clipboard";
 import "prismjs/plugins/normalize-whitespace/prism-normalize-whitespace";
+
+import useSourceFile from "../../lib/useSourceFile";
 
 const cleanHref = (name) => {
   return String(name).replace(".", "").replace(" ", "-");
@@ -102,6 +103,8 @@ const Autofunction = ({
 
   if (streamlitFunction in streamlit) {
     functionObject = streamlit[streamlitFunction];
+    const sourceFile = useSourceFile(functionObject.source);
+
     if (
       functionObject.description !== undefined &&
       functionObject.description
@@ -247,7 +250,6 @@ const Autofunction = ({
     <section className="autofunction" ref={blockRef}>
       {header}
       {body}
-      <Helpful slug={slug} sourcefile={functionObject.source} />
     </section>
   );
 };

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -1,7 +1,7 @@
 import reverse from "lodash/reverse";
 import React, { useEffect, useState, useRef } from "react";
 import Table from "./table";
-import SuggestEdits from "../utilities/suggestEdits";
+import Helpful from "../utilities/helpful";
 import { H2 } from "./headers";
 import Warning from "./warning";
 import { withRouter, useRouter } from "next/router";
@@ -247,7 +247,7 @@ const Autofunction = ({
     <section className="autofunction" ref={blockRef}>
       {header}
       {body}
-      <SuggestEdits sourcefile={functionObject.source} />
+      <Helpful slug={slug} sourcefile={functionObject.source} />
     </section>
   );
 };

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -1,6 +1,7 @@
 import reverse from "lodash/reverse";
 import React, { useEffect, useState, useRef } from "react";
 import Table from "./table";
+import SuggestEdits from "../utilities/suggestEdits";
 import { H2 } from "./headers";
 import Warning from "./warning";
 import { withRouter, useRouter } from "next/router";
@@ -246,6 +247,7 @@ const Autofunction = ({
     <section className="autofunction" ref={blockRef}>
       {header}
       {body}
+      <SuggestEdits sourcefile={functionObject.source} />
     </section>
   );
 };

--- a/context/AppContext.js
+++ b/context/AppContext.js
@@ -4,9 +4,12 @@ const AppContext = createContext();
 
 export function AppContextProvider({ children }) {
   const [version, setVersion] = useState(null);
+  const [sourceFile, setSourceFile] = useState(null);
 
   return (
-    <AppContext.Provider value={{ version, setVersion }}>
+    <AppContext.Provider
+      value={{ version, setVersion, sourceFile, setSourceFile }}
+    >
       {children}
     </AppContext.Provider>
   );

--- a/lib/useSourceFile.js
+++ b/lib/useSourceFile.js
@@ -1,0 +1,10 @@
+import { useAppContext } from "../context/AppContext";
+
+const useSourceFile = (source = null) => {
+  const { sourceFile, setSourceFile } = useAppContext();
+  setSourceFile(source);
+
+  return sourceFile;
+};
+
+export default useSourceFile;

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -2,7 +2,6 @@ import fs from "fs";
 import { join, basename } from "path";
 import sortBy from "lodash/sortBy";
 import React from "react";
-import { useRouter } from "next/router";
 import Link from "next/link";
 import Head from "next/head";
 import { serialize } from "next-mdx-remote/serialize";
@@ -22,6 +21,7 @@ import {
 } from "../lib/api";
 import { getPreviousNextFromMenu } from "../lib/utils.js";
 import useVersion from "../lib/useVersion.js";
+import { useAppContext } from "../context/AppContext";
 import Layout from "../components/layouts/globalTemplate";
 import BreadCrumbs from "../components/utilities/breadCrumbs";
 import SideBar from "../components/navigation/sideBar";
@@ -35,7 +35,6 @@ import ArrowLink from "../components/navigation/arrowLink";
 import Helpful from "../components/utilities/helpful";
 import { H1, H2, H3 } from "../components/blocks/headers";
 import Psa from "../components/utilities/psa";
-import SuggestEdits from "../components/utilities/suggestEdits";
 import FloatingNav from "../components/utilities/floatingNav";
 
 // MDX Components
@@ -72,11 +71,14 @@ export default function Article({
   let versionWarning;
   let currentLink;
   let sourceFile;
+  const autoFunctionSourceFile = useAppContext();
+
   sourceFile =
-    "https://github.com/streamlit/docs/tree/main" +
-    filename.substring(filename.indexOf("/content/"));
+    Object.keys(streamlit).length > 0 && autoFunctionSourceFile
+      ? autoFunctionSourceFile.sourceFile
+      : "https://github.com/streamlit/docs/tree/main" +
+        filename.substring(filename.indexOf("/content/"));
   const maxVersion = versions[versions.length - 1];
-  const router = useRouter();
   const version = useVersion(versionFromStaticLoad, versions, currMenuItem);
 
   const components = {

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -135,12 +135,22 @@ export default function Article({
 
   if (prevMenuItem) {
     previousArrow = (
-      <ArrowLink link={prevMenuItem.url} type="back" content={prevMenuItem.name} />
+      <ArrowLink
+        link={prevMenuItem.url}
+        type="back"
+        content={prevMenuItem.name}
+      />
     );
   }
 
   if (nextMenuItem) {
-    nextArrow = <ArrowLink link={nextMenuItem.url} type="next" content={nextMenuItem.name} />;
+    nextArrow = (
+      <ArrowLink
+        link={nextMenuItem.url}
+        type="next"
+        content={nextMenuItem.name}
+      />
+    );
   }
 
   if (nextMenuItem || prevMenuItem) {
@@ -222,9 +232,9 @@ export default function Article({
               <FloatingNav slug={slug} menu={menu} version={version} />
               <div className="content">
                 <MDXRemote {...source} components={components} />
+                <Helpful slug={slug} sourcefile={sourceFile} />
               </div>
             </article>
-            <Helpful slug={slug} sourcefile={sourceFile} />
             <Psa />
             {arrowContainer}
           </section>
@@ -307,7 +317,11 @@ export async function getStaticProps(context) {
     props["slug"] = context.params.slug;
     props["source"] = source;
     props["currMenuItem"] = current
-      ?  { name: current.name, url: current.url, isVersioned: !!current.isVersioned }
+      ? {
+          name: current.name,
+          url: current.url,
+          isVersioned: !!current.isVersioned,
+        }
       : null;
     props["nextMenuItem"] = next ? { name: next.name, url: next.url } : null;
     props["prevMenuItem"] = prev ? { name: prev.name, url: prev.url } : null;

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -70,12 +70,12 @@ export default function Article({
 }) {
   let versionWarning;
   let currentLink;
-  let sourceFile;
-  const autoFunctionSourceFile = useAppContext();
+  let suggestEditURL;
+  const { sourceFile } = useAppContext();
 
-  sourceFile =
-    Object.keys(streamlit).length > 0 && autoFunctionSourceFile
-      ? autoFunctionSourceFile.sourceFile
+  suggestEditURL =
+    Object.keys(streamlit).length > 0 && sourceFile
+      ? sourceFile
       : "https://github.com/streamlit/docs/tree/main" +
         filename.substring(filename.indexOf("/content/"));
   const maxVersion = versions[versions.length - 1];
@@ -234,7 +234,7 @@ export default function Article({
               <FloatingNav slug={slug} menu={menu} version={version} />
               <div className="content">
                 <MDXRemote {...source} components={components} />
-                <Helpful slug={slug} sourcefile={sourceFile} />
+                <Helpful slug={slug} sourcefile={suggestEditURL} />
               </div>
             </article>
             <Psa />

--- a/python/generate.py
+++ b/python/generate.py
@@ -29,6 +29,18 @@ def strip_code_prompts(rst_string):
     """Removes >>> and ... prompts from code blocks in examples."""
     return rst_string.replace('&gt;&gt;&gt; ', '').replace('&gt;&gt;&gt;\n', '\n').replace('\n...', '\n')
 
+def get_github_source(func):
+    repo_prefix = "https://github.com/streamlit/streamlit/blob/develop/lib"
+
+    # For Streamlit commands (e.g. st.spinner) wrapped by decorator
+    while '__wrapped__' in func.__dict__:
+        func = func.__wrapped__
+
+    path_parts = func.__code__.co_filename.partition("/streamlit")
+    line = func.__code__.co_firstlineno
+
+    return ''.join([repo_prefix, path_parts[1], path_parts[2], f'#L{line}'])
+
 
 def get_function_docstring_dict(func, funcname, signature_prefix):
     description = {}
@@ -96,18 +108,7 @@ def get_function_docstring_dict(func, funcname, signature_prefix):
                 return_obj['return_name'] = returns.return_name
                 description['returns'].append(return_obj)
         
-        description['source'] = []
-        repo_prefix = "https://github.com/streamlit/streamlit/blob/develop/lib"
-
-        try: # For Streamlit commands wrapped by decorator
-            path_parts = func.__wrapped__.__code__.co_filename.partition("/streamlit")
-            line_number = func.__wrapped__.__code__.co_firstlineno
-        except:
-            path_parts = func.__code__.co_filename.partition("/streamlit")
-            line_number = func.__code__.co_firstlineno
-        
-        description['source'] = repo_prefix + path_parts[1] + path_parts[2]+ f'#L{line_number}'
-
+        description['source'] = get_github_source(func)
 
     return description
 

--- a/python/generate.py
+++ b/python/generate.py
@@ -95,6 +95,19 @@ def get_function_docstring_dict(func, funcname, signature_prefix):
                 return_obj['description'] = parse_rst(returns.description) if returns.description else ''
                 return_obj['return_name'] = returns.return_name
                 description['returns'].append(return_obj)
+        
+        description['source'] = []
+        repo_prefix = "https://github.com/streamlit/streamlit/blob/develop/lib"
+
+        try: # For Streamlit commands wrapped by decorator
+            path_parts = func.__wrapped__.__code__.co_filename.partition("/streamlit")
+            line_number = func.__wrapped__.__code__.co_firstlineno
+        except:
+            path_parts = func.__code__.co_filename.partition("/streamlit")
+            line_number = func.__code__.co_firstlineno
+        
+        description['source'] = repo_prefix + path_parts[1] + path_parts[2]+ f'#L{line_number}'
+
 
     return description
 

--- a/python/streamlit.json
+++ b/python/streamlit.json
@@ -1123,7 +1123,7 @@
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7f467366c850>, step=None, format=None, key=None, help=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7ffa4a321b20>, step=None, format=None, key=None, help=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -3047,7 +3047,7 @@
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7f467366c850>, step=None, format=None, key=None, help=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7ffa4a321b20>, step=None, format=None, key=None, help=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -5241,7 +5241,7 @@
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f1025165400>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f213acaf400>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -7487,7 +7487,7 @@
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f1025165400>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f213acaf400>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -9856,7 +9856,7 @@
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f2909577760>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fc9fff326a0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -12095,7 +12095,7 @@
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f2909577760>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fc9fff326a0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -14521,7 +14521,7 @@
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f5cb67462b0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f38fb790190>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -16787,7 +16787,7 @@
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f5cb67462b0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f38fb790190>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -19251,7 +19251,7 @@
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f2908bfc970>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fe322468850>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -21563,7 +21563,7 @@
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f2908bfc970>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fe322468850>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -24119,7 +24119,7 @@
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f4351e17070>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fd7fa3d3f10>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -26511,7 +26511,7 @@
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f4351e17070>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fd7fa3d3f10>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -29150,7 +29150,7 @@
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fe9fb3e3c10>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7efcdee0ca60>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -31549,7 +31549,7 @@
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fe9fb3e3c10>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7efcdee0ca60>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -34188,7 +34188,7 @@
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fdd3367da60>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fd17eabe760>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -36587,7 +36587,7 @@
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fdd3367da60>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fd17eabe760>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -39226,7 +39226,7 @@
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f6f3a960fd0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f595e607dc0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -41625,7 +41625,7 @@
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f6f3a960fd0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f595e607dc0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -44264,7 +44264,7 @@
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f3d192a18e0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f22e96158b0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -46677,7 +46677,7 @@
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f3d192a18e0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f22e96158b0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -49337,7 +49337,7 @@
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f73b53e96a0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f844d8215b0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -51757,7 +51757,7 @@
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f73b53e96a0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f844d8215b0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [

--- a/python/streamlit.json
+++ b/python/streamlit.json
@@ -1,3823 +1,4 @@
 {
-  "0.82.0": {
-    "streamlit.altair_chart": {
-      "name": "altair_chart",
-      "signature": "st.altair_chart(altair_chart, use_container_width=False)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nimport pandas as pd\nimport numpy as np\nimport altair as alt\n\ndf = pd.DataFrame(\n     np.random.randn(200, 3),\n     columns=['a', 'b', 'c'])\n\nc = alt.Chart(df).mark_circle().encode(\n     x='a', y='b', size='c', color='c', tooltip=['a', 'b', 'c'])\n\nst.altair_chart(c, use_container_width=True)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 200px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Examples of Altair charts can be found at\n<a class=\"reference external\" href=\"https://altair-viz.github.io/gallery/\">https://altair-viz.github.io/gallery/</a>.</p>\n</blockquote>\n",
-      "description": "Display a chart using the Altair library.",
-      "args": [
-        {
-          "name": "altair_chart",
-          "type_name": "altair.vegalite.v2.api.Chart",
-          "is_optional": false,
-          "description": "<p>The Altair chart object to display.</p>\n",
-          "default": null
-        },
-        {
-          "name": "use_container_width",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.area_chart": {
-      "name": "area_chart",
-      "signature": "st.area_chart(data=None, width=0, height=0, use_container_width=True)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nchart_data = pd.DataFrame(\n     np.random.randn(20, 3),\n     columns=['a', 'b', 'c'])\n\nst.area_chart(chart_data)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.50.0-td2L/index.html?id=Pp65STuFj65cJRDfhGh4Jt&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 220px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.50.0-td2L/index.html?id=Pp65STuFj65cJRDfhGh4Jt\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display an area chart.</p>\n<p>This is just syntax-sugar around st.altair_chart. The main difference\nis this command uses the data's own column and indices to figure out\nthe chart's spec. As a result this is easier to use for many &quot;just plot\nthis&quot; scenarios, while being less customizable.</p>\n<p>If st.area_chart does not guess the data specification\ncorrectly, try specifying your desired chart using st.altair_chart.</p>\n",
-      "args": [
-        {
-          "name": "data",
-          "type_name": "pandas.DataFrame, pandas.Styler, numpy.ndarray, Iterable, or dict",
-          "is_optional": false,
-          "description": "<p>Data to be plotted.</p>\n",
-          "default": null
-        },
-        {
-          "name": "width",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The chart width in pixels. If 0, selects the width automatically.</p>\n",
-          "default": null
-        },
-        {
-          "name": "height",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The chart width in pixels. If 0, selects the height automatically.</p>\n",
-          "default": null
-        },
-        {
-          "name": "use_container_width",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.audio": {
-      "name": "audio",
-      "signature": "st.audio(data, format=\"audio/wav\", start_time=0)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\naudio_file = open('myaudio.ogg', 'rb')\naudio_bytes = audio_file.read()\n\nst.audio(audio_bytes, format='audio/ogg')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=Dv3M9sA7Cg8gwusgnVNTHb&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 400px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=Dv3M9sA7Cg8gwusgnVNTHb\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "Display an audio player.",
-      "args": [
-        {
-          "name": "data",
-          "type_name": "str, bytes, BytesIO, numpy.ndarray, or file opened with",
-          "is_optional": false,
-          "description": "<p>io.open().\nRaw audio data, filename, or a URL pointing to the file to load.\nNumpy arrays and raw data formats must include all necessary file\nheaders to match specified file format.</p>\n",
-          "default": null
-        },
-        {
-          "name": "start_time",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The time from which this element should start playing.</p>\n",
-          "default": null
-        },
-        {
-          "name": "format",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
-          "default": "s"
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.balloons": {
-      "name": "balloons",
-      "signature": "st.balloons()",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
-      "description": "Draw celebratory balloons.",
-      "args": [],
-      "returns": []
-    },
-    "streamlit.bar_chart": {
-      "name": "bar_chart",
-      "signature": "st.bar_chart(data=None, width=0, height=0, use_container_width=True)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nchart_data = pd.DataFrame(\n     np.random.randn(50, 3),\n     columns=[&quot;a&quot;, &quot;b&quot;, &quot;c&quot;])\n\nst.bar_chart(chart_data)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-2BLtg/index.html?id=GaYDn6vxskvBUkBwsGVEaL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 220px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-2BLtg/index.html?id=GaYDn6vxskvBUkBwsGVEaL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display a bar chart.</p>\n<p>This is just syntax-sugar around st.altair_chart. The main difference\nis this command uses the data's own column and indices to figure out\nthe chart's spec. As a result this is easier to use for many &quot;just plot\nthis&quot; scenarios, while being less customizable.</p>\n<p>If st.bar_chart does not guess the data specification\ncorrectly, try specifying your desired chart using st.altair_chart.</p>\n",
-      "args": [
-        {
-          "name": "data",
-          "type_name": "pandas.DataFrame, pandas.Styler, numpy.ndarray, Iterable, or dict",
-          "is_optional": false,
-          "description": "<p>Data to be plotted.</p>\n",
-          "default": null
-        },
-        {
-          "name": "width",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The chart width in pixels. If 0, selects the width automatically.</p>\n",
-          "default": null
-        },
-        {
-          "name": "height",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The chart width in pixels. If 0, selects the height automatically.</p>\n",
-          "default": null
-        },
-        {
-          "name": "use_container_width",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.beta_columns": {
-      "name": "beta_columns",
-      "signature": "st.beta_columns(spec)",
-      "examples": "<blockquote>\n<p>You can use <cite>with</cite> notation to insert any element into a column:</p>\n<pre class=\"doctest-block\">\ncol1, col2, col3 = st.beta_columns(3)\n\nwith col1:\n    st.header(&quot;A cat&quot;)\n    st.image(&quot;https://static.streamlit.io/examples/cat.jpg&quot;)\n\nwith col2:\n    st.header(&quot;A dog&quot;)\n    st.image(&quot;https://static.streamlit.io/examples/dog.jpg&quot;)\n\nwith col3:\n    st.header(&quot;An owl&quot;)\n    st.image(&quot;https://static.streamlit.io/examples/owl.jpg&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=VW45Va5XmSKed2ayzf7vYa&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 550px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=VW45Va5XmSKed2ayzf7vYa\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Or you can just call methods directly in the returned objects:</p>\n<pre class=\"doctest-block\">\ncol1, col2 = st.beta_columns([3, 1])\ndata = np.random.randn(10, 1)\n\ncol1.subheader(&quot;A wide column with a chart&quot;)\ncol1.line_chart(data)\n\ncol2.subheader(&quot;A narrow column with the data&quot;)\ncol2.write(data)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=XSQ6VkonfGcT2AyNYMZN83&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 400px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=XSQ6VkonfGcT2AyNYMZN83\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Insert containers laid out as side-by-side columns.</p>\n<p>Inserts a number of multi-element containers laid out side-by-side and\nreturns a list of container objects.</p>\n<p>To add elements to the returned containers, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n<div class=\"admonition warning\">\n<p class=\"first admonition-title\">Warning</p>\n<p class=\"last\">Currently, you may not put columns inside another column.</p>\n</div>\n",
-      "args": [
-        {
-          "name": "spec",
-          "type_name": "int or list of numbers",
-          "is_optional": false,
-          "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.beta_columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "list of containers",
-          "is_generator": false,
-          "description": "<p>A list of container objects.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "streamlit.beta_container": {
-      "name": "beta_container",
-      "signature": "st.beta_container()",
-      "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.beta_container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.beta_container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": [],
-      "returns": []
-    },
-    "streamlit.beta_expander": {
-      "name": "beta_expander",
-      "signature": "st.beta_expander(label=None, expanded=False)",
-      "examples": "<blockquote>\n<pre class=\"doctest-block\">\nst.line_chart({&quot;data&quot;: [1, 5, 2, 6, 2, 1]})\n\nwith st.beta_expander(&quot;See explanation&quot;):\n     st.write(&quot;&quot;&quot;\n         The chart above shows some numbers I picked for you.\n         I rolled actual dice for these, so they're *guaranteed* to\n         be random.\n     &quot;&quot;&quot;)\n     st.image(&quot;https://static.streamlit.io/examples/dice.jpg&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-2BLtg/index.html?id=7v2tgefVbW278gemvYrRny&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 750px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-2BLtg/index.html?id=7v2tgefVbW278gemvYrRny\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Insert a multi-element container that can be expanded/collapsed.</p>\n<p>Inserts a container into your app that can be used to hold multiple elements\nand can be expanded or collapsed by the user. When collapsed, all that is\nvisible is the provided label.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n<div class=\"admonition warning\">\n<p class=\"first admonition-title\">Warning</p>\n<p class=\"last\">Currently, you may not put expanders inside another expander.</p>\n</div>\n",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A string to use as the header for the expander.</p>\n",
-          "default": null
-        },
-        {
-          "name": "expanded",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
-          "default": "s"
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.bokeh_chart": {
-      "name": "bokeh_chart",
-      "signature": "st.bokeh_chart(figure, use_container_width=False)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nimport streamlit as st\nfrom bokeh.plotting import figure\n\nx = [1, 2, 3, 4, 5]\ny = [6, 7, 2, 4, 5]\n\np = figure(\n     title='simple line example',\n     x_axis_label='x',\n     y_axis_label='y')\n\np.line(x, y, legend_label='Trend', line_width=2)\n\nst.bokeh_chart(p, use_container_width=True)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.56.0-xTAd/index.html?id=Fdhg51uMbGMLRRxXV6ubzp&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 600px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.56.0-xTAd/index.html?id=Fdhg51uMbGMLRRxXV6ubzp\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display an interactive Bokeh chart.</p>\n<p>Bokeh is a charting library for Python. The arguments to this function\nclosely follow the ones for Bokeh's <cite>show</cite> function. You can find\nmore about Bokeh at <a class=\"reference external\" href=\"https://bokeh.pydata.org\">https://bokeh.pydata.org</a>.</p>\n",
-      "args": [
-        {
-          "name": "figure",
-          "type_name": "bokeh.plotting.figure.Figure",
-          "is_optional": false,
-          "description": "<p>A Bokeh figure to plot.</p>\n",
-          "default": null
-        },
-        {
-          "name": "use_container_width",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Bokeh's native <cite>width</cite> value.</p>\n",
-          "default": null
-        },
-        {
-          "name": "To show Bokeh charts in Streamlit, call `st.bokeh_chart`",
-          "type_name": null,
-          "is_optional": null,
-          "description": "",
-          "default": null
-        },
-        {
-          "name": "wherever you would call Bokeh's `show`.",
-          "type_name": null,
-          "is_optional": null,
-          "description": "",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.button": {
-      "name": "button",
-      "signature": "st.button(label, key=None, help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nif st.button('Say hello'):\n     st.write('Why hello there')\n else:\n     st.write('Goodbye')\n</pre>\n</blockquote>\n",
-      "description": "Display a button widget.",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this button is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed when the button is hovered over.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "bool",
-          "is_generator": false,
-          "description": "<p>If the button was clicked on the last run of the app.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "streamlit.cache": {
-      "name": "cache",
-      "signature": "st.cache(func=None, persist=False, allow_output_mutation=False, show_spinner=True, suppress_st_warning=False, hash_funcs=None, max_entries=None, ttl=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\n&#64;st.cache\n def fetch_and_clean_data(url):\n     # Fetch data from URL here, and then clean it up.\n     return data\n\nd1 = fetch_and_clean_data(DATA_URL_1)\n# Actually executes the function, since this is the first time it was\n# encountered.\n\nd2 = fetch_and_clean_data(DATA_URL_1)\n# Does not execute the function. Instead, returns its previously computed\n# value. This means that now the data in d1 is the same as in d2.\n\nd3 = fetch_and_clean_data(DATA_URL_2)\n# This is a different URL, so the function executes.\n</pre>\n<p>To set the <cite>persist</cite> parameter, use this command as follows:</p>\n<pre class=\"doctest-block\">\n&#64;st.cache(persist=True)\n def fetch_and_clean_data(url):\n     # Fetch data from URL here, and then clean it up.\n     return data\n</pre>\n<p>To disable hashing return values, set the <cite>allow_output_mutation</cite> parameter to <cite>True</cite>:</p>\n<pre class=\"doctest-block\">\n&#64;st.cache(allow_output_mutation=True)\n def fetch_and_clean_data(url):\n     # Fetch data from URL here, and then clean it up.\n     return data\n</pre>\n<p>To override the default hashing behavior, pass a custom hash function.\nYou can do that by mapping a type (e.g. <cite>MongoClient</cite>) to a hash function (<cite>id</cite>) like this:</p>\n<pre class=\"doctest-block\">\n&#64;st.cache(hash_funcs={MongoClient: id})\n def connect_to_database(url):\n     return MongoClient(url)\n</pre>\n<p>Alternatively, you can map the type's fully-qualified name\n(e.g. <cite>&quot;pymongo.mongo_client.MongoClient&quot;</cite>) to the hash function instead:</p>\n<pre class=\"doctest-block\">\n&#64;st.cache(hash_funcs={&quot;pymongo.mongo_client.MongoClient&quot;: id})\n def connect_to_database(url):\n     return MongoClient(url)\n</pre>\n</blockquote>\n",
-      "description": "Function decorator to memoize function executions.",
-      "args": [
-        {
-          "name": "func",
-          "type_name": "callable",
-          "is_optional": false,
-          "description": "<p>The function to cache. Streamlit hashes the function and dependent code.</p>\n",
-          "default": null
-        },
-        {
-          "name": "persist",
-          "type_name": "boolean",
-          "is_optional": false,
-          "description": "<p>Whether to persist the cache on disk.</p>\n",
-          "default": null
-        },
-        {
-          "name": "allow_output_mutation",
-          "type_name": "boolean",
-          "is_optional": false,
-          "description": "<p>Streamlit normally shows a warning when return values are mutated, as that\ncan have unintended consequences. This is done by hashing the return value internally.</p>\n<p>If you know what you're doing and would like to override this warning, set this to True.</p>\n",
-          "default": null
-        },
-        {
-          "name": "show_spinner",
-          "type_name": "boolean",
-          "is_optional": false,
-          "description": "<p>Enable the spinner. Default is True to show a spinner when there is\na cache miss.</p>\n",
-          "default": "True"
-        },
-        {
-          "name": "suppress_st_warning",
-          "type_name": "boolean",
-          "is_optional": false,
-          "description": "<p>Suppress warnings about calling Streamlit functions from within\nthe cached function.</p>\n",
-          "default": null
-        },
-        {
-          "name": "hash_funcs",
-          "type_name": "dict or None",
-          "is_optional": false,
-          "description": "<p>Mapping of types or fully qualified names to hash functions. This is used to override\nthe behavior of the hasher inside Streamlit's caching mechanism: when the hasher\nencounters an object, it will first check to see if its type matches a key in this\ndict and, if so, will use the provided function to generate a hash for it. See below\nfor an example of how this can be used.</p>\n",
-          "default": null
-        },
-        {
-          "name": "max_entries",
-          "type_name": "int or None",
-          "is_optional": false,
-          "description": "<p>The maximum number of entries to keep in the cache, or None\nfor an unbounded cache. (When a new entry is added to a full cache,\nthe oldest cached entry will be removed.) The default is None.</p>\n",
-          "default": "None."
-        },
-        {
-          "name": "ttl",
-          "type_name": "float or None",
-          "is_optional": false,
-          "description": "<p>The maximum number of seconds to keep an entry in the cache, or\nNone if cache entries should not expire. The default is None.</p>\n",
-          "default": "None."
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.caption": {
-      "name": "caption",
-      "signature": "st.caption(body)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.caption('This is a string that explains something above.')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=SFcBGANWd8kWXF28XnaEZj&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 100px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=SFcBGANWd8kWXF28XnaEZj\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display text in small font.</p>\n<p>This should be used for captions, asides, footnotes, sidenotes, and\nother explanatory text.</p>\n",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The text to display.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.checkbox": {
-      "name": "checkbox",
-      "signature": "st.checkbox(label, value=False, key=None, help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nagree = st.checkbox('I agree')\n\nif agree:\n     st.write('Great!')\n</pre>\n</blockquote>\n",
-      "description": "Display a checkbox widget.",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this checkbox is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "value",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>Preselect the checkbox when it first renders. This will be\ncast to bool internally.</p>\n",
-          "default": null
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the checkbox.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "bool",
-          "is_generator": false,
-          "description": "<p>Whether or not the checkbox is checked.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "streamlit.code": {
-      "name": "code",
-      "signature": "st.code(body, language=\"python\")",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\ncode = '''def hello():\n     print(&quot;Hello, Streamlit!&quot;)'''\nst.code(code, language='python')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.27.0-kBtt/index.html?id=VDRnaCEZWSBCNUd5gNQZv2&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 100px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.27.0-kBtt/index.html?id=VDRnaCEZWSBCNUd5gNQZv2\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display a code block with optional syntax highlighting.</p>\n<p>(This is a convenience wrapper around <cite>st.markdown()</cite>)</p>\n",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The string to display as code.</p>\n",
-          "default": null
-        },
-        {
-          "name": "language",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.color_picker": {
-      "name": "color_picker",
-      "signature": "st.color_picker(label, value=None, key=None, help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\ncolor = st.color_picker('Pick A Color', '#00f900')\nst.write('The current color is', color)\n</pre>\n</blockquote>\n",
-      "description": "Display a color picker widget.",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this input is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "value",
-          "type_name": "str or None",
-          "is_optional": false,
-          "description": "<p>The hex value of this widget when it first renders. If None,\ndefaults to black.</p>\n",
-          "default": "black."
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the color picker.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "str",
-          "is_generator": false,
-          "description": "<p>The selected color as a hex string.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "streamlit.dataframe": {
-      "name": "dataframe",
-      "signature": "st.dataframe(data=None, width=None, height=None)",
-      "examples": "<blockquote>\n<pre class=\"doctest-block\">\ndf = pd.DataFrame(\n    np.random.randn(50, 20),\n    columns=('col %d' % i for i in range(20)))\n\nst.dataframe(df)  # Same as st.write(df)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=165mJbzWdAC8Duf8a4tjyQ&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 330px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=165mJbzWdAC8Duf8a4tjyQ\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <pre class=\"doctest-block\">\nst.dataframe(df, 200, 100)\n</pre>\n<p>You can also pass a Pandas Styler object to change the style of\nthe rendered DataFrame:</p>\n<pre class=\"doctest-block\">\ndf = pd.DataFrame(\n    np.random.randn(10, 20),\n    columns=('col %d' % i for i in range(20)))\n\nst.dataframe(df.style.highlight_max(axis=0))\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.29.0-dV1Y/index.html?id=Hb6UymSNuZDzojUNybzPby&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 285px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.29.0-dV1Y/index.html?id=Hb6UymSNuZDzojUNybzPby\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "Display a dataframe as an interactive table.",
-      "args": [
-        {
-          "name": "data",
-          "type_name": "pandas.DataFrame, pandas.Styler, numpy.ndarray, Iterable, dict,",
-          "is_optional": false,
-          "description": "<p>or None\nThe data to display.</p>\n<p>If 'data' is a pandas.Styler, it will be used to style its\nunderyling DataFrame. Streamlit supports custom cell\nvalues and colors. (It does not support some of the more exotic\npandas styling features, like bar charts, hovering, and captions.)\nStyler support is experimental!</p>\n",
-          "default": null
-        },
-        {
-          "name": "width",
-          "type_name": "int or None",
-          "is_optional": false,
-          "description": "<p>Desired width of the UI element expressed in pixels. If None, a\ndefault width based on the page width is used.</p>\n",
-          "default": "width"
-        },
-        {
-          "name": "height",
-          "type_name": "int or None",
-          "is_optional": false,
-          "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
-          "default": "height"
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.date_input": {
-      "name": "date_input",
-      "signature": "st.date_input(label, value=None, min_value=None, max_value=None, key=None, help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nd = st.date_input(\n     &quot;When's your birthday&quot;,\n     datetime.date(2019, 7, 6))\nst.write('Your birthday is:', d)\n</pre>\n</blockquote>\n",
-      "description": "Display a date input widget.",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this date input is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "value",
-          "type_name": "datetime.date or datetime.datetime or list/tuple of datetime.date or datetime.datetime or None",
-          "is_optional": false,
-          "description": "<p>The value of this widget when it first renders. If a list/tuple with\n0 to 2 date/datetime values is provided, the datepicker will allow\nusers to provide a range. Defaults to today as a single-date picker.</p>\n",
-          "default": "today"
-        },
-        {
-          "name": "min_value",
-          "type_name": "datetime.date or datetime.datetime",
-          "is_optional": false,
-          "description": "<p>The minimum selectable date. Defaults to today-10y.</p>\n",
-          "default": "today-10y."
-        },
-        {
-          "name": "max_value",
-          "type_name": "datetime.date or datetime.datetime",
-          "is_optional": false,
-          "description": "<p>The maximum selectable date. Defaults to today+10y.</p>\n",
-          "default": "today"
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "datetime.date",
-          "is_generator": false,
-          "description": "<p>The current value of the date input widget.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "streamlit.echo": {
-      "name": "echo",
-      "signature": "st.echo(code_location=\"above\")",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nwith st.echo():\n    st.write('This code will be printed')\n</pre>\n</blockquote>\n",
-      "description": "Use in a `with` block to draw some code on the app, then execute it.",
-      "args": [
-        {
-          "name": "code_location",
-          "type_name": "\"above\" or \"below\"",
-          "is_optional": false,
-          "description": "<p>Whether to show the echoed code before or after the results of the\nexecuted code block.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.empty": {
-      "name": "empty",
-      "signature": "st.empty()",
-      "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.beta_container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
-      "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": [],
-      "returns": []
-    },
-    "streamlit.error": {
-      "name": "error",
-      "signature": "st.error(body)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.error('This is an error')\n</pre>\n</blockquote>\n",
-      "description": "Display error message.",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The error text to display.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.exception": {
-      "name": "exception",
-      "signature": "st.exception(exception)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\ne = RuntimeError('This is an exception of type RuntimeError')\nst.exception(e)\n</pre>\n</blockquote>\n",
-      "description": "Display an exception.",
-      "args": [
-        {
-          "name": "exception",
-          "type_name": "Exception",
-          "is_optional": false,
-          "description": "<p>The exception to display.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.experimental_get_query_params": {
-      "name": "experimental_get_query_params",
-      "signature": "st.experimental_get_query_params()",
-      "example": "<blockquote>\n<p>Let's say the user's web browser is at\n<cite>http://localhost:8501/?show_map=True&amp;selected=asia&amp;selected=america</cite>.\nThen, you can get the query parameters using the following:</p>\n<pre class=\"doctest-block\">\nst.experimental_get_query_params()\n{&quot;show_map&quot;: [&quot;True&quot;], &quot;selected&quot;: [&quot;asia&quot;, &quot;america&quot;]}\n</pre>\n<p>Note that the values in the returned dict are <em>always</em> lists. This is\nbecause we internally use Python's urllib.parse.parse_qs(), which behaves\nthis way. And this behavior makes sense when you consider that every item\nin a query string is potentially a 1-element array.</p>\n</blockquote>\n",
-      "description": "Return the query parameters that is currently showing in the browser's URL bar.",
-      "args": [],
-      "returns": [
-        {
-          "type_name": "dict",
-          "is_generator": false,
-          "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "streamlit.experimental_rerun": {
-      "name": "experimental_rerun",
-      "signature": "st.experimental_rerun()",
-      "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
-      "args": [],
-      "returns": []
-    },
-    "streamlit.experimental_set_query_params": {
-      "name": "experimental_set_query_params",
-      "signature": "st.experimental_set_query_params(**query_params)",
-      "example": "<blockquote>\n<p>To point the user's web browser to something like\n&quot;<a class=\"reference external\" href=\"http://localhost:8501/?show_map=True&amp;selected=asia&amp;selected=america\">http://localhost:8501/?show_map=True&amp;selected=asia&amp;selected=america</a>&quot;,\nyou would do the following:</p>\n<pre class=\"doctest-block\">\nst.experimental_set_query_params(\n     show_map=True,\n     selected=[&quot;asia&quot;, &quot;america&quot;],\n )\n</pre>\n</blockquote>\n",
-      "description": "Set the query parameters that are shown in the browser's URL bar.",
-      "args": [
-        {
-          "name": "**query_params",
-          "type_name": "dict",
-          "is_optional": false,
-          "description": "<p>The query parameters to set, as key-value pairs.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.experimental_show": {
-      "name": "experimental_show",
-      "signature": "st.experimental_show(*args)",
-      "notes": "<blockquote>\n<p>This is an experimental feature with usage limitations:</p>\n<ul class=\"simple\">\n<li>The method must be called with the name <cite>show</cite>.</li>\n<li>Must be called in one line of code, and only once per line.</li>\n<li>When passing multiple arguments the inclusion of <cite>,</cite> or <cite>)</cite> in a string</li>\n</ul>\n<div class=\"system-message\">\n<p class=\"system-message-title\">System Message: WARNING/2 (<tt class=\"docutils\">&lt;string&gt;</tt>, line 6)</p>\nBullet list ends without a blank line; unexpected unindent.</div>\n<p>argument may cause an error.</p>\n</blockquote>\n",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\ndataframe = pd.DataFrame({\n     'first column': [1, 2, 3, 4],\n     'second column': [10, 20, 30, 40],\n }))\nst.experimental_show(dataframe)\n</pre>\n</blockquote>\n",
-      "description": "<p>Write arguments and <em>argument names</em> to your app for debugging purposes.</p>\n<p>Show() has similar properties to write():</p>\n<blockquote>\n<ol class=\"arabic simple\">\n<li>You can pass in multiple arguments, all of which will be debugged.</li>\n<li>It returns None, so it's &quot;slot&quot; in the app cannot be reused.</li>\n</ol>\n</blockquote>\n<p>Note: This is an experimental feature. See\n<a class=\"reference external\" href=\"https://docs.streamlit.io/en/latest/api.html#pre-release-features\">https://docs.streamlit.io/en/latest/api.html#pre-release-features</a> for more information.</p>\n",
-      "args": [
-        {
-          "name": "*args",
-          "type_name": "any",
-          "is_optional": false,
-          "description": "<p>One or many objects to debug in the App.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.file_uploader": {
-      "name": "file_uploader",
-      "signature": "st.file_uploader(label, type=None, accept_multiple_files=False, key=None, help=None)",
-      "examples": "<blockquote>\n<p>Insert a file uploader that accepts a single file at a time:</p>\n<pre class=\"doctest-block\">\nuploaded_file = st.file_uploader(&quot;Choose a file&quot;)\nif uploaded_file is not None:\n     # To read file as bytes:\n     bytes_data = uploaded_file.getvalue()\n     st.write(bytes_data)\n\n     # To convert to a string based IO:\n     stringio = StringIO(uploaded_file.getvalue().decode(&quot;utf-8&quot;))\n     st.write(stringio)\n\n     # To read file as string:\n     string_data = stringio.read()\n     st.write(string_data)\n\n     # Can be used wherever a &quot;file-like&quot; object is accepted:\n     dataframe = pd.read_csv(uploaded_file)\n     st.write(dataframe)\n</pre>\n<p>Insert a file uploader that accepts multiple files at a time:</p>\n<pre class=\"doctest-block\">\nuploaded_files = st.file_uploader(&quot;Choose a CSV file&quot;, accept_multiple_files=True)\nfor uploaded_file in uploaded_files:\n     bytes_data = uploaded_file.read()\n     st.write(&quot;filename:&quot;, uploaded_file.name)\n     st.write(bytes_data)\n</pre>\n</blockquote>\n",
-      "description": "<p>Display a file uploader widget.</p>\n<p>By default, uploaded files are limited to 200MB. You can configure\nthis using the <cite>server.maxUploadSize</cite> config option.</p>\n",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this file uploader is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "type",
-          "type_name": "str or list of str or None",
-          "is_optional": false,
-          "description": "<p>Array of allowed extensions. ['png', 'jpg']\nThe default is None, which means all extensions are allowed.</p>\n",
-          "default": "None"
-        },
-        {
-          "name": "accept_multiple_files",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, allows the user to upload multiple files at the same time,\nin which case the return value will be a list of files.\nDefault: False</p>\n",
-          "default": "False"
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the file uploader.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "None or UploadedFile or list of UploadedFile",
-          "is_generator": false,
-          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "streamlit.form": {
-      "name": "form",
-      "signature": "st.form(key)",
-      "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.form(&quot;my_form&quot;):\n    st.write(&quot;Inside the form&quot;)\n    slider_val = st.slider(&quot;Form slider&quot;)\n    checkbox_val = st.checkbox(&quot;Form checkbox&quot;)\n\n    # Every form must have a submit button.\n    submitted = st.form_submit_button(&quot;Submit&quot;)\n    if submitted:\n        st.write(&quot;slider&quot;, slider_val, &quot;checkbox&quot;, checkbox_val)\n\nst.write(&quot;Outside the form&quot;)\n</pre>\n<p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\nform = st.form(&quot;my_form&quot;)\nform.slider(&quot;Inside the form&quot;)\nst.slider(&quot;Outside the form&quot;)\n\n# Now add a submit button to the form:\nform.form_submit_button(&quot;Submit&quot;)\n</pre>\n</blockquote>\n",
-      "description": "<p>Create a form that batches elements together with a &quot;Submit&quot; button.</p>\n<p>A form is a container that visually groups other elements and\nwidgets together, and contains a Submit button. When the form's\nSubmit button is pressed, all widget values inside the form will be\nsent to Streamlit in a batch.</p>\n<p>To add elements to a form object, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the form. See\nexamples below.</p>\n<p>Forms have a few constraints:</p>\n<ul class=\"simple\">\n<li>Every form must contain a <cite>st.form_submit_button</cite>.</li>\n<li>You cannot add a normal <cite>st.button</cite> to a form.</li>\n<li>Forms can appear anywhere in your app (sidebar, columns, etc),\nbut they cannot be embedded inside other forms.</li>\n</ul>\n<p>For more information about forms, check out our\n<a class=\"reference external\" href=\"https://blog.streamlit.io/introducing-submit-button-and-forms/\">blog post</a>.</p>\n",
-      "args": [
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A string that identifies the form. Each form must have its own\nkey. (This key is not displayed to the user in the interface.)</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.form_submit_button": {
-      "name": "form_submit_button",
-      "signature": "st.form_submit_button(label=\"Submit\")",
-      "description": "<p>Display a form submit button.</p>\n<p>When this button is clicked, all widget values inside the form will be\nsent to Streamlit in a batch.</p>\n<p>Every form must have a form_submit_button. A form_submit_button\ncannot exist outside a form.</p>\n<p>For more information about forms, check out our\n<a class=\"reference external\" href=\"https://blog.streamlit.io/introducing-submit-button-and-forms/\">blog post</a>.</p>\n",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this button is for.\nDefaults to &quot;Submit&quot;.</p>\n",
-          "default": "s"
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "bool",
-          "is_generator": false,
-          "description": "<p>True if the submit button was clicked.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "streamlit.get_option": {
-      "name": "get_option",
-      "signature": "st.get_option(key)",
-      "description": "<p>Return the current value of a given Streamlit config option.</p>\n<p>Run <cite>streamlit config show</cite> in the terminal to see all available options.</p>\n",
-      "args": [
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The config option key of the form &quot;section.optionName&quot;. To see all\navailable options, run <cite>streamlit config show</cite> on a terminal.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.graphviz_chart": {
-      "name": "graphviz_chart",
-      "signature": "st.graphviz_chart(figure_or_dot, use_container_width=False)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nimport streamlit as st\nimport graphviz as graphviz\n\n# Create a graphlib graph object\ngraph = graphviz.Digraph()\ngraph.edge('run', 'intr')\ngraph.edge('intr', 'runbl')\ngraph.edge('runbl', 'run')\ngraph.edge('run', 'kernel')\ngraph.edge('kernel', 'zombie')\ngraph.edge('kernel', 'sleep')\ngraph.edge('kernel', 'runmem')\ngraph.edge('sleep', 'swap')\ngraph.edge('swap', 'runswap')\ngraph.edge('runswap', 'new')\ngraph.edge('runswap', 'runmem')\ngraph.edge('new', 'runmem')\ngraph.edge('sleep', 'runmem')\n\nst.graphviz_chart(graph)\n</pre>\n<p>Or you can render the chart from the graph using GraphViz's Dot\nlanguage:</p>\n<pre class=\"doctest-block\">\nst.graphviz_chart('''\n    digraph {\n        run -&gt; intr\n        intr -&gt; runbl\n        runbl -&gt; run\n        run -&gt; kernel\n        kernel -&gt; zombie\n        kernel -&gt; sleep\n        kernel -&gt; runmem\n        sleep -&gt; swap\n        swap -&gt; runswap\n        runswap -&gt; new\n        runswap -&gt; runmem\n        new -&gt; runmem\n        sleep -&gt; runmem\n    }\n''')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.56.0-xTAd/index.html?id=GBn3GXZie5K1kXuBKe4yQL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 400px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.56.0-xTAd/index.html?id=GBn3GXZie5K1kXuBKe4yQL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "Display a graph using the dagre-d3 library.",
-      "args": [
-        {
-          "name": "figure_or_dot",
-          "type_name": "graphviz.dot.Graph, graphviz.dot.Digraph, str",
-          "is_optional": false,
-          "description": "<p>The Graphlib graph object or dot string to display</p>\n",
-          "default": null
-        },
-        {
-          "name": "use_container_width",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.header": {
-      "name": "header",
-      "signature": "st.header(body, anchor=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.header('This is a header')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=AnfQVFgSCQtGv6yMUMUYjj&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 100px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=AnfQVFgSCQtGv6yMUMUYjj\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "Display text in header formatting.",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The text to display.</p>\n",
-          "default": null
-        },
-        {
-          "name": "anchor",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.help": {
-      "name": "help",
-      "signature": "st.help(obj)",
-      "example": "<blockquote>\n<p>Don't remember how to initialize a dataframe? Try this:</p>\n<pre class=\"doctest-block\">\nst.help(pandas.DataFrame)\n</pre>\n<p>Want to quickly check what datatype is output by a certain function?\nTry:</p>\n<pre class=\"doctest-block\">\nx = my_poorly_documented_function()\nst.help(x)\n</pre>\n</blockquote>\n",
-      "description": "<p>Display object's doc string, nicely formatted.</p>\n<p>Displays the doc string for this object.</p>\n",
-      "args": [
-        {
-          "name": "obj",
-          "type_name": "Object",
-          "is_optional": false,
-          "description": "<p>The object whose docstring should be displayed.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.image": {
-      "name": "image",
-      "signature": "st.image(image, caption=None, width=None, use_column_width=None, clamp=False, channels=\"RGB\", output_format=\"auto\")",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nfrom PIL import Image\nimage = Image.open('sunrise.jpg')\n\nst.image(image, caption='Sunrise by the mountains')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.61.0-yRE1/index.html?id=Sn228UQxBfKoE5C7A7Y2Qk&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 630px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.61.0-yRE1/index.html?id=Sn228UQxBfKoE5C7A7Y2Qk\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "Display an image or list of images.",
-      "args": [
-        {
-          "name": "image",
-          "type_name": "numpy.ndarray, [numpy.ndarray], BytesIO, str, or [str]",
-          "is_optional": false,
-          "description": "<p>Monochrome image of shape (w,h) or (w,h,1)\nOR a color image of shape (w,h,3)\nOR an RGBA image of shape (w,h,4)\nOR a URL to fetch the image from\nOR a path of a local image file\nOR an SVG XML string like <cite>&lt;svg xmlns=...&lt;/svg&gt;</cite>\nOR a list of one of the above, to display multiple images.</p>\n",
-          "default": null
-        },
-        {
-          "name": "caption",
-          "type_name": "str or list of str",
-          "is_optional": false,
-          "description": "<p>Image caption. If displaying multiple images, caption should be a\nlist of captions (one for each image).</p>\n",
-          "default": null
-        },
-        {
-          "name": "width",
-          "type_name": "int or None",
-          "is_optional": false,
-          "description": "<p>Image width. None means use the image width,\nbut do not exceed the width of the column.\nShould be set for SVG images, as they have no default image width.</p>\n",
-          "default": "image"
-        },
-        {
-          "name": "use_column_width",
-          "type_name": "'auto' or 'always' or 'never' or bool",
-          "is_optional": false,
-          "description": "<p>If 'auto', set the image's width to its natural size,\nbut do not exceed the width of the column.\nIf 'always' or True, set the image's width to the column width.\nIf 'never' or False, set the image's width to its natural size.\nNote: if set, <cite>use_column_width</cite> takes precedence over the <cite>width</cite> parameter.</p>\n",
-          "default": null
-        },
-        {
-          "name": "clamp",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>Clamp image pixel values to a valid range ([0-255] per channel).\nThis is only meaningful for byte array images; the parameter is\nignored for image URLs. If this is not set, and an image has an\nout-of-range value, an error will be thrown.</p>\n",
-          "default": null
-        },
-        {
-          "name": "channels",
-          "type_name": "'RGB' or 'BGR'",
-          "is_optional": false,
-          "description": "<p>If image is an nd.array, this parameter denotes the format used to\nrepresent color information. Defaults to 'RGB', meaning\n<cite>image[:, :, 0]</cite> is the red channel, <cite>image[:, :, 1]</cite> is green, and\n<cite>image[:, :, 2]</cite> is blue. For images coming from libraries like\nOpenCV you should set this to 'BGR', instead.</p>\n",
-          "default": "s"
-        },
-        {
-          "name": "output_format",
-          "type_name": "'JPEG', 'PNG', or 'auto'",
-          "is_optional": false,
-          "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
-          "default": "s"
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.info": {
-      "name": "info",
-      "signature": "st.info(body)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.info('This is a purely informational message')\n</pre>\n</blockquote>\n",
-      "description": "Display an informational message.",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The info text to display.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.json": {
-      "name": "json",
-      "signature": "st.json(body)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.json({\n     'foo': 'bar',\n     'baz': 'boz',\n     'stuff': [\n         'stuff 1',\n         'stuff 2',\n         'stuff 3',\n         'stuff 5',\n     ],\n })\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=CTFkMQd89hw3yZbZ4AUymS&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 280px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=CTFkMQd89hw3yZbZ4AUymS\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "Display object or string as a pretty-printed JSON string.",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "Object or str",
-          "is_optional": false,
-          "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.latex": {
-      "name": "latex",
-      "signature": "st.latex(body)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.latex(r'''\n     a + ar + a r^2 + a r^3 + \\cdots + a r^{n-1} =\n     \\sum_{k=0}^{n-1} ar^k =\n     a \\left(\\frac{1-r^{n}}{1-r}\\right)\n     ''')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.50.0-td2L/index.html?id=NJFsy6NbGTsH2RF9W6ioQ4&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 75px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.50.0-td2L/index.html?id=NJFsy6NbGTsH2RF9W6ioQ4\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display mathematical expressions formatted as LaTeX.</p>\n<p>Supported LaTeX functions are listed at\n<a class=\"reference external\" href=\"https://katex.org/docs/supported.html\">https://katex.org/docs/supported.html</a>.</p>\n",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str or SymPy expression",
-          "is_optional": false,
-          "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.line_chart": {
-      "name": "line_chart",
-      "signature": "st.line_chart(data=None, width=0, height=0, use_container_width=True)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nchart_data = pd.DataFrame(\n     np.random.randn(20, 3),\n     columns=['a', 'b', 'c'])\n\nst.line_chart(chart_data)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.50.0-td2L/index.html?id=BdxXG3MmrVBfJyqS2R2ki8&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 220px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.50.0-td2L/index.html?id=BdxXG3MmrVBfJyqS2R2ki8\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display a line chart.</p>\n<p>This is syntax-sugar around st.altair_chart. The main difference\nis this command uses the data's own column and indices to figure out\nthe chart's spec. As a result this is easier to use for many &quot;just plot\nthis&quot; scenarios, while being less customizable.</p>\n<p>If st.line_chart does not guess the data specification\ncorrectly, try specifying your desired chart using st.altair_chart.</p>\n",
-      "args": [
-        {
-          "name": "data",
-          "type_name": "pandas.DataFrame, pandas.Styler, numpy.ndarray, Iterable, dict",
-          "is_optional": false,
-          "description": "<p>or None\nData to be plotted.</p>\n",
-          "default": null
-        },
-        {
-          "name": "width",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The chart width in pixels. If 0, selects the width automatically.</p>\n",
-          "default": null
-        },
-        {
-          "name": "height",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The chart width in pixels. If 0, selects the height automatically.</p>\n",
-          "default": null
-        },
-        {
-          "name": "use_container_width",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.map": {
-      "name": "map",
-      "signature": "st.map(data=None, zoom=None, use_container_width=True)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nimport pandas as pd\nimport numpy as np\n\ndf = pd.DataFrame(\n     np.random.randn(1000, 2) / [50, 50] + [37.76, -122.4],\n     columns=['lat', 'lon'])\n\nst.map(df)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.53.0-SULT/index.html?id=9gTiomqPEbvHY2huTLoQtH&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 600px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.53.0-SULT/index.html?id=9gTiomqPEbvHY2huTLoQtH\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display a map with points on it.</p>\n<p>This is a wrapper around st.pydeck_chart to quickly create scatterplot\ncharts on top of a map, with auto-centering and auto-zoom.</p>\n<p>When using this command, we advise all users to use a personal Mapbox\ntoken. This ensures the map tiles used in this chart are more\nrobust. You can do this with the mapbox.token config option.</p>\n<p>To get a token for yourself, create an account at\n<a class=\"reference external\" href=\"https://mapbox.com\">https://mapbox.com</a>. It's free! (for moderate usage levels) See\n<a class=\"reference external\" href=\"https://docs.streamlit.io/en/latest/cli.html#view-all-config-options\">https://docs.streamlit.io/en/latest/cli.html#view-all-config-options</a> for more\ninfo on how to set config options.</p>\n",
-      "args": [
-        {
-          "name": "data",
-          "type_name": "pandas.DataFrame, pandas.Styler, numpy.ndarray, Iterable, dict,",
-          "is_optional": false,
-          "description": "<p>or None\nThe data to be plotted. Must have columns called 'lat', 'lon',\n'latitude', or 'longitude'.</p>\n",
-          "default": null
-        },
-        {
-          "name": "zoom",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.markdown": {
-      "name": "markdown",
-      "signature": "st.markdown(body, unsafe_allow_html=False)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.markdown('Streamlit is **_really_ cool**.')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=PXz9xgY8aB88eziDVEZLyS&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 50px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=PXz9xgY8aB88eziDVEZLyS\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "Display string formatted as Markdown.",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The string to display as Github-flavored Markdown. Syntax\ninformation can be found at: <a class=\"reference external\" href=\"https://github.github.com/gfm\">https://github.github.com/gfm</a>.</p>\n<p>This also supports:</p>\n<ul class=\"simple\">\n<li>Emoji shortcodes, such as <cite>:+1:</cite>  and <cite>:sunglasses:</cite>.\nFor a list of all supported codes,\nsee <a class=\"reference external\" href=\"https://raw.githubusercontent.com/omnidan/node-emoji/master/lib/emoji.json\">https://raw.githubusercontent.com/omnidan/node-emoji/master/lib/emoji.json</a>.</li>\n<li>LaTeX expressions, by wrapping them in &quot;$&quot; or &quot;$$&quot; (the &quot;$$&quot;\nmust be on their own lines). Supported LaTeX functions are listed\nat <a class=\"reference external\" href=\"https://katex.org/docs/supported.html\">https://katex.org/docs/supported.html</a>.</li>\n</ul>\n",
-          "default": null
-        },
-        {
-          "name": "unsafe_allow_html",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.multiselect": {
-      "name": "multiselect",
-      "signature": "st.multiselect(label, options, default=None, format_func=special_internal_function, key=None, help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\noptions = st.multiselect(\n     'What are your favorite colors',\n     ['Green', 'Yellow', 'Red', 'Blue'],\n     ['Yellow', 'Red'])\n\nst.write('You selected:', options)\n</pre>\n<div class=\"admonition note\">\n<p class=\"first admonition-title\">Note</p>\n<p class=\"last\">User experience can be degraded for large lists of <cite>options</cite> (100+), as this widget\nis not designed to handle arbitrary text search efficiently. See this\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/streamlit-loading-column-data-takes-too-much-time/1791\">thread</a>\non the Streamlit community forum for more information and\n<a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/1059\">GitHub issue #1059</a> for updates on the issue.</p>\n</div>\n</blockquote>\n",
-      "description": "<p>Display a multiselect widget.</p>\n<p>The multiselect widget starts as empty.</p>\n",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this select widget is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "options",
-          "type_name": "list, tuple, numpy.ndarray, pandas.Series, or pandas.DataFrame",
-          "is_optional": false,
-          "description": "<p>Labels for the select options. This will be cast to str internally\nby default. For pandas.DataFrame, the first column is selected.</p>\n",
-          "default": "."
-        },
-        {
-          "name": "default",
-          "type_name": "[str] or None",
-          "is_optional": false,
-          "description": "<p>List of default values.</p>\n",
-          "default": "values."
-        },
-        {
-          "name": "format_func",
-          "type_name": "function",
-          "is_optional": false,
-          "description": "<p>Function to modify the display of selectbox options. It receives\nthe raw option as an argument and should output the label to be\nshown for that option. This has no impact on the return value of\nthe selectbox.</p>\n",
-          "default": null
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the multiselect.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "[str]",
-          "is_generator": false,
-          "description": "<p>A list with the selected options</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "streamlit.number_input": {
-      "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7fd8494723d0>, step=None, format=None, key=None, help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
-      "description": "Display a numeric input widget.",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this input is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "min_value",
-          "type_name": "int or float or None",
-          "is_optional": false,
-          "description": "<p>The minimum permitted value.\nIf None, there will be no minimum.</p>\n",
-          "default": null
-        },
-        {
-          "name": "max_value",
-          "type_name": "int or float or None",
-          "is_optional": false,
-          "description": "<p>The maximum permitted value.\nIf None, there will be no maximum.</p>\n",
-          "default": null
-        },
-        {
-          "name": "value",
-          "type_name": "int or float or None",
-          "is_optional": false,
-          "description": "<p>The value of this widget when it first renders.\nDefaults to min_value, or 0.0 if min_value is None</p>\n",
-          "default": "min_value"
-        },
-        {
-          "name": "step",
-          "type_name": "int or float or None",
-          "is_optional": false,
-          "description": "<p>The stepping interval.\nDefaults to 1 if the value is an int, 0.01 otherwise.\nIf the value is not specified, the format parameter will be used.</p>\n",
-          "default": "1"
-        },
-        {
-          "name": "format",
-          "type_name": "str or None",
-          "is_optional": false,
-          "description": "<p>A printf-style format string controlling how the interface should\ndisplay numbers. Output must be purely numeric. This does not impact\nthe return value. Valid formatters: %d %e %f %g %i %u</p>\n",
-          "default": null
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "int or float",
-          "is_generator": false,
-          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "streamlit.object_beta_warning": {
-      "name": "object_beta_warning",
-      "signature": "st.object_beta_warning(obj, obj_name, date)",
-      "description": "<p>Wrapper for objects that are no longer in beta.</p>\n<p>Wrapped objects will run as normal, but then proceed to show an st.warning\nsaying that the <a href=\"#id1\"><span class=\"problematic\" id=\"id2\">beta_</span></a> version will be removed in ~3 months.</p>\n<div class=\"system-messages section\">\n<h1>Docutils System Messages</h1>\n<div class=\"system-message\" id=\"id1\">\n<p class=\"system-message-title\">System Message: ERROR/3 (<tt class=\"docutils\">&lt;string&gt;</tt>, line 3); <em><a href=\"#id2\">backlink</a></em></p>\nUnknown target name: &quot;beta&quot;.</div>\n</div>\n",
-      "args": [
-        {
-          "name": "obj",
-          "type_name": "Any",
-          "is_optional": false,
-          "description": "<p>The <cite>st.</cite> object that used to be in beta.</p>\n",
-          "default": null
-        },
-        {
-          "name": "obj_name",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The name of the object within __init__.py</p>\n",
-          "default": null
-        },
-        {
-          "name": "date",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A date like &quot;2020-01-01&quot;, indicating the last day we'll guarantee\nsupport for the <a href=\"#id1\"><span class=\"problematic\" id=\"id2\">beta_</span></a> prefix.</p>\n<div class=\"system-messages section\">\n<h1>Docutils System Messages</h1>\n<div class=\"system-message\" id=\"id1\">\n<p class=\"system-message-title\">System Message: ERROR/3 (<tt class=\"docutils\">&lt;string&gt;</tt>, line 1); <em><a href=\"#id2\">backlink</a></em></p>\nUnknown target name: &quot;beta&quot;.</div>\n</div>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.plotly_chart": {
-      "name": "plotly_chart",
-      "signature": "st.plotly_chart(figure_or_data, use_container_width=False, sharing=\"streamlit\", **kwargs)",
-      "example": "<blockquote>\n<p>The example below comes straight from the examples at\n<a class=\"reference external\" href=\"https://plot.ly/python\">https://plot.ly/python</a>:</p>\n<pre class=\"doctest-block\">\nimport streamlit as st\nimport plotly.figure_factory as ff\nimport numpy as np\n\n# Add histogram data\nx1 = np.random.randn(200) - 2\nx2 = np.random.randn(200)\nx3 = np.random.randn(200) + 2\n\n# Group data together\nhist_data = [x1, x2, x3]\n\ngroup_labels = ['Group 1', 'Group 2', 'Group 3']\n\n# Create distplot with custom bin_size\nfig = ff.create_distplot(\n         hist_data, group_labels, bin_size=[.1, .25, .5])\n\n# Plot!\nst.plotly_chart(fig, use_container_width=True)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.56.0-xTAd/index.html?id=TuP96xX8JnsoQeUGAPjkGQ&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 400px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.56.0-xTAd/index.html?id=TuP96xX8JnsoQeUGAPjkGQ\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display an interactive Plotly chart.</p>\n<p>Plotly is a charting library for Python. The arguments to this function\nclosely follow the ones for Plotly's <cite>plot()</cite> function. You can find\nmore about Plotly at <a class=\"reference external\" href=\"https://plot.ly/python\">https://plot.ly/python</a>.</p>\n",
-      "args": [
-        {
-          "name": "figure_or_data",
-          "type_name": "plotly.graph_objs.Figure, plotly.graph_objs.Data,",
-          "is_optional": false,
-          "description": "<p>dict/list of plotly.graph_objs.Figure/Data</p>\n<p>See <a class=\"reference external\" href=\"https://plot.ly/python/\">https://plot.ly/python/</a> for examples of graph descriptions.</p>\n",
-          "default": null
-        },
-        {
-          "name": "use_container_width",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
-          "default": null
-        },
-        {
-          "name": "sharing",
-          "type_name": "{'streamlit', 'private', 'secret', 'public'}",
-          "is_optional": false,
-          "description": "<p>Use 'streamlit' to insert the plot and all its dependencies\ndirectly in the Streamlit app using plotly's offline mode (default).\nUse any other sharing mode to send the chart to Plotly chart studio, which\nrequires an account. See <a class=\"reference external\" href=\"https://plotly.com/chart-studio/\">https://plotly.com/chart-studio/</a> for more information.</p>\n",
-          "default": null
-        },
-        {
-          "name": "**kwargs",
-          "type_name": null,
-          "is_optional": null,
-          "description": "<p>Any argument accepted by Plotly's <cite>plot()</cite> function.</p>\n",
-          "default": null
-        },
-        {
-          "name": "To show Plotly charts in Streamlit, call `st.plotly_chart`",
-          "type_name": null,
-          "is_optional": null,
-          "description": "",
-          "default": null
-        },
-        {
-          "name": "wherever you would call Plotly's `py.plot` or `py.iplot`.",
-          "type_name": null,
-          "is_optional": null,
-          "description": "",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.progress": {
-      "name": "progress",
-      "signature": "st.progress(value)",
-      "example": "<blockquote>\n<p>Here is an example of a progress bar increasing over time:</p>\n<pre class=\"doctest-block\">\nimport time\n\nmy_bar = st.progress(0)\n\nfor percent_complete in range(100):\n     time.sleep(0.1)\n     my_bar.progress(percent_complete + 1)\n</pre>\n</blockquote>\n",
-      "description": "Display a progress bar.",
-      "args": [
-        {
-          "name": "value",
-          "type_name": "int or float",
-          "is_optional": false,
-          "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.pydeck_chart": {
-      "name": "pydeck_chart",
-      "signature": "st.pydeck_chart(pydeck_obj=None, use_container_width=False)",
-      "example": "<blockquote>\n<p>Here's a chart using a HexagonLayer and a ScatterplotLayer on top of\nthe light map style:</p>\n<pre class=\"doctest-block\">\ndf = pd.DataFrame(\n    np.random.randn(1000, 2) / [50, 50] + [37.76, -122.4],\n    columns=['lat', 'lon'])\n\nst.pydeck_chart(pdk.Deck(\n     map_style='mapbox://styles/mapbox/light-v9',\n     initial_view_state=pdk.ViewState(\n         latitude=37.76,\n         longitude=-122.4,\n         zoom=11,\n         pitch=50,\n     ),\n     layers=[\n         pdk.Layer(\n            'HexagonLayer',\n            data=df,\n            get_position='[lon, lat]',\n            radius=200,\n            elevation_scale=4,\n            elevation_range=[0, 1000],\n            pickable=True,\n            extruded=True,\n         ),\n         pdk.Layer(\n             'ScatterplotLayer',\n             data=df,\n             get_position='[lon, lat]',\n             get_color='[200, 30, 0, 160]',\n             get_radius=200,\n         ),\n     ],\n ))\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=ASTdExBpJ1WxbGceneKN1i&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 530px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=ASTdExBpJ1WxbGceneKN1i\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Draw a chart using the PyDeck library.</p>\n<p>This supports 3D maps, point clouds, and more! More info about PyDeck\nat <a class=\"reference external\" href=\"https://deckgl.readthedocs.io/en/latest/\">https://deckgl.readthedocs.io/en/latest/</a>.</p>\n<p>These docs are also quite useful:</p>\n<ul class=\"simple\">\n<li>DeckGL docs: <a class=\"reference external\" href=\"https://github.com/uber/deck.gl/tree/master/docs\">https://github.com/uber/deck.gl/tree/master/docs</a></li>\n<li>DeckGL JSON docs: <a class=\"reference external\" href=\"https://github.com/uber/deck.gl/tree/master/modules/json\">https://github.com/uber/deck.gl/tree/master/modules/json</a></li>\n</ul>\n<p>When using this command, we advise all users to use a personal Mapbox\ntoken. This ensures the map tiles used in this chart are more\nrobust. You can do this with the mapbox.token config option.</p>\n<p>To get a token for yourself, create an account at\n<a class=\"reference external\" href=\"https://mapbox.com\">https://mapbox.com</a>. It's free! (for moderate usage levels) See\n<a class=\"reference external\" href=\"https://docs.streamlit.io/en/latest/cli.html#view-all-config-options\">https://docs.streamlit.io/en/latest/cli.html#view-all-config-options</a> for more\ninfo on how to set config options.</p>\n",
-      "args": [
-        {
-          "name": "spec",
-          "type_name": "pydeck.Deck or None",
-          "is_optional": false,
-          "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.pyplot": {
-      "name": "pyplot",
-      "signature": "st.pyplot(fig=None, clear_figure=None, **kwargs)",
-      "notes": "<blockquote>\n<div class=\"admonition note\">\n<p class=\"first admonition-title\">Note</p>\n<p class=\"last\">Deprecation warning. After December 1st, 2020, we will remove the ability\nto specify no arguments in <cite>st.pyplot()</cite>, as that requires the use of\nMatplotlib's global figure object, which is not thread-safe. So\nplease always pass a figure object as shown in the example section\nabove.</p>\n</div>\n<p>Matplotlib support several different types of &quot;backends&quot;. If you're\ngetting an error using Matplotlib with Streamlit, try setting your\nbackend to &quot;TkAgg&quot;:</p>\n<pre class=\"literal-block\">\necho &quot;backend: TkAgg&quot; &gt;&gt; ~/.matplotlib/matplotlibrc\n</pre>\n<p>For more information, see <a class=\"reference external\" href=\"https://matplotlib.org/faq/usage_faq.html\">https://matplotlib.org/faq/usage_faq.html</a>.</p>\n</blockquote>\n",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nimport matplotlib.pyplot as plt\nimport numpy as np\n\narr = np.random.normal(1, 1, size=100)\nfig, ax = plt.subplots()\nax.hist(arr, bins=20)\n\nst.pyplot(fig)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=PwzFN7oLZsvb6HDdwdjkRB&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 530px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=PwzFN7oLZsvb6HDdwdjkRB\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "Display a matplotlib.pyplot figure.",
-      "args": [
-        {
-          "name": "fig",
-          "type_name": "Matplotlib Figure",
-          "is_optional": false,
-          "description": "<p>The figure to plot. When this argument isn't specified, this\nfunction will render the global figure (but this is deprecated,\nas described below)</p>\n",
-          "default": null
-        },
-        {
-          "name": "clear_figure",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, the figure will be cleared after being rendered.\nIf False, the figure will not be cleared after being rendered.\nIf left unspecified, we pick a default based on the value of <cite>fig</cite>.</p>\n<ul class=\"simple\">\n<li>If <cite>fig</cite> is set, defaults to <cite>False</cite>.</li>\n<li>If <cite>fig</cite> is not set, defaults to <cite>True</cite>. This simulates Jupyter's\napproach to matplotlib rendering.</li>\n</ul>\n",
-          "default": "based"
-        },
-        {
-          "name": "**kwargs",
-          "type_name": "any",
-          "is_optional": false,
-          "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.radio": {
-      "name": "radio",
-      "signature": "st.radio(label, options, index=0, format_func=special_internal_function, key=None, help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\ngenre = st.radio(\n     &quot;What's your favorite movie genre&quot;,\n     ('Comedy', 'Drama', 'Documentary'))\n\nif genre == 'Comedy':\n     st.write('You selected comedy.')\n else:\n     st.write(&quot;You didn't select comedy.&quot;)\n</pre>\n</blockquote>\n",
-      "description": "Display a radio button widget.",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this radio group is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "options",
-          "type_name": "list, tuple, numpy.ndarray, pandas.Series, or pandas.DataFrame",
-          "is_optional": false,
-          "description": "<p>Labels for the radio options. This will be cast to str internally\nby default. For pandas.DataFrame, the first column is selected.</p>\n",
-          "default": "."
-        },
-        {
-          "name": "index",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The index of the preselected option on first render.</p>\n",
-          "default": null
-        },
-        {
-          "name": "format_func",
-          "type_name": "function",
-          "is_optional": false,
-          "description": "<p>Function to modify the display of radio options. It receives\nthe raw option as an argument and should output the label to be\nshown for that option. This has no impact on the return value of\nthe radio.</p>\n",
-          "default": null
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the radio.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "any",
-          "is_generator": false,
-          "description": "<p>The selected option.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "streamlit.select_slider": {
-      "name": "select_slider",
-      "signature": "st.select_slider(label, options=[], value=None, format_func=special_internal_function, key=None, help=None)",
-      "examples": "<pre class=\"doctest-block\">\ncolor = st.select_slider(\n     'Select a color of the rainbow',\n     options=['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet'])\nst.write('My favorite color is', color)\n</pre>\n<p>And here's an example of a range select slider:</p>\n<pre class=\"doctest-block\">\nstart_color, end_color = st.select_slider(\n     'Select a range of color wavelength',\n     options=['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet'],\n     value=('red', 'blue'))\nst.write('You selected wavelengths between', start_color, 'and', end_color)\n</pre>\n",
-      "description": "<p>Display a slider widget to select items from a list.</p>\n<p>This also allows you to render a range slider by passing a two-element\ntuple or list as the <cite>value</cite>.</p>\n<p>The difference between <cite>st.select_slider</cite> and <cite>st.slider</cite> is that\n<cite>select_slider</cite> accepts any datatype and takes an iterable set of\noptions, while <cite>slider</cite> only accepts numerical or date/time data and\ntakes a range as input.</p>\n",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this slider is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "options",
-          "type_name": "list, tuple, numpy.ndarray, pandas.Series, or pandas.DataFrame",
-          "is_optional": false,
-          "description": "<p>Labels for the slider options. All options will be cast to str\ninternally by default. For pandas.DataFrame, the first column is\nselected.</p>\n",
-          "default": "."
-        },
-        {
-          "name": "value",
-          "type_name": "a supported type or a tuple/list of supported types or None",
-          "is_optional": false,
-          "description": "<p>The value of the slider when it first renders. If a tuple/list\nof two values is passed here, then a range slider with those lower\nand upper bounds is rendered. For example, if set to <cite>(1, 10)</cite> the\nslider will have a selectable range between 1 and 10.\nDefaults to first option.</p>\n",
-          "default": "first"
-        },
-        {
-          "name": "format_func",
-          "type_name": "function",
-          "is_optional": false,
-          "description": "<p>Function to modify the display of the labels from the options.\nargument. It receives the option as an argument and its output\nwill be cast to str.</p>\n",
-          "default": null
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the select slider.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "any value or tuple of any value",
-          "is_generator": false,
-          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "streamlit.selectbox": {
-      "name": "selectbox",
-      "signature": "st.selectbox(label, options, index=0, format_func=special_internal_function, key=None, help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\noption = st.selectbox(\n     'How would you like to be contacted?',\n     ('Email', 'Home phone', 'Mobile phone'))\n\nst.write('You selected:', option)\n</pre>\n</blockquote>\n",
-      "description": "Display a select widget.",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this select widget is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "options",
-          "type_name": "list, tuple, numpy.ndarray, pandas.Series, or pandas.DataFrame",
-          "is_optional": false,
-          "description": "<p>Labels for the select options. This will be cast to str internally\nby default. For pandas.DataFrame, the first column is selected.</p>\n",
-          "default": "."
-        },
-        {
-          "name": "index",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The index of the preselected option on first render.</p>\n",
-          "default": null
-        },
-        {
-          "name": "format_func",
-          "type_name": "function",
-          "is_optional": false,
-          "description": "<p>Function to modify the display of the labels. It receives the option\nas an argument and its output will be cast to str.</p>\n",
-          "default": null
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the selectbox.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "any",
-          "is_generator": false,
-          "description": "<p>The selected option</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "streamlit.set_option": {
-      "name": "set_option",
-      "signature": "st.set_option(key, value)",
-      "description": "<p>Set config option.</p>\n<dl class=\"docutils\">\n<dt>Currently, only the following config options can be set within the script itself:</dt>\n<dd><ul class=\"first last simple\">\n<li>client.caching</li>\n<li>client.displayEnabled</li>\n<li>deprecation.*</li>\n</ul>\n</dd>\n</dl>\n<p>Calling with any other options will raise StreamlitAPIException.</p>\n<p>Run <cite>streamlit config show</cite> in the terminal to see all available options.</p>\n",
-      "args": [
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The config option key of the form &quot;section.optionName&quot;. To see all\navailable options, run <cite>streamlit config show</cite> on a terminal.</p>\n",
-          "default": null
-        },
-        {
-          "name": "value",
-          "type_name": null,
-          "is_optional": null,
-          "description": "<p>The new value to assign to this config option.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.set_page_config": {
-      "name": "set_page_config",
-      "signature": "st.set_page_config(page_title=None, page_icon=None, layout=\"centered\", initial_sidebar_state=\"auto\")",
-      "example": "<pre class=\"doctest-block\">\nst.set_page_config(\n     page_title=&quot;Ex-stream-ly Cool App&quot;,\n     page_icon=&quot;\ud83e\uddca&quot;,\n     layout=&quot;wide&quot;,\n     initial_sidebar_state=&quot;expanded&quot;,\n )\n</pre>\n",
-      "description": "<p>Configures the default settings of the page.</p>\n<div class=\"admonition note\">\n<p class=\"first admonition-title\">Note</p>\n<p class=\"last\">This must be the first Streamlit command used in your app, and must only\nbe set once.</p>\n</div>\n",
-      "args": [
-        {
-          "name": "page_title",
-          "type_name": "str or None",
-          "is_optional": false,
-          "description": "<p>The page title, shown in the browser tab. If None, defaults to the\nfilename of the script (&quot;app.py&quot; would show &quot;app \u2022 Streamlit&quot;).</p>\n",
-          "default": "the"
-        },
-        {
-          "name": "page_icon",
-          "type_name": "Anything supported by st.image or str or None",
-          "is_optional": false,
-          "description": "<p>The page favicon.\nBesides the types supported by <cite>st.image</cite> (like URLs or numpy arrays),\nyou can pass in an emoji as a string (&quot;\ud83e\udd88&quot;) or a shortcode (&quot;:shark:&quot;).\nIf you're feeling lucky, try &quot;random&quot; for a random emoji!\nEmoji icons are courtesy of Twemoji and loaded from MaxCDN.</p>\n",
-          "default": null
-        },
-        {
-          "name": "layout",
-          "type_name": "\"centered\" or \"wide\"",
-          "is_optional": false,
-          "description": "<p>How the page content should be laid out. Defaults to &quot;centered&quot;,\nwhich constrains the elements into a centered column of fixed width;\n&quot;wide&quot; uses the entire screen.</p>\n",
-          "default": "s"
-        },
-        {
-          "name": "initial_sidebar_state",
-          "type_name": "\"auto\" or \"expanded\" or \"collapsed\"",
-          "is_optional": false,
-          "description": "<p>How the sidebar should start out. Defaults to &quot;auto&quot;,\nwhich hides the sidebar on mobile-sized devices, and shows it otherwise.\n&quot;expanded&quot; shows the sidebar initially; &quot;collapsed&quot; hides it.</p>\n",
-          "default": "s"
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.slider": {
-      "name": "slider",
-      "signature": "st.slider(label, min_value=None, max_value=None, value=None, step=None, format=None, key=None, help=None)",
-      "examples": "<blockquote>\n<pre class=\"doctest-block\">\nage = st.slider('How old are you?', 0, 130, 25)\nst.write(&quot;I'm &quot;, age, 'years old')\n</pre>\n<p>And here's an example of a range slider:</p>\n<pre class=\"doctest-block\">\nvalues = st.slider(\n     'Select a range of values',\n     0.0, 100.0, (25.0, 75.0))\nst.write('Values:', values)\n</pre>\n<p>This is a range time slider:</p>\n<pre class=\"doctest-block\">\nfrom datetime import time\nappointment = st.slider(\n     &quot;Schedule your appointment:&quot;,\n     value=(time(11, 30), time(12, 45)))\nst.write(&quot;You're scheduled for:&quot;, appointment)\n</pre>\n<p>Finally, a datetime slider:</p>\n<pre class=\"doctest-block\">\nfrom datetime import datetime\nstart_time = st.slider(\n     &quot;When do you start?&quot;,\n     value=datetime(2020, 1, 1, 9, 30),\n     format=&quot;MM/DD/YY - hh:mm&quot;)\nst.write(&quot;Start time:&quot;, start_time)\n</pre>\n</blockquote>\n",
-      "description": "<p>Display a slider widget.</p>\n<p>This supports int, float, date, time, and datetime types.</p>\n<p>This also allows you to render a range slider by passing a two-element\ntuple or list as the <cite>value</cite>.</p>\n<p>The difference between <cite>st.slider</cite> and <cite>st.select_slider</cite> is that\n<cite>slider</cite> only accepts numerical or date/time data and takes a range as\ninput, while <cite>select_slider</cite> accepts any datatype and takes an iterable\nset of options.</p>\n",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this slider is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "min_value",
-          "type_name": "a supported type or None",
-          "is_optional": false,
-          "description": "<p>The minimum permitted value.\nDefaults to 0 if the value is an int, 0.0 if a float,\nvalue - timedelta(days=14) if a date/datetime, time.min if a time</p>\n",
-          "default": "0"
-        },
-        {
-          "name": "max_value",
-          "type_name": "a supported type or None",
-          "is_optional": false,
-          "description": "<p>The maximum permitted value.\nDefaults to 100 if the value is an int, 1.0 if a float,\nvalue + timedelta(days=14) if a date/datetime, time.max if a time</p>\n",
-          "default": "100"
-        },
-        {
-          "name": "value",
-          "type_name": "a supported type or a tuple/list of supported types or None",
-          "is_optional": false,
-          "description": "<p>The value of the slider when it first renders. If a tuple/list\nof two values is passed here, then a range slider with those lower\nand upper bounds is rendered. For example, if set to <cite>(1, 10)</cite> the\nslider will have a selectable range between 1 and 10.\nDefaults to min_value.</p>\n",
-          "default": "min_value."
-        },
-        {
-          "name": "step",
-          "type_name": "int/float/timedelta or None",
-          "is_optional": false,
-          "description": "<p>The stepping interval.\nDefaults to 1 if the value is an int, 0.01 if a float,\ntimedelta(days=1) if a date/datetime, timedelta(minutes=15) if a time\n(or if max_value - min_value &lt; 1 day)</p>\n",
-          "default": "1"
-        },
-        {
-          "name": "format",
-          "type_name": "str or None",
-          "is_optional": false,
-          "description": "<p>A printf-style format string controlling how the interface should\ndisplay numbers. This does not impact the return value.\nFormatter for int/float supports: %d %e %f %g %i\nFormatter for date/time/datetime uses Moment.js notation:\n<a class=\"reference external\" href=\"https://momentjs.com/docs/#/displaying/format/\">https://momentjs.com/docs/#/displaying/format/</a></p>\n",
-          "default": null
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the slider.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
-          "is_generator": false,
-          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "streamlit.spinner": {
-      "name": "spinner",
-      "signature": "st.spinner(text=\"In progress...\")",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nwith st.spinner('Wait for it...'):\n    time.sleep(5)\nst.success('Done!')\n</pre>\n</blockquote>\n",
-      "description": "Temporarily displays a message while executing a block of code.",
-      "args": [
-        {
-          "name": "text",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A message to display while executing that block</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.stop": {
-      "name": "stop",
-      "signature": "st.stop()",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
-      "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
-      "args": [],
-      "returns": []
-    },
-    "streamlit.subheader": {
-      "name": "subheader",
-      "signature": "st.subheader(body, anchor=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.subheader('This is a subheader')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=LBKJTfFUwudrbWENSHV6cJ&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 100px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=LBKJTfFUwudrbWENSHV6cJ\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "Display text in subheader formatting.",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The text to display.</p>\n",
-          "default": null
-        },
-        {
-          "name": "anchor",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.success": {
-      "name": "success",
-      "signature": "st.success(body)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.success('This is a success message!')\n</pre>\n</blockquote>\n",
-      "description": "Display a success message.",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The success text to display.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.table": {
-      "name": "table",
-      "signature": "st.table(data=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\ndf = pd.DataFrame(\n    np.random.randn(10, 5),\n    columns=('col %d' % i for i in range(5)))\n\nst.table(df)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=KfZvDMprL4JFKXbpjD3fpq&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 480px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=KfZvDMprL4JFKXbpjD3fpq\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display a static table.</p>\n<p>This differs from <cite>st.dataframe</cite> in that the table in this case is\nstatic: its entire contents are laid out directly on the page.</p>\n",
-      "args": [
-        {
-          "name": "data",
-          "type_name": "pandas.DataFrame, pandas.Styler, numpy.ndarray, Iterable, dict,",
-          "is_optional": false,
-          "description": "<p>or None\nThe table data.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.text": {
-      "name": "text",
-      "signature": "st.text(body)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.text('This is some text.')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=PYxU1kee5ubuhGR11NsnT1&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 50px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=PYxU1kee5ubuhGR11NsnT1\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "Write fixed-width and preformatted text.",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The string to display.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.text_area": {
-      "name": "text_area",
-      "signature": "st.text_area(label, value=\"\", height=None, max_chars=None, key=None, help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\ntxt = st.text_area('Text to analyze', '''\n     It was the best of times, it was the worst of times, it was\n     the age of wisdom, it was the age of foolishness, it was\n     the epoch of belief, it was the epoch of incredulity, it\n     was the season of Light, it was the season of Darkness, it\n     was the spring of hope, it was the winter of despair, (...)\n     ''')\nst.write('Sentiment:', run_sentiment_analysis(txt))\n</pre>\n</blockquote>\n",
-      "description": "Display a multi-line text input widget.",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this input is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "value",
-          "type_name": "any",
-          "is_optional": false,
-          "description": "<p>The text value of this widget when it first renders. This will be\ncast to str internally.</p>\n",
-          "default": null
-        },
-        {
-          "name": "height",
-          "type_name": "int or None",
-          "is_optional": false,
-          "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
-          "default": "height"
-        },
-        {
-          "name": "max_chars",
-          "type_name": "int or None",
-          "is_optional": false,
-          "description": "<p>Maximum number of characters allowed in text area.</p>\n",
-          "default": null
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the textarea.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "str",
-          "is_generator": false,
-          "description": "<p>The current value of the text input widget.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "streamlit.text_input": {
-      "name": "text_input",
-      "signature": "st.text_input(label, value=\"\", max_chars=None, key=None, type=\"default\", help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\ntitle = st.text_input('Movie title', 'Life of Brian')\nst.write('The current movie title is', title)\n</pre>\n</blockquote>\n",
-      "description": "Display a single-line text input widget.",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this input is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "value",
-          "type_name": "any",
-          "is_optional": false,
-          "description": "<p>The text value of this widget when it first renders. This will be\ncast to str internally.</p>\n",
-          "default": null
-        },
-        {
-          "name": "max_chars",
-          "type_name": "int or None",
-          "is_optional": false,
-          "description": "<p>Max number of characters allowed in text input.</p>\n",
-          "default": null
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "type",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The type of the text input. This can be either &quot;default&quot; (for\na regular text input), or &quot;password&quot; (for a text input that\nmasks the user's typed value). Defaults to &quot;default&quot;.</p>\n",
-          "default": "s"
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "str",
-          "is_generator": false,
-          "description": "<p>The current value of the text input widget.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "streamlit.time_input": {
-      "name": "time_input",
-      "signature": "st.time_input(label, value=None, key=None, help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nt = st.time_input('Set an alarm for', datetime.time(8, 45))\nst.write('Alarm is set for', t)\n</pre>\n</blockquote>\n",
-      "description": "Display a time input widget.",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this time input is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "value",
-          "type_name": "datetime.time/datetime.datetime",
-          "is_optional": false,
-          "description": "<p>The value of this widget when it first renders. This will be\ncast to str internally. Defaults to the current time.</p>\n",
-          "default": "the"
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "datetime.time",
-          "is_generator": false,
-          "description": "<p>The current value of the time input widget.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "streamlit.title": {
-      "name": "title",
-      "signature": "st.title(body, anchor=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.title('This is a title')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=SFcBGANWd8kWXF28XnaEZj&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 100px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=SFcBGANWd8kWXF28XnaEZj\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display text in title formatting.</p>\n<p>Each document should have a single <cite>st.title()</cite>, although this is not\nenforced.</p>\n",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The text to display.</p>\n",
-          "default": null
-        },
-        {
-          "name": "anchor",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.vega_lite_chart": {
-      "name": "vega_lite_chart",
-      "signature": "st.vega_lite_chart(data=None, spec=None, use_container_width=False, **kwargs)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nimport pandas as pd\nimport numpy as np\n\ndf = pd.DataFrame(\n     np.random.randn(200, 3),\n     columns=['a', 'b', 'c'])\n\nst.vega_lite_chart(df, {\n     'mark': {'type': 'circle', 'tooltip': True},\n     'encoding': {\n         'x': {'field': 'a', 'type': 'quantitative'},\n         'y': {'field': 'b', 'type': 'quantitative'},\n         'size': {'field': 'c', 'type': 'quantitative'},\n         'color': {'field': 'c', 'type': 'quantitative'},\n     },\n })\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 200px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Examples of Vega-Lite usage without Streamlit can be found at\n<a class=\"reference external\" href=\"https://vega.github.io/vega-lite/examples/\">https://vega.github.io/vega-lite/examples/</a>. Most of those can be easily\ntranslated to the syntax shown above.</p>\n</blockquote>\n",
-      "description": "Display a chart using the Vega-Lite library.",
-      "args": [
-        {
-          "name": "data",
-          "type_name": "pandas.DataFrame, pandas.Styler, numpy.ndarray, Iterable, dict,",
-          "is_optional": false,
-          "description": "<p>or None\nEither the data to be plotted or a Vega-Lite spec containing the\ndata (which more closely follows the Vega-Lite API).</p>\n",
-          "default": null
-        },
-        {
-          "name": "spec",
-          "type_name": "dict or None",
-          "is_optional": false,
-          "description": "<p>The Vega-Lite spec for the chart. If the spec was already passed in\nthe previous argument, this must be set to None. See\n<a class=\"reference external\" href=\"https://vega.github.io/vega-lite/docs/\">https://vega.github.io/vega-lite/docs/</a> for more info.</p>\n",
-          "default": null
-        },
-        {
-          "name": "use_container_width",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Vega-Lite's native <cite>width</cite> value.</p>\n",
-          "default": null
-        },
-        {
-          "name": "**kwargs",
-          "type_name": "any",
-          "is_optional": false,
-          "description": "<p>Same as spec, but as keywords.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.video": {
-      "name": "video",
-      "signature": "st.video(data, format=\"video/mp4\", start_time=0)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nvideo_file = open('myvideo.mp4', 'rb')\nvideo_bytes = video_file.read()\n\nst.video(video_bytes)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-2BLtg/index.html?id=DzAouvizGRAyuLjkPpR894&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 600px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-2BLtg/index.html?id=DzAouvizGRAyuLjkPpR894\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <div class=\"admonition note\">\n<p class=\"first admonition-title\">Note</p>\n<p class=\"last\">Some videos may not display if they are encoded using MP4V (which is an export option in OpenCV), as this codec is\nnot widely supported by browsers. Converting your video to H.264 will allow the video to be displayed in Streamlit.\nSee this <a class=\"reference external\" href=\"https://stackoverflow.com/a/49535220/2394542\">StackOverflow post</a> or this\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/st-video-doesnt-show-opencv-generated-mp4/3193/2\">Streamlit forum post</a>\nfor more information.</p>\n</div>\n</blockquote>\n",
-      "description": "Display a video player.",
-      "args": [
-        {
-          "name": "data",
-          "type_name": "str, bytes, BytesIO, numpy.ndarray, or file opened with",
-          "is_optional": false,
-          "description": "<p>io.open().\nRaw video data, filename, or URL pointing to a video to load.\nIncludes support for YouTube URLs.\nNumpy arrays and raw data formats must include all necessary file\nheaders to match specified file format.</p>\n",
-          "default": null
-        },
-        {
-          "name": "format",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The mime type for the video file. Defaults to 'video/mp4'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
-          "default": "s"
-        },
-        {
-          "name": "start_time",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The time from which this element should start playing.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.warning": {
-      "name": "warning",
-      "signature": "st.warning(body)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.warning('This is a warning')\n</pre>\n</blockquote>\n",
-      "description": "Display warning message.",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The warning text to display.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.write": {
-      "name": "write",
-      "signature": "st.write(*args, **kwargs)",
-      "example": "<blockquote>\n<p>Its basic use case is to draw Markdown-formatted text, whenever the\ninput is a string:</p>\n<pre class=\"doctest-block\">\nwrite('Hello, *World!* :sunglasses:')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.50.2-ZWk9/index.html?id=Pn5sjhgNs4a8ZbiUoSTRxE&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 50px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.50.2-ZWk9/index.html?id=Pn5sjhgNs4a8ZbiUoSTRxE\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>As mentioned earlier, <cite>st.write()</cite> also accepts other data formats, such as\nnumbers, data frames, styled data frames, and assorted objects:</p>\n<pre class=\"doctest-block\">\nst.write(1234)\nst.write(pd.DataFrame({\n     'first column': [1, 2, 3, 4],\n     'second column': [10, 20, 30, 40],\n }))\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=FCp9AMJHwHRsWSiqMgUZGD&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 250px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=FCp9AMJHwHRsWSiqMgUZGD\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Finally, you can pass in multiple arguments to do things like:</p>\n<pre class=\"doctest-block\">\nst.write('1 + 1 = ', 2)\nst.write('Below is a DataFrame:', data_frame, 'Above is a dataframe.')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=DHkcU72sxYcGarkFbf4kK1&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 300px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=DHkcU72sxYcGarkFbf4kK1\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Oh, one more thing: <cite>st.write</cite> accepts chart objects too! For example:</p>\n<pre class=\"doctest-block\">\nimport pandas as pd\nimport numpy as np\nimport altair as alt\n\ndf = pd.DataFrame(\n     np.random.randn(200, 3),\n     columns=['a', 'b', 'c'])\n\nc = alt.Chart(df).mark_circle().encode(\n     x='a', y='b', size='c', color='c', tooltip=['a', 'b', 'c'])\n\nst.write(c)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 200px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Write arguments to the app.</p>\n<p>This is the Swiss Army knife of Streamlit commands: it does different\nthings depending on what you throw at it. Unlike other Streamlit commands,\nwrite() has some unique properties:</p>\n<ol class=\"arabic simple\">\n<li>You can pass in multiple arguments, all of which will be written.</li>\n<li>Its behavior depends on the input types as follows.</li>\n<li>It returns None, so its &quot;slot&quot; in the App cannot be reused.</li>\n</ol>\n",
-      "args": [
-        {
-          "name": "*args",
-          "type_name": "any",
-          "is_optional": false,
-          "description": "<p>One or many objects to print to the App.</p>\n<p>Arguments are handled as follows:</p>\n<ul class=\"simple\">\n<li><dl class=\"first docutils\">\n<dt>write(string) <span class=\"classifier-delimiter\">:</span> <span class=\"classifier\">Prints the formatted Markdown string, with</span></dt>\n<dd>support for LaTeX expression and emoji shortcodes.\nSee docs for st.markdown for more.</dd>\n</dl>\n</li>\n<li>write(data_frame) : Displays the DataFrame as a table.</li>\n<li>write(error)      : Prints an exception specially.</li>\n<li>write(func)       : Displays information about a function.</li>\n<li>write(module)     : Displays information about the module.</li>\n<li>write(dict)       : Displays dict in an interactive widget.</li>\n<li>write(mpl_fig)    : Displays a Matplotlib figure.</li>\n<li>write(altair)     : Displays an Altair chart.</li>\n<li>write(keras)      : Displays a Keras model.</li>\n<li>write(graphviz)   : Displays a Graphviz graph.</li>\n<li>write(plotly_fig) : Displays a Plotly figure.</li>\n<li>write(bokeh_fig)  : Displays a Bokeh figure.</li>\n<li>write(sympy_expr) : Prints SymPy expression using LaTeX.</li>\n<li>write(htmlable)   : Prints _repr_html_() for the object if available.</li>\n<li>write(obj)        : Prints str(obj) if otherwise unknown.</li>\n</ul>\n",
-          "default": null
-        },
-        {
-          "name": "unsafe_allow_html",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
-          "default": "False."
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.add_rows": {
-      "name": "add_rows",
-      "signature": "element.add_rows(self, data=None, **kwargs)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\ndf1 = pd.DataFrame(\n    np.random.randn(50, 20),\n    columns=('col %d' % i for i in range(20)))\n\nmy_table = st.table(df1)\n\ndf2 = pd.DataFrame(\n    np.random.randn(50, 20),\n    columns=('col %d' % i for i in range(20)))\n\nmy_table.add_rows(df2)\n# Now the table shown in the Streamlit app contains the data for\n# df1 followed by the data for df2.\n</pre>\n<p>You can do the same thing with plots. For example, if you want to add\nmore data to a line chart:</p>\n<pre class=\"doctest-block\">\n# Assuming df1 and df2 from the example above still exist...\nmy_chart = st.line_chart(df1)\nmy_chart.add_rows(df2)\n# Now the chart shown in the Streamlit app contains the data for\n# df1 followed by the data for df2.\n</pre>\n<p>And for plots whose datasets are named, you can pass the data with a\nkeyword argument where the key is the name:</p>\n<pre class=\"doctest-block\">\nmy_chart = st.vega_lite_chart({\n     'mark': 'line',\n     'encoding': {'x': 'a', 'y': 'b'},\n     'datasets': {\n       'some_fancy_name': df1,  # &lt;-- named dataset\n      },\n     'data': {'name': 'some_fancy_name'},\n }),\nmy_chart.add_rows(some_fancy_name=df2)  # &lt;-- name used as keyword\n</pre>\n</blockquote>\n",
-      "description": "Concatenate a dataframe to the bottom of the current one.",
-      "args": [
-        {
-          "name": "data",
-          "type_name": "pandas.DataFrame, pandas.Styler, numpy.ndarray, Iterable, dict,",
-          "is_optional": false,
-          "description": "",
-          "default": null
-        },
-        {
-          "name": "or None",
-          "type_name": null,
-          "is_optional": null,
-          "description": "<p>Table to concat. Optional.</p>\n",
-          "default": null
-        },
-        {
-          "name": "**kwargs",
-          "type_name": "pandas.DataFrame, numpy.ndarray, Iterable, dict, or None",
-          "is_optional": false,
-          "description": "<p>The named dataset to concat. Optional. You can only pass in 1\ndataset (including the one in the data parameter).</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.altair_chart": {
-      "name": "altair_chart",
-      "signature": "element.altair_chart(self, altair_chart, use_container_width=False)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nimport pandas as pd\nimport numpy as np\nimport altair as alt\n\ndf = pd.DataFrame(\n     np.random.randn(200, 3),\n     columns=['a', 'b', 'c'])\n\nc = alt.Chart(df).mark_circle().encode(\n     x='a', y='b', size='c', color='c', tooltip=['a', 'b', 'c'])\n\nst.altair_chart(c, use_container_width=True)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 200px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Examples of Altair charts can be found at\n<a class=\"reference external\" href=\"https://altair-viz.github.io/gallery/\">https://altair-viz.github.io/gallery/</a>.</p>\n</blockquote>\n",
-      "description": "Display a chart using the Altair library.",
-      "args": [
-        {
-          "name": "altair_chart",
-          "type_name": "altair.vegalite.v2.api.Chart",
-          "is_optional": false,
-          "description": "<p>The Altair chart object to display.</p>\n",
-          "default": null
-        },
-        {
-          "name": "use_container_width",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Altair's native <cite>width</cite> value.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.area_chart": {
-      "name": "area_chart",
-      "signature": "element.area_chart(self, data=None, width=0, height=0, use_container_width=True)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nchart_data = pd.DataFrame(\n     np.random.randn(20, 3),\n     columns=['a', 'b', 'c'])\n\nst.area_chart(chart_data)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.50.0-td2L/index.html?id=Pp65STuFj65cJRDfhGh4Jt&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 220px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.50.0-td2L/index.html?id=Pp65STuFj65cJRDfhGh4Jt\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display an area chart.</p>\n<p>This is just syntax-sugar around st.altair_chart. The main difference\nis this command uses the data's own column and indices to figure out\nthe chart's spec. As a result this is easier to use for many &quot;just plot\nthis&quot; scenarios, while being less customizable.</p>\n<p>If st.area_chart does not guess the data specification\ncorrectly, try specifying your desired chart using st.altair_chart.</p>\n",
-      "args": [
-        {
-          "name": "data",
-          "type_name": "pandas.DataFrame, pandas.Styler, numpy.ndarray, Iterable, or dict",
-          "is_optional": false,
-          "description": "<p>Data to be plotted.</p>\n",
-          "default": null
-        },
-        {
-          "name": "width",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The chart width in pixels. If 0, selects the width automatically.</p>\n",
-          "default": null
-        },
-        {
-          "name": "height",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The chart width in pixels. If 0, selects the height automatically.</p>\n",
-          "default": null
-        },
-        {
-          "name": "use_container_width",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.audio": {
-      "name": "audio",
-      "signature": "element.audio(self, data, format=\"audio/wav\", start_time=0)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\naudio_file = open('myaudio.ogg', 'rb')\naudio_bytes = audio_file.read()\n\nst.audio(audio_bytes, format='audio/ogg')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=Dv3M9sA7Cg8gwusgnVNTHb&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 400px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=Dv3M9sA7Cg8gwusgnVNTHb\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "Display an audio player.",
-      "args": [
-        {
-          "name": "data",
-          "type_name": "str, bytes, BytesIO, numpy.ndarray, or file opened with",
-          "is_optional": false,
-          "description": "<p>io.open().\nRaw audio data, filename, or a URL pointing to the file to load.\nNumpy arrays and raw data formats must include all necessary file\nheaders to match specified file format.</p>\n",
-          "default": null
-        },
-        {
-          "name": "start_time",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The time from which this element should start playing.</p>\n",
-          "default": null
-        },
-        {
-          "name": "format",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The mime type for the audio file. Defaults to 'audio/wav'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
-          "default": "s"
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.balloons": {
-      "name": "balloons",
-      "signature": "element.balloons(self)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
-      "description": "Draw celebratory balloons.",
-      "args": [],
-      "returns": []
-    },
-    "DeltaGenerator.bar_chart": {
-      "name": "bar_chart",
-      "signature": "element.bar_chart(self, data=None, width=0, height=0, use_container_width=True)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nchart_data = pd.DataFrame(\n     np.random.randn(50, 3),\n     columns=[&quot;a&quot;, &quot;b&quot;, &quot;c&quot;])\n\nst.bar_chart(chart_data)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-2BLtg/index.html?id=GaYDn6vxskvBUkBwsGVEaL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 220px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-2BLtg/index.html?id=GaYDn6vxskvBUkBwsGVEaL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display a bar chart.</p>\n<p>This is just syntax-sugar around st.altair_chart. The main difference\nis this command uses the data's own column and indices to figure out\nthe chart's spec. As a result this is easier to use for many &quot;just plot\nthis&quot; scenarios, while being less customizable.</p>\n<p>If st.bar_chart does not guess the data specification\ncorrectly, try specifying your desired chart using st.altair_chart.</p>\n",
-      "args": [
-        {
-          "name": "data",
-          "type_name": "pandas.DataFrame, pandas.Styler, numpy.ndarray, Iterable, or dict",
-          "is_optional": false,
-          "description": "<p>Data to be plotted.</p>\n",
-          "default": null
-        },
-        {
-          "name": "width",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The chart width in pixels. If 0, selects the width automatically.</p>\n",
-          "default": null
-        },
-        {
-          "name": "height",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The chart width in pixels. If 0, selects the height automatically.</p>\n",
-          "default": null
-        },
-        {
-          "name": "use_container_width",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.beta_columns": {
-      "name": "beta_columns",
-      "signature": "element.beta_columns(self, spec)",
-      "examples": "<blockquote>\n<p>You can use <cite>with</cite> notation to insert any element into a column:</p>\n<pre class=\"doctest-block\">\ncol1, col2, col3 = st.beta_columns(3)\n\nwith col1:\n    st.header(&quot;A cat&quot;)\n    st.image(&quot;https://static.streamlit.io/examples/cat.jpg&quot;)\n\nwith col2:\n    st.header(&quot;A dog&quot;)\n    st.image(&quot;https://static.streamlit.io/examples/dog.jpg&quot;)\n\nwith col3:\n    st.header(&quot;An owl&quot;)\n    st.image(&quot;https://static.streamlit.io/examples/owl.jpg&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=VW45Va5XmSKed2ayzf7vYa&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 550px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=VW45Va5XmSKed2ayzf7vYa\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Or you can just call methods directly in the returned objects:</p>\n<pre class=\"doctest-block\">\ncol1, col2 = st.beta_columns([3, 1])\ndata = np.random.randn(10, 1)\n\ncol1.subheader(&quot;A wide column with a chart&quot;)\ncol1.line_chart(data)\n\ncol2.subheader(&quot;A narrow column with the data&quot;)\ncol2.write(data)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=XSQ6VkonfGcT2AyNYMZN83&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 400px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=XSQ6VkonfGcT2AyNYMZN83\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Insert containers laid out as side-by-side columns.</p>\n<p>Inserts a number of multi-element containers laid out side-by-side and\nreturns a list of container objects.</p>\n<p>To add elements to the returned containers, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n<div class=\"admonition warning\">\n<p class=\"first admonition-title\">Warning</p>\n<p class=\"last\">Currently, you may not put columns inside another column.</p>\n</div>\n",
-      "args": [
-        {
-          "name": "spec",
-          "type_name": "int or list of numbers",
-          "is_optional": false,
-          "description": "<dl class=\"docutils\">\n<dt>If an int</dt>\n<dd>Specifies the number of columns to insert, and all columns\nhave equal width.</dd>\n<dt>If a list of numbers</dt>\n<dd><p class=\"first\">Creates a column for each number, and each\ncolumn's width is proportional to the number provided. Numbers can\nbe ints or floats, but they must be positive.</p>\n<p class=\"last\">For example, <cite>st.beta_columns([3, 1, 2])</cite> creates 3 columns where\nthe first column is 3 times the width of the second, and the last\ncolumn is 2 times that width.</p>\n</dd>\n</dl>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "list of containers",
-          "is_generator": false,
-          "description": "<p>A list of container objects.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "DeltaGenerator.beta_container": {
-      "name": "beta_container",
-      "signature": "element.beta_container(self)",
-      "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.beta_container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.beta_container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
-      "args": [],
-      "returns": []
-    },
-    "DeltaGenerator.beta_expander": {
-      "name": "beta_expander",
-      "signature": "element.beta_expander(self, label=None, expanded=False)",
-      "examples": "<blockquote>\n<pre class=\"doctest-block\">\nst.line_chart({&quot;data&quot;: [1, 5, 2, 6, 2, 1]})\n\nwith st.beta_expander(&quot;See explanation&quot;):\n     st.write(&quot;&quot;&quot;\n         The chart above shows some numbers I picked for you.\n         I rolled actual dice for these, so they're *guaranteed* to\n         be random.\n     &quot;&quot;&quot;)\n     st.image(&quot;https://static.streamlit.io/examples/dice.jpg&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-2BLtg/index.html?id=7v2tgefVbW278gemvYrRny&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 750px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-2BLtg/index.html?id=7v2tgefVbW278gemvYrRny\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Insert a multi-element container that can be expanded/collapsed.</p>\n<p>Inserts a container into your app that can be used to hold multiple elements\nand can be expanded or collapsed by the user. When collapsed, all that is\nvisible is the provided label.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n<div class=\"admonition warning\">\n<p class=\"first admonition-title\">Warning</p>\n<p class=\"last\">Currently, you may not put expanders inside another expander.</p>\n</div>\n",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A string to use as the header for the expander.</p>\n",
-          "default": null
-        },
-        {
-          "name": "expanded",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, initializes the expander in &quot;expanded&quot; state. Defaults to\nFalse (collapsed).</p>\n",
-          "default": "s"
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.bokeh_chart": {
-      "name": "bokeh_chart",
-      "signature": "element.bokeh_chart(self, figure, use_container_width=False)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nimport streamlit as st\nfrom bokeh.plotting import figure\n\nx = [1, 2, 3, 4, 5]\ny = [6, 7, 2, 4, 5]\n\np = figure(\n     title='simple line example',\n     x_axis_label='x',\n     y_axis_label='y')\n\np.line(x, y, legend_label='Trend', line_width=2)\n\nst.bokeh_chart(p, use_container_width=True)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.56.0-xTAd/index.html?id=Fdhg51uMbGMLRRxXV6ubzp&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 600px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.56.0-xTAd/index.html?id=Fdhg51uMbGMLRRxXV6ubzp\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display an interactive Bokeh chart.</p>\n<p>Bokeh is a charting library for Python. The arguments to this function\nclosely follow the ones for Bokeh's <cite>show</cite> function. You can find\nmore about Bokeh at <a class=\"reference external\" href=\"https://bokeh.pydata.org\">https://bokeh.pydata.org</a>.</p>\n",
-      "args": [
-        {
-          "name": "figure",
-          "type_name": "bokeh.plotting.figure.Figure",
-          "is_optional": false,
-          "description": "<p>A Bokeh figure to plot.</p>\n",
-          "default": null
-        },
-        {
-          "name": "use_container_width",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Bokeh's native <cite>width</cite> value.</p>\n",
-          "default": null
-        },
-        {
-          "name": "To show Bokeh charts in Streamlit, call `st.bokeh_chart`",
-          "type_name": null,
-          "is_optional": null,
-          "description": "",
-          "default": null
-        },
-        {
-          "name": "wherever you would call Bokeh's `show`.",
-          "type_name": null,
-          "is_optional": null,
-          "description": "",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.button": {
-      "name": "button",
-      "signature": "element.button(self, label, key=None, help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nif st.button('Say hello'):\n     st.write('Why hello there')\n else:\n     st.write('Goodbye')\n</pre>\n</blockquote>\n",
-      "description": "Display a button widget.",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this button is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed when the button is hovered over.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "bool",
-          "is_generator": false,
-          "description": "<p>If the button was clicked on the last run of the app.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "DeltaGenerator.caption": {
-      "name": "caption",
-      "signature": "element.caption(self, body)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.caption('This is a string that explains something above.')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=SFcBGANWd8kWXF28XnaEZj&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 100px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=SFcBGANWd8kWXF28XnaEZj\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display text in small font.</p>\n<p>This should be used for captions, asides, footnotes, sidenotes, and\nother explanatory text.</p>\n",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The text to display.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.checkbox": {
-      "name": "checkbox",
-      "signature": "element.checkbox(self, label, value=False, key=None, help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nagree = st.checkbox('I agree')\n\nif agree:\n     st.write('Great!')\n</pre>\n</blockquote>\n",
-      "description": "Display a checkbox widget.",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this checkbox is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "value",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>Preselect the checkbox when it first renders. This will be\ncast to bool internally.</p>\n",
-          "default": null
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the checkbox.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "bool",
-          "is_generator": false,
-          "description": "<p>Whether or not the checkbox is checked.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "DeltaGenerator.code": {
-      "name": "code",
-      "signature": "element.code(self, body, language=\"python\")",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\ncode = '''def hello():\n     print(&quot;Hello, Streamlit!&quot;)'''\nst.code(code, language='python')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.27.0-kBtt/index.html?id=VDRnaCEZWSBCNUd5gNQZv2&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 100px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.27.0-kBtt/index.html?id=VDRnaCEZWSBCNUd5gNQZv2\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display a code block with optional syntax highlighting.</p>\n<p>(This is a convenience wrapper around <cite>st.markdown()</cite>)</p>\n",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The string to display as code.</p>\n",
-          "default": null
-        },
-        {
-          "name": "language",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The language that the code is written in, for syntax highlighting.\nIf omitted, the code will be unstyled.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.color_picker": {
-      "name": "color_picker",
-      "signature": "element.color_picker(self, label, value=None, key=None, help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\ncolor = st.color_picker('Pick A Color', '#00f900')\nst.write('The current color is', color)\n</pre>\n</blockquote>\n",
-      "description": "Display a color picker widget.",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this input is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "value",
-          "type_name": "str or None",
-          "is_optional": false,
-          "description": "<p>The hex value of this widget when it first renders. If None,\ndefaults to black.</p>\n",
-          "default": "black."
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the color picker.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "str",
-          "is_generator": false,
-          "description": "<p>The selected color as a hex string.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "DeltaGenerator.dataframe": {
-      "name": "dataframe",
-      "signature": "element.dataframe(self, data=None, width=None, height=None)",
-      "examples": "<blockquote>\n<pre class=\"doctest-block\">\ndf = pd.DataFrame(\n    np.random.randn(50, 20),\n    columns=('col %d' % i for i in range(20)))\n\nst.dataframe(df)  # Same as st.write(df)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=165mJbzWdAC8Duf8a4tjyQ&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 330px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=165mJbzWdAC8Duf8a4tjyQ\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <pre class=\"doctest-block\">\nst.dataframe(df, 200, 100)\n</pre>\n<p>You can also pass a Pandas Styler object to change the style of\nthe rendered DataFrame:</p>\n<pre class=\"doctest-block\">\ndf = pd.DataFrame(\n    np.random.randn(10, 20),\n    columns=('col %d' % i for i in range(20)))\n\nst.dataframe(df.style.highlight_max(axis=0))\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.29.0-dV1Y/index.html?id=Hb6UymSNuZDzojUNybzPby&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 285px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.29.0-dV1Y/index.html?id=Hb6UymSNuZDzojUNybzPby\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "Display a dataframe as an interactive table.",
-      "args": [
-        {
-          "name": "data",
-          "type_name": "pandas.DataFrame, pandas.Styler, numpy.ndarray, Iterable, dict,",
-          "is_optional": false,
-          "description": "<p>or None\nThe data to display.</p>\n<p>If 'data' is a pandas.Styler, it will be used to style its\nunderyling DataFrame. Streamlit supports custom cell\nvalues and colors. (It does not support some of the more exotic\npandas styling features, like bar charts, hovering, and captions.)\nStyler support is experimental!</p>\n",
-          "default": null
-        },
-        {
-          "name": "width",
-          "type_name": "int or None",
-          "is_optional": false,
-          "description": "<p>Desired width of the UI element expressed in pixels. If None, a\ndefault width based on the page width is used.</p>\n",
-          "default": "width"
-        },
-        {
-          "name": "height",
-          "type_name": "int or None",
-          "is_optional": false,
-          "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
-          "default": "height"
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.date_input": {
-      "name": "date_input",
-      "signature": "element.date_input(self, label, value=None, min_value=None, max_value=None, key=None, help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nd = st.date_input(\n     &quot;When's your birthday&quot;,\n     datetime.date(2019, 7, 6))\nst.write('Your birthday is:', d)\n</pre>\n</blockquote>\n",
-      "description": "Display a date input widget.",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this date input is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "value",
-          "type_name": "datetime.date or datetime.datetime or list/tuple of datetime.date or datetime.datetime or None",
-          "is_optional": false,
-          "description": "<p>The value of this widget when it first renders. If a list/tuple with\n0 to 2 date/datetime values is provided, the datepicker will allow\nusers to provide a range. Defaults to today as a single-date picker.</p>\n",
-          "default": "today"
-        },
-        {
-          "name": "min_value",
-          "type_name": "datetime.date or datetime.datetime",
-          "is_optional": false,
-          "description": "<p>The minimum selectable date. Defaults to today-10y.</p>\n",
-          "default": "today-10y."
-        },
-        {
-          "name": "max_value",
-          "type_name": "datetime.date or datetime.datetime",
-          "is_optional": false,
-          "description": "<p>The maximum selectable date. Defaults to today+10y.</p>\n",
-          "default": "today"
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "datetime.date",
-          "is_generator": false,
-          "description": "<p>The current value of the date input widget.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "DeltaGenerator.empty": {
-      "name": "empty",
-      "signature": "element.empty(self)",
-      "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.beta_container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
-      "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
-      "args": [],
-      "returns": []
-    },
-    "DeltaGenerator.error": {
-      "name": "error",
-      "signature": "element.error(self, body)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.error('This is an error')\n</pre>\n</blockquote>\n",
-      "description": "Display error message.",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The error text to display.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.exception": {
-      "name": "exception",
-      "signature": "element.exception(self, exception)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\ne = RuntimeError('This is an exception of type RuntimeError')\nst.exception(e)\n</pre>\n</blockquote>\n",
-      "description": "Display an exception.",
-      "args": [
-        {
-          "name": "exception",
-          "type_name": "Exception",
-          "is_optional": false,
-          "description": "<p>The exception to display.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.file_uploader": {
-      "name": "file_uploader",
-      "signature": "element.file_uploader(self, label, type=None, accept_multiple_files=False, key=None, help=None)",
-      "examples": "<blockquote>\n<p>Insert a file uploader that accepts a single file at a time:</p>\n<pre class=\"doctest-block\">\nuploaded_file = st.file_uploader(&quot;Choose a file&quot;)\nif uploaded_file is not None:\n     # To read file as bytes:\n     bytes_data = uploaded_file.getvalue()\n     st.write(bytes_data)\n\n     # To convert to a string based IO:\n     stringio = StringIO(uploaded_file.getvalue().decode(&quot;utf-8&quot;))\n     st.write(stringio)\n\n     # To read file as string:\n     string_data = stringio.read()\n     st.write(string_data)\n\n     # Can be used wherever a &quot;file-like&quot; object is accepted:\n     dataframe = pd.read_csv(uploaded_file)\n     st.write(dataframe)\n</pre>\n<p>Insert a file uploader that accepts multiple files at a time:</p>\n<pre class=\"doctest-block\">\nuploaded_files = st.file_uploader(&quot;Choose a CSV file&quot;, accept_multiple_files=True)\nfor uploaded_file in uploaded_files:\n     bytes_data = uploaded_file.read()\n     st.write(&quot;filename:&quot;, uploaded_file.name)\n     st.write(bytes_data)\n</pre>\n</blockquote>\n",
-      "description": "<p>Display a file uploader widget.</p>\n<p>By default, uploaded files are limited to 200MB. You can configure\nthis using the <cite>server.maxUploadSize</cite> config option.</p>\n",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this file uploader is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "type",
-          "type_name": "str or list of str or None",
-          "is_optional": false,
-          "description": "<p>Array of allowed extensions. ['png', 'jpg']\nThe default is None, which means all extensions are allowed.</p>\n",
-          "default": "None"
-        },
-        {
-          "name": "accept_multiple_files",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, allows the user to upload multiple files at the same time,\nin which case the return value will be a list of files.\nDefault: False</p>\n",
-          "default": "False"
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the file uploader.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "None or UploadedFile or list of UploadedFile",
-          "is_generator": false,
-          "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "DeltaGenerator.form": {
-      "name": "form",
-      "signature": "element.form(self, key)",
-      "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.form(&quot;my_form&quot;):\n    st.write(&quot;Inside the form&quot;)\n    slider_val = st.slider(&quot;Form slider&quot;)\n    checkbox_val = st.checkbox(&quot;Form checkbox&quot;)\n\n    # Every form must have a submit button.\n    submitted = st.form_submit_button(&quot;Submit&quot;)\n    if submitted:\n        st.write(&quot;slider&quot;, slider_val, &quot;checkbox&quot;, checkbox_val)\n\nst.write(&quot;Outside the form&quot;)\n</pre>\n<p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\nform = st.form(&quot;my_form&quot;)\nform.slider(&quot;Inside the form&quot;)\nst.slider(&quot;Outside the form&quot;)\n\n# Now add a submit button to the form:\nform.form_submit_button(&quot;Submit&quot;)\n</pre>\n</blockquote>\n",
-      "description": "<p>Create a form that batches elements together with a &quot;Submit&quot; button.</p>\n<p>A form is a container that visually groups other elements and\nwidgets together, and contains a Submit button. When the form's\nSubmit button is pressed, all widget values inside the form will be\nsent to Streamlit in a batch.</p>\n<p>To add elements to a form object, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the form. See\nexamples below.</p>\n<p>Forms have a few constraints:</p>\n<ul class=\"simple\">\n<li>Every form must contain a <cite>st.form_submit_button</cite>.</li>\n<li>You cannot add a normal <cite>st.button</cite> to a form.</li>\n<li>Forms can appear anywhere in your app (sidebar, columns, etc),\nbut they cannot be embedded inside other forms.</li>\n</ul>\n<p>For more information about forms, check out our\n<a class=\"reference external\" href=\"https://blog.streamlit.io/introducing-submit-button-and-forms/\">blog post</a>.</p>\n",
-      "args": [
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A string that identifies the form. Each form must have its own\nkey. (This key is not displayed to the user in the interface.)</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.form_submit_button": {
-      "name": "form_submit_button",
-      "signature": "element.form_submit_button(self, label=\"Submit\")",
-      "description": "<p>Display a form submit button.</p>\n<p>When this button is clicked, all widget values inside the form will be\nsent to Streamlit in a batch.</p>\n<p>Every form must have a form_submit_button. A form_submit_button\ncannot exist outside a form.</p>\n<p>For more information about forms, check out our\n<a class=\"reference external\" href=\"https://blog.streamlit.io/introducing-submit-button-and-forms/\">blog post</a>.</p>\n",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this button is for.\nDefaults to &quot;Submit&quot;.</p>\n",
-          "default": "s"
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "bool",
-          "is_generator": false,
-          "description": "<p>True if the submit button was clicked.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "DeltaGenerator.graphviz_chart": {
-      "name": "graphviz_chart",
-      "signature": "element.graphviz_chart(self, figure_or_dot, use_container_width=False)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nimport streamlit as st\nimport graphviz as graphviz\n\n# Create a graphlib graph object\ngraph = graphviz.Digraph()\ngraph.edge('run', 'intr')\ngraph.edge('intr', 'runbl')\ngraph.edge('runbl', 'run')\ngraph.edge('run', 'kernel')\ngraph.edge('kernel', 'zombie')\ngraph.edge('kernel', 'sleep')\ngraph.edge('kernel', 'runmem')\ngraph.edge('sleep', 'swap')\ngraph.edge('swap', 'runswap')\ngraph.edge('runswap', 'new')\ngraph.edge('runswap', 'runmem')\ngraph.edge('new', 'runmem')\ngraph.edge('sleep', 'runmem')\n\nst.graphviz_chart(graph)\n</pre>\n<p>Or you can render the chart from the graph using GraphViz's Dot\nlanguage:</p>\n<pre class=\"doctest-block\">\nst.graphviz_chart('''\n    digraph {\n        run -&gt; intr\n        intr -&gt; runbl\n        runbl -&gt; run\n        run -&gt; kernel\n        kernel -&gt; zombie\n        kernel -&gt; sleep\n        kernel -&gt; runmem\n        sleep -&gt; swap\n        swap -&gt; runswap\n        runswap -&gt; new\n        runswap -&gt; runmem\n        new -&gt; runmem\n        sleep -&gt; runmem\n    }\n''')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.56.0-xTAd/index.html?id=GBn3GXZie5K1kXuBKe4yQL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 400px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.56.0-xTAd/index.html?id=GBn3GXZie5K1kXuBKe4yQL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "Display a graph using the dagre-d3 library.",
-      "args": [
-        {
-          "name": "figure_or_dot",
-          "type_name": "graphviz.dot.Graph, graphviz.dot.Digraph, str",
-          "is_optional": false,
-          "description": "<p>The Graphlib graph object or dot string to display</p>\n",
-          "default": null
-        },
-        {
-          "name": "use_container_width",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.header": {
-      "name": "header",
-      "signature": "element.header(self, body, anchor=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.header('This is a header')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=AnfQVFgSCQtGv6yMUMUYjj&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 100px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=AnfQVFgSCQtGv6yMUMUYjj\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "Display text in header formatting.",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The text to display.</p>\n",
-          "default": null
-        },
-        {
-          "name": "anchor",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.help": {
-      "name": "help",
-      "signature": "element.help(self, obj)",
-      "example": "<blockquote>\n<p>Don't remember how to initialize a dataframe? Try this:</p>\n<pre class=\"doctest-block\">\nst.help(pandas.DataFrame)\n</pre>\n<p>Want to quickly check what datatype is output by a certain function?\nTry:</p>\n<pre class=\"doctest-block\">\nx = my_poorly_documented_function()\nst.help(x)\n</pre>\n</blockquote>\n",
-      "description": "<p>Display object's doc string, nicely formatted.</p>\n<p>Displays the doc string for this object.</p>\n",
-      "args": [
-        {
-          "name": "obj",
-          "type_name": "Object",
-          "is_optional": false,
-          "description": "<p>The object whose docstring should be displayed.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.image": {
-      "name": "image",
-      "signature": "element.image(self, image, caption=None, width=None, use_column_width=None, clamp=False, channels=\"RGB\", output_format=\"auto\")",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nfrom PIL import Image\nimage = Image.open('sunrise.jpg')\n\nst.image(image, caption='Sunrise by the mountains')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.61.0-yRE1/index.html?id=Sn228UQxBfKoE5C7A7Y2Qk&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 630px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.61.0-yRE1/index.html?id=Sn228UQxBfKoE5C7A7Y2Qk\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "Display an image or list of images.",
-      "args": [
-        {
-          "name": "image",
-          "type_name": "numpy.ndarray, [numpy.ndarray], BytesIO, str, or [str]",
-          "is_optional": false,
-          "description": "<p>Monochrome image of shape (w,h) or (w,h,1)\nOR a color image of shape (w,h,3)\nOR an RGBA image of shape (w,h,4)\nOR a URL to fetch the image from\nOR a path of a local image file\nOR an SVG XML string like <cite>&lt;svg xmlns=...&lt;/svg&gt;</cite>\nOR a list of one of the above, to display multiple images.</p>\n",
-          "default": null
-        },
-        {
-          "name": "caption",
-          "type_name": "str or list of str",
-          "is_optional": false,
-          "description": "<p>Image caption. If displaying multiple images, caption should be a\nlist of captions (one for each image).</p>\n",
-          "default": null
-        },
-        {
-          "name": "width",
-          "type_name": "int or None",
-          "is_optional": false,
-          "description": "<p>Image width. None means use the image width,\nbut do not exceed the width of the column.\nShould be set for SVG images, as they have no default image width.</p>\n",
-          "default": "image"
-        },
-        {
-          "name": "use_column_width",
-          "type_name": "'auto' or 'always' or 'never' or bool",
-          "is_optional": false,
-          "description": "<p>If 'auto', set the image's width to its natural size,\nbut do not exceed the width of the column.\nIf 'always' or True, set the image's width to the column width.\nIf 'never' or False, set the image's width to its natural size.\nNote: if set, <cite>use_column_width</cite> takes precedence over the <cite>width</cite> parameter.</p>\n",
-          "default": null
-        },
-        {
-          "name": "clamp",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>Clamp image pixel values to a valid range ([0-255] per channel).\nThis is only meaningful for byte array images; the parameter is\nignored for image URLs. If this is not set, and an image has an\nout-of-range value, an error will be thrown.</p>\n",
-          "default": null
-        },
-        {
-          "name": "channels",
-          "type_name": "'RGB' or 'BGR'",
-          "is_optional": false,
-          "description": "<p>If image is an nd.array, this parameter denotes the format used to\nrepresent color information. Defaults to 'RGB', meaning\n<cite>image[:, :, 0]</cite> is the red channel, <cite>image[:, :, 1]</cite> is green, and\n<cite>image[:, :, 2]</cite> is blue. For images coming from libraries like\nOpenCV you should set this to 'BGR', instead.</p>\n",
-          "default": "s"
-        },
-        {
-          "name": "output_format",
-          "type_name": "'JPEG', 'PNG', or 'auto'",
-          "is_optional": false,
-          "description": "<p>This parameter specifies the format to use when transferring the\nimage data. Photos should use the JPEG format for lossy compression\nwhile diagrams should use the PNG format for lossless compression.\nDefaults to 'auto' which identifies the compression type based\non the type and format of the image argument.</p>\n",
-          "default": "s"
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.info": {
-      "name": "info",
-      "signature": "element.info(self, body)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.info('This is a purely informational message')\n</pre>\n</blockquote>\n",
-      "description": "Display an informational message.",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The info text to display.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.json": {
-      "name": "json",
-      "signature": "element.json(self, body)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.json({\n     'foo': 'bar',\n     'baz': 'boz',\n     'stuff': [\n         'stuff 1',\n         'stuff 2',\n         'stuff 3',\n         'stuff 5',\n     ],\n })\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=CTFkMQd89hw3yZbZ4AUymS&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 280px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=CTFkMQd89hw3yZbZ4AUymS\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "Display object or string as a pretty-printed JSON string.",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "Object or str",
-          "is_optional": false,
-          "description": "<p>The object to print as JSON. All referenced objects should be\nserializable to JSON as well. If object is a string, we assume it\ncontains serialized JSON.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.latex": {
-      "name": "latex",
-      "signature": "element.latex(self, body)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.latex(r'''\n     a + ar + a r^2 + a r^3 + \\cdots + a r^{n-1} =\n     \\sum_{k=0}^{n-1} ar^k =\n     a \\left(\\frac{1-r^{n}}{1-r}\\right)\n     ''')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.50.0-td2L/index.html?id=NJFsy6NbGTsH2RF9W6ioQ4&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 75px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.50.0-td2L/index.html?id=NJFsy6NbGTsH2RF9W6ioQ4\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display mathematical expressions formatted as LaTeX.</p>\n<p>Supported LaTeX functions are listed at\n<a class=\"reference external\" href=\"https://katex.org/docs/supported.html\">https://katex.org/docs/supported.html</a>.</p>\n",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str or SymPy expression",
-          "is_optional": false,
-          "description": "<p>The string or SymPy expression to display as LaTeX. If str, it's\na good idea to use raw Python strings since LaTeX uses backslashes\na lot.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.line_chart": {
-      "name": "line_chart",
-      "signature": "element.line_chart(self, data=None, width=0, height=0, use_container_width=True)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nchart_data = pd.DataFrame(\n     np.random.randn(20, 3),\n     columns=['a', 'b', 'c'])\n\nst.line_chart(chart_data)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.50.0-td2L/index.html?id=BdxXG3MmrVBfJyqS2R2ki8&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 220px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.50.0-td2L/index.html?id=BdxXG3MmrVBfJyqS2R2ki8\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display a line chart.</p>\n<p>This is syntax-sugar around st.altair_chart. The main difference\nis this command uses the data's own column and indices to figure out\nthe chart's spec. As a result this is easier to use for many &quot;just plot\nthis&quot; scenarios, while being less customizable.</p>\n<p>If st.line_chart does not guess the data specification\ncorrectly, try specifying your desired chart using st.altair_chart.</p>\n",
-      "args": [
-        {
-          "name": "data",
-          "type_name": "pandas.DataFrame, pandas.Styler, numpy.ndarray, Iterable, dict",
-          "is_optional": false,
-          "description": "<p>or None\nData to be plotted.</p>\n",
-          "default": null
-        },
-        {
-          "name": "width",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The chart width in pixels. If 0, selects the width automatically.</p>\n",
-          "default": null
-        },
-        {
-          "name": "height",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The chart width in pixels. If 0, selects the height automatically.</p>\n",
-          "default": null
-        },
-        {
-          "name": "use_container_width",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the width argument.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.map": {
-      "name": "map",
-      "signature": "element.map(self, data=None, zoom=None, use_container_width=True)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nimport pandas as pd\nimport numpy as np\n\ndf = pd.DataFrame(\n     np.random.randn(1000, 2) / [50, 50] + [37.76, -122.4],\n     columns=['lat', 'lon'])\n\nst.map(df)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.53.0-SULT/index.html?id=9gTiomqPEbvHY2huTLoQtH&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 600px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.53.0-SULT/index.html?id=9gTiomqPEbvHY2huTLoQtH\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display a map with points on it.</p>\n<p>This is a wrapper around st.pydeck_chart to quickly create scatterplot\ncharts on top of a map, with auto-centering and auto-zoom.</p>\n<p>When using this command, we advise all users to use a personal Mapbox\ntoken. This ensures the map tiles used in this chart are more\nrobust. You can do this with the mapbox.token config option.</p>\n<p>To get a token for yourself, create an account at\n<a class=\"reference external\" href=\"https://mapbox.com\">https://mapbox.com</a>. It's free! (for moderate usage levels) See\n<a class=\"reference external\" href=\"https://docs.streamlit.io/en/latest/cli.html#view-all-config-options\">https://docs.streamlit.io/en/latest/cli.html#view-all-config-options</a> for more\ninfo on how to set config options.</p>\n",
-      "args": [
-        {
-          "name": "data",
-          "type_name": "pandas.DataFrame, pandas.Styler, numpy.ndarray, Iterable, dict,",
-          "is_optional": false,
-          "description": "<p>or None\nThe data to be plotted. Must have columns called 'lat', 'lon',\n'latitude', or 'longitude'.</p>\n",
-          "default": null
-        },
-        {
-          "name": "zoom",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>Zoom level as specified in\n<a class=\"reference external\" href=\"https://wiki.openstreetmap.org/wiki/Zoom_levels\">https://wiki.openstreetmap.org/wiki/Zoom_levels</a></p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.markdown": {
-      "name": "markdown",
-      "signature": "element.markdown(self, body, unsafe_allow_html=False)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.markdown('Streamlit is **_really_ cool**.')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=PXz9xgY8aB88eziDVEZLyS&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 50px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=PXz9xgY8aB88eziDVEZLyS\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "Display string formatted as Markdown.",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The string to display as Github-flavored Markdown. Syntax\ninformation can be found at: <a class=\"reference external\" href=\"https://github.github.com/gfm\">https://github.github.com/gfm</a>.</p>\n<p>This also supports:</p>\n<ul class=\"simple\">\n<li>Emoji shortcodes, such as <cite>:+1:</cite>  and <cite>:sunglasses:</cite>.\nFor a list of all supported codes,\nsee <a class=\"reference external\" href=\"https://raw.githubusercontent.com/omnidan/node-emoji/master/lib/emoji.json\">https://raw.githubusercontent.com/omnidan/node-emoji/master/lib/emoji.json</a>.</li>\n<li>LaTeX expressions, by wrapping them in &quot;$&quot; or &quot;$$&quot; (the &quot;$$&quot;\nmust be on their own lines). Supported LaTeX functions are listed\nat <a class=\"reference external\" href=\"https://katex.org/docs/supported.html\">https://katex.org/docs/supported.html</a>.</li>\n</ul>\n",
-          "default": null
-        },
-        {
-          "name": "unsafe_allow_html",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>By default, any HTML tags found in the body will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, we <em>strongly advise against it</em>. It is hard to write\nsecure HTML, so by using this argument you may be compromising your\nusers' security. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><em>Also note that `unsafe_allow_html` is a temporary measure and may\nbe removed from Streamlit at any time.</em></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us\nyour exact use case here:</p>\n<p><a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a></p>\n<p>This will help us come up with safe APIs that allow you to do what\nyou want.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.multiselect": {
-      "name": "multiselect",
-      "signature": "element.multiselect(self, label, options, default=None, format_func=special_internal_function, key=None, help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\noptions = st.multiselect(\n     'What are your favorite colors',\n     ['Green', 'Yellow', 'Red', 'Blue'],\n     ['Yellow', 'Red'])\n\nst.write('You selected:', options)\n</pre>\n<div class=\"admonition note\">\n<p class=\"first admonition-title\">Note</p>\n<p class=\"last\">User experience can be degraded for large lists of <cite>options</cite> (100+), as this widget\nis not designed to handle arbitrary text search efficiently. See this\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/streamlit-loading-column-data-takes-too-much-time/1791\">thread</a>\non the Streamlit community forum for more information and\n<a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/1059\">GitHub issue #1059</a> for updates on the issue.</p>\n</div>\n</blockquote>\n",
-      "description": "<p>Display a multiselect widget.</p>\n<p>The multiselect widget starts as empty.</p>\n",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this select widget is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "options",
-          "type_name": "list, tuple, numpy.ndarray, pandas.Series, or pandas.DataFrame",
-          "is_optional": false,
-          "description": "<p>Labels for the select options. This will be cast to str internally\nby default. For pandas.DataFrame, the first column is selected.</p>\n",
-          "default": "."
-        },
-        {
-          "name": "default",
-          "type_name": "[str] or None",
-          "is_optional": false,
-          "description": "<p>List of default values.</p>\n",
-          "default": "values."
-        },
-        {
-          "name": "format_func",
-          "type_name": "function",
-          "is_optional": false,
-          "description": "<p>Function to modify the display of selectbox options. It receives\nthe raw option as an argument and should output the label to be\nshown for that option. This has no impact on the return value of\nthe selectbox.</p>\n",
-          "default": null
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the multiselect.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "[str]",
-          "is_generator": false,
-          "description": "<p>A list with the selected options</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "DeltaGenerator.number_input": {
-      "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7fd8494723d0>, step=None, format=None, key=None, help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
-      "description": "Display a numeric input widget.",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this input is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "min_value",
-          "type_name": "int or float or None",
-          "is_optional": false,
-          "description": "<p>The minimum permitted value.\nIf None, there will be no minimum.</p>\n",
-          "default": null
-        },
-        {
-          "name": "max_value",
-          "type_name": "int or float or None",
-          "is_optional": false,
-          "description": "<p>The maximum permitted value.\nIf None, there will be no maximum.</p>\n",
-          "default": null
-        },
-        {
-          "name": "value",
-          "type_name": "int or float or None",
-          "is_optional": false,
-          "description": "<p>The value of this widget when it first renders.\nDefaults to min_value, or 0.0 if min_value is None</p>\n",
-          "default": "min_value"
-        },
-        {
-          "name": "step",
-          "type_name": "int or float or None",
-          "is_optional": false,
-          "description": "<p>The stepping interval.\nDefaults to 1 if the value is an int, 0.01 otherwise.\nIf the value is not specified, the format parameter will be used.</p>\n",
-          "default": "1"
-        },
-        {
-          "name": "format",
-          "type_name": "str or None",
-          "is_optional": false,
-          "description": "<p>A printf-style format string controlling how the interface should\ndisplay numbers. Output must be purely numeric. This does not impact\nthe return value. Valid formatters: %d %e %f %g %i %u</p>\n",
-          "default": null
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "int or float",
-          "is_generator": false,
-          "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "DeltaGenerator.plotly_chart": {
-      "name": "plotly_chart",
-      "signature": "element.plotly_chart(self, figure_or_data, use_container_width=False, sharing=\"streamlit\", **kwargs)",
-      "example": "<blockquote>\n<p>The example below comes straight from the examples at\n<a class=\"reference external\" href=\"https://plot.ly/python\">https://plot.ly/python</a>:</p>\n<pre class=\"doctest-block\">\nimport streamlit as st\nimport plotly.figure_factory as ff\nimport numpy as np\n\n# Add histogram data\nx1 = np.random.randn(200) - 2\nx2 = np.random.randn(200)\nx3 = np.random.randn(200) + 2\n\n# Group data together\nhist_data = [x1, x2, x3]\n\ngroup_labels = ['Group 1', 'Group 2', 'Group 3']\n\n# Create distplot with custom bin_size\nfig = ff.create_distplot(\n         hist_data, group_labels, bin_size=[.1, .25, .5])\n\n# Plot!\nst.plotly_chart(fig, use_container_width=True)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.56.0-xTAd/index.html?id=TuP96xX8JnsoQeUGAPjkGQ&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 400px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.56.0-xTAd/index.html?id=TuP96xX8JnsoQeUGAPjkGQ\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display an interactive Plotly chart.</p>\n<p>Plotly is a charting library for Python. The arguments to this function\nclosely follow the ones for Plotly's <cite>plot()</cite> function. You can find\nmore about Plotly at <a class=\"reference external\" href=\"https://plot.ly/python\">https://plot.ly/python</a>.</p>\n",
-      "args": [
-        {
-          "name": "figure_or_data",
-          "type_name": "plotly.graph_objs.Figure, plotly.graph_objs.Data,",
-          "is_optional": false,
-          "description": "<p>dict/list of plotly.graph_objs.Figure/Data</p>\n<p>See <a class=\"reference external\" href=\"https://plot.ly/python/\">https://plot.ly/python/</a> for examples of graph descriptions.</p>\n",
-          "default": null
-        },
-        {
-          "name": "use_container_width",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over the figure's native <cite>width</cite> value.</p>\n",
-          "default": null
-        },
-        {
-          "name": "sharing",
-          "type_name": "{'streamlit', 'private', 'secret', 'public'}",
-          "is_optional": false,
-          "description": "<p>Use 'streamlit' to insert the plot and all its dependencies\ndirectly in the Streamlit app using plotly's offline mode (default).\nUse any other sharing mode to send the chart to Plotly chart studio, which\nrequires an account. See <a class=\"reference external\" href=\"https://plotly.com/chart-studio/\">https://plotly.com/chart-studio/</a> for more information.</p>\n",
-          "default": null
-        },
-        {
-          "name": "**kwargs",
-          "type_name": null,
-          "is_optional": null,
-          "description": "<p>Any argument accepted by Plotly's <cite>plot()</cite> function.</p>\n",
-          "default": null
-        },
-        {
-          "name": "To show Plotly charts in Streamlit, call `st.plotly_chart`",
-          "type_name": null,
-          "is_optional": null,
-          "description": "",
-          "default": null
-        },
-        {
-          "name": "wherever you would call Plotly's `py.plot` or `py.iplot`.",
-          "type_name": null,
-          "is_optional": null,
-          "description": "",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.progress": {
-      "name": "progress",
-      "signature": "element.progress(self, value)",
-      "example": "<blockquote>\n<p>Here is an example of a progress bar increasing over time:</p>\n<pre class=\"doctest-block\">\nimport time\n\nmy_bar = st.progress(0)\n\nfor percent_complete in range(100):\n     time.sleep(0.1)\n     my_bar.progress(percent_complete + 1)\n</pre>\n</blockquote>\n",
-      "description": "Display a progress bar.",
-      "args": [
-        {
-          "name": "value",
-          "type_name": "int or float",
-          "is_optional": false,
-          "description": "<p>0 &lt;= value &lt;= 100 for int</p>\n<p>0.0 &lt;= value &lt;= 1.0 for float</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.pydeck_chart": {
-      "name": "pydeck_chart",
-      "signature": "element.pydeck_chart(self, pydeck_obj=None, use_container_width=False)",
-      "example": "<blockquote>\n<p>Here's a chart using a HexagonLayer and a ScatterplotLayer on top of\nthe light map style:</p>\n<pre class=\"doctest-block\">\ndf = pd.DataFrame(\n    np.random.randn(1000, 2) / [50, 50] + [37.76, -122.4],\n    columns=['lat', 'lon'])\n\nst.pydeck_chart(pdk.Deck(\n     map_style='mapbox://styles/mapbox/light-v9',\n     initial_view_state=pdk.ViewState(\n         latitude=37.76,\n         longitude=-122.4,\n         zoom=11,\n         pitch=50,\n     ),\n     layers=[\n         pdk.Layer(\n            'HexagonLayer',\n            data=df,\n            get_position='[lon, lat]',\n            radius=200,\n            elevation_scale=4,\n            elevation_range=[0, 1000],\n            pickable=True,\n            extruded=True,\n         ),\n         pdk.Layer(\n             'ScatterplotLayer',\n             data=df,\n             get_position='[lon, lat]',\n             get_color='[200, 30, 0, 160]',\n             get_radius=200,\n         ),\n     ],\n ))\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=ASTdExBpJ1WxbGceneKN1i&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 530px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=ASTdExBpJ1WxbGceneKN1i\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Draw a chart using the PyDeck library.</p>\n<p>This supports 3D maps, point clouds, and more! More info about PyDeck\nat <a class=\"reference external\" href=\"https://deckgl.readthedocs.io/en/latest/\">https://deckgl.readthedocs.io/en/latest/</a>.</p>\n<p>These docs are also quite useful:</p>\n<ul class=\"simple\">\n<li>DeckGL docs: <a class=\"reference external\" href=\"https://github.com/uber/deck.gl/tree/master/docs\">https://github.com/uber/deck.gl/tree/master/docs</a></li>\n<li>DeckGL JSON docs: <a class=\"reference external\" href=\"https://github.com/uber/deck.gl/tree/master/modules/json\">https://github.com/uber/deck.gl/tree/master/modules/json</a></li>\n</ul>\n<p>When using this command, we advise all users to use a personal Mapbox\ntoken. This ensures the map tiles used in this chart are more\nrobust. You can do this with the mapbox.token config option.</p>\n<p>To get a token for yourself, create an account at\n<a class=\"reference external\" href=\"https://mapbox.com\">https://mapbox.com</a>. It's free! (for moderate usage levels) See\n<a class=\"reference external\" href=\"https://docs.streamlit.io/en/latest/cli.html#view-all-config-options\">https://docs.streamlit.io/en/latest/cli.html#view-all-config-options</a> for more\ninfo on how to set config options.</p>\n",
-      "args": [
-        {
-          "name": "spec",
-          "type_name": "pydeck.Deck or None",
-          "is_optional": false,
-          "description": "<p>Object specifying the PyDeck chart to draw.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.pyplot": {
-      "name": "pyplot",
-      "signature": "element.pyplot(self, fig=None, clear_figure=None, **kwargs)",
-      "notes": "<blockquote>\n<div class=\"admonition note\">\n<p class=\"first admonition-title\">Note</p>\n<p class=\"last\">Deprecation warning. After December 1st, 2020, we will remove the ability\nto specify no arguments in <cite>st.pyplot()</cite>, as that requires the use of\nMatplotlib's global figure object, which is not thread-safe. So\nplease always pass a figure object as shown in the example section\nabove.</p>\n</div>\n<p>Matplotlib support several different types of &quot;backends&quot;. If you're\ngetting an error using Matplotlib with Streamlit, try setting your\nbackend to &quot;TkAgg&quot;:</p>\n<pre class=\"literal-block\">\necho &quot;backend: TkAgg&quot; &gt;&gt; ~/.matplotlib/matplotlibrc\n</pre>\n<p>For more information, see <a class=\"reference external\" href=\"https://matplotlib.org/faq/usage_faq.html\">https://matplotlib.org/faq/usage_faq.html</a>.</p>\n</blockquote>\n",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nimport matplotlib.pyplot as plt\nimport numpy as np\n\narr = np.random.normal(1, 1, size=100)\nfig, ax = plt.subplots()\nax.hist(arr, bins=20)\n\nst.pyplot(fig)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=PwzFN7oLZsvb6HDdwdjkRB&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 530px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=PwzFN7oLZsvb6HDdwdjkRB\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "Display a matplotlib.pyplot figure.",
-      "args": [
-        {
-          "name": "fig",
-          "type_name": "Matplotlib Figure",
-          "is_optional": false,
-          "description": "<p>The figure to plot. When this argument isn't specified, this\nfunction will render the global figure (but this is deprecated,\nas described below)</p>\n",
-          "default": null
-        },
-        {
-          "name": "clear_figure",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, the figure will be cleared after being rendered.\nIf False, the figure will not be cleared after being rendered.\nIf left unspecified, we pick a default based on the value of <cite>fig</cite>.</p>\n<ul class=\"simple\">\n<li>If <cite>fig</cite> is set, defaults to <cite>False</cite>.</li>\n<li>If <cite>fig</cite> is not set, defaults to <cite>True</cite>. This simulates Jupyter's\napproach to matplotlib rendering.</li>\n</ul>\n",
-          "default": "based"
-        },
-        {
-          "name": "**kwargs",
-          "type_name": "any",
-          "is_optional": false,
-          "description": "<p>Arguments to pass to Matplotlib's savefig function.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.radio": {
-      "name": "radio",
-      "signature": "element.radio(self, label, options, index=0, format_func=special_internal_function, key=None, help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\ngenre = st.radio(\n     &quot;What's your favorite movie genre&quot;,\n     ('Comedy', 'Drama', 'Documentary'))\n\nif genre == 'Comedy':\n     st.write('You selected comedy.')\n else:\n     st.write(&quot;You didn't select comedy.&quot;)\n</pre>\n</blockquote>\n",
-      "description": "Display a radio button widget.",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this radio group is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "options",
-          "type_name": "list, tuple, numpy.ndarray, pandas.Series, or pandas.DataFrame",
-          "is_optional": false,
-          "description": "<p>Labels for the radio options. This will be cast to str internally\nby default. For pandas.DataFrame, the first column is selected.</p>\n",
-          "default": "."
-        },
-        {
-          "name": "index",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The index of the preselected option on first render.</p>\n",
-          "default": null
-        },
-        {
-          "name": "format_func",
-          "type_name": "function",
-          "is_optional": false,
-          "description": "<p>Function to modify the display of radio options. It receives\nthe raw option as an argument and should output the label to be\nshown for that option. This has no impact on the return value of\nthe radio.</p>\n",
-          "default": null
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the radio.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "any",
-          "is_generator": false,
-          "description": "<p>The selected option.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "DeltaGenerator.select_slider": {
-      "name": "select_slider",
-      "signature": "element.select_slider(self, label, options=[], value=None, format_func=special_internal_function, key=None, help=None)",
-      "examples": "<pre class=\"doctest-block\">\ncolor = st.select_slider(\n     'Select a color of the rainbow',\n     options=['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet'])\nst.write('My favorite color is', color)\n</pre>\n<p>And here's an example of a range select slider:</p>\n<pre class=\"doctest-block\">\nstart_color, end_color = st.select_slider(\n     'Select a range of color wavelength',\n     options=['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet'],\n     value=('red', 'blue'))\nst.write('You selected wavelengths between', start_color, 'and', end_color)\n</pre>\n",
-      "description": "<p>Display a slider widget to select items from a list.</p>\n<p>This also allows you to render a range slider by passing a two-element\ntuple or list as the <cite>value</cite>.</p>\n<p>The difference between <cite>st.select_slider</cite> and <cite>st.slider</cite> is that\n<cite>select_slider</cite> accepts any datatype and takes an iterable set of\noptions, while <cite>slider</cite> only accepts numerical or date/time data and\ntakes a range as input.</p>\n",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this slider is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "options",
-          "type_name": "list, tuple, numpy.ndarray, pandas.Series, or pandas.DataFrame",
-          "is_optional": false,
-          "description": "<p>Labels for the slider options. All options will be cast to str\ninternally by default. For pandas.DataFrame, the first column is\nselected.</p>\n",
-          "default": "."
-        },
-        {
-          "name": "value",
-          "type_name": "a supported type or a tuple/list of supported types or None",
-          "is_optional": false,
-          "description": "<p>The value of the slider when it first renders. If a tuple/list\nof two values is passed here, then a range slider with those lower\nand upper bounds is rendered. For example, if set to <cite>(1, 10)</cite> the\nslider will have a selectable range between 1 and 10.\nDefaults to first option.</p>\n",
-          "default": "first"
-        },
-        {
-          "name": "format_func",
-          "type_name": "function",
-          "is_optional": false,
-          "description": "<p>Function to modify the display of the labels from the options.\nargument. It receives the option as an argument and its output\nwill be cast to str.</p>\n",
-          "default": null
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the select slider.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "any value or tuple of any value",
-          "is_generator": false,
-          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "DeltaGenerator.selectbox": {
-      "name": "selectbox",
-      "signature": "element.selectbox(self, label, options, index=0, format_func=special_internal_function, key=None, help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\noption = st.selectbox(\n     'How would you like to be contacted?',\n     ('Email', 'Home phone', 'Mobile phone'))\n\nst.write('You selected:', option)\n</pre>\n</blockquote>\n",
-      "description": "Display a select widget.",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this select widget is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "options",
-          "type_name": "list, tuple, numpy.ndarray, pandas.Series, or pandas.DataFrame",
-          "is_optional": false,
-          "description": "<p>Labels for the select options. This will be cast to str internally\nby default. For pandas.DataFrame, the first column is selected.</p>\n",
-          "default": "."
-        },
-        {
-          "name": "index",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The index of the preselected option on first render.</p>\n",
-          "default": null
-        },
-        {
-          "name": "format_func",
-          "type_name": "function",
-          "is_optional": false,
-          "description": "<p>Function to modify the display of the labels. It receives the option\nas an argument and its output will be cast to str.</p>\n",
-          "default": null
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the selectbox.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "any",
-          "is_generator": false,
-          "description": "<p>The selected option</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "DeltaGenerator.slider": {
-      "name": "slider",
-      "signature": "element.slider(self, label, min_value=None, max_value=None, value=None, step=None, format=None, key=None, help=None)",
-      "examples": "<blockquote>\n<pre class=\"doctest-block\">\nage = st.slider('How old are you?', 0, 130, 25)\nst.write(&quot;I'm &quot;, age, 'years old')\n</pre>\n<p>And here's an example of a range slider:</p>\n<pre class=\"doctest-block\">\nvalues = st.slider(\n     'Select a range of values',\n     0.0, 100.0, (25.0, 75.0))\nst.write('Values:', values)\n</pre>\n<p>This is a range time slider:</p>\n<pre class=\"doctest-block\">\nfrom datetime import time\nappointment = st.slider(\n     &quot;Schedule your appointment:&quot;,\n     value=(time(11, 30), time(12, 45)))\nst.write(&quot;You're scheduled for:&quot;, appointment)\n</pre>\n<p>Finally, a datetime slider:</p>\n<pre class=\"doctest-block\">\nfrom datetime import datetime\nstart_time = st.slider(\n     &quot;When do you start?&quot;,\n     value=datetime(2020, 1, 1, 9, 30),\n     format=&quot;MM/DD/YY - hh:mm&quot;)\nst.write(&quot;Start time:&quot;, start_time)\n</pre>\n</blockquote>\n",
-      "description": "<p>Display a slider widget.</p>\n<p>This supports int, float, date, time, and datetime types.</p>\n<p>This also allows you to render a range slider by passing a two-element\ntuple or list as the <cite>value</cite>.</p>\n<p>The difference between <cite>st.slider</cite> and <cite>st.select_slider</cite> is that\n<cite>slider</cite> only accepts numerical or date/time data and takes a range as\ninput, while <cite>select_slider</cite> accepts any datatype and takes an iterable\nset of options.</p>\n",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this slider is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "min_value",
-          "type_name": "a supported type or None",
-          "is_optional": false,
-          "description": "<p>The minimum permitted value.\nDefaults to 0 if the value is an int, 0.0 if a float,\nvalue - timedelta(days=14) if a date/datetime, time.min if a time</p>\n",
-          "default": "0"
-        },
-        {
-          "name": "max_value",
-          "type_name": "a supported type or None",
-          "is_optional": false,
-          "description": "<p>The maximum permitted value.\nDefaults to 100 if the value is an int, 1.0 if a float,\nvalue + timedelta(days=14) if a date/datetime, time.max if a time</p>\n",
-          "default": "100"
-        },
-        {
-          "name": "value",
-          "type_name": "a supported type or a tuple/list of supported types or None",
-          "is_optional": false,
-          "description": "<p>The value of the slider when it first renders. If a tuple/list\nof two values is passed here, then a range slider with those lower\nand upper bounds is rendered. For example, if set to <cite>(1, 10)</cite> the\nslider will have a selectable range between 1 and 10.\nDefaults to min_value.</p>\n",
-          "default": "min_value."
-        },
-        {
-          "name": "step",
-          "type_name": "int/float/timedelta or None",
-          "is_optional": false,
-          "description": "<p>The stepping interval.\nDefaults to 1 if the value is an int, 0.01 if a float,\ntimedelta(days=1) if a date/datetime, timedelta(minutes=15) if a time\n(or if max_value - min_value &lt; 1 day)</p>\n",
-          "default": "1"
-        },
-        {
-          "name": "format",
-          "type_name": "str or None",
-          "is_optional": false,
-          "description": "<p>A printf-style format string controlling how the interface should\ndisplay numbers. This does not impact the return value.\nFormatter for int/float supports: %d %e %f %g %i\nFormatter for date/time/datetime uses Moment.js notation:\n<a class=\"reference external\" href=\"https://momentjs.com/docs/#/displaying/format/\">https://momentjs.com/docs/#/displaying/format/</a></p>\n",
-          "default": null
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the slider.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "int/float/date/time/datetime or tuple of int/float/date/time/datetime",
-          "is_generator": false,
-          "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "DeltaGenerator.subheader": {
-      "name": "subheader",
-      "signature": "element.subheader(self, body, anchor=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.subheader('This is a subheader')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=LBKJTfFUwudrbWENSHV6cJ&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 100px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=LBKJTfFUwudrbWENSHV6cJ\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "Display text in subheader formatting.",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The text to display.</p>\n",
-          "default": null
-        },
-        {
-          "name": "anchor",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.success": {
-      "name": "success",
-      "signature": "element.success(self, body)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.success('This is a success message!')\n</pre>\n</blockquote>\n",
-      "description": "Display a success message.",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The success text to display.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.table": {
-      "name": "table",
-      "signature": "element.table(self, data=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\ndf = pd.DataFrame(\n    np.random.randn(10, 5),\n    columns=('col %d' % i for i in range(5)))\n\nst.table(df)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=KfZvDMprL4JFKXbpjD3fpq&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 480px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=KfZvDMprL4JFKXbpjD3fpq\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display a static table.</p>\n<p>This differs from <cite>st.dataframe</cite> in that the table in this case is\nstatic: its entire contents are laid out directly on the page.</p>\n",
-      "args": [
-        {
-          "name": "data",
-          "type_name": "pandas.DataFrame, pandas.Styler, numpy.ndarray, Iterable, dict,",
-          "is_optional": false,
-          "description": "<p>or None\nThe table data.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.text": {
-      "name": "text",
-      "signature": "element.text(self, body)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.text('This is some text.')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=PYxU1kee5ubuhGR11NsnT1&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 50px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=PYxU1kee5ubuhGR11NsnT1\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "Write fixed-width and preformatted text.",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The string to display.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.text_area": {
-      "name": "text_area",
-      "signature": "element.text_area(self, label, value=\"\", height=None, max_chars=None, key=None, help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\ntxt = st.text_area('Text to analyze', '''\n     It was the best of times, it was the worst of times, it was\n     the age of wisdom, it was the age of foolishness, it was\n     the epoch of belief, it was the epoch of incredulity, it\n     was the season of Light, it was the season of Darkness, it\n     was the spring of hope, it was the winter of despair, (...)\n     ''')\nst.write('Sentiment:', run_sentiment_analysis(txt))\n</pre>\n</blockquote>\n",
-      "description": "Display a multi-line text input widget.",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this input is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "value",
-          "type_name": "any",
-          "is_optional": false,
-          "description": "<p>The text value of this widget when it first renders. This will be\ncast to str internally.</p>\n",
-          "default": null
-        },
-        {
-          "name": "height",
-          "type_name": "int or None",
-          "is_optional": false,
-          "description": "<p>Desired height of the UI element expressed in pixels. If None, a\ndefault height is used.</p>\n",
-          "default": "height"
-        },
-        {
-          "name": "max_chars",
-          "type_name": "int or None",
-          "is_optional": false,
-          "description": "<p>Maximum number of characters allowed in text area.</p>\n",
-          "default": null
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the textarea.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "str",
-          "is_generator": false,
-          "description": "<p>The current value of the text input widget.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "DeltaGenerator.text_input": {
-      "name": "text_input",
-      "signature": "element.text_input(self, label, value=\"\", max_chars=None, key=None, type=\"default\", help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\ntitle = st.text_input('Movie title', 'Life of Brian')\nst.write('The current movie title is', title)\n</pre>\n</blockquote>\n",
-      "description": "Display a single-line text input widget.",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this input is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "value",
-          "type_name": "any",
-          "is_optional": false,
-          "description": "<p>The text value of this widget when it first renders. This will be\ncast to str internally.</p>\n",
-          "default": null
-        },
-        {
-          "name": "max_chars",
-          "type_name": "int or None",
-          "is_optional": false,
-          "description": "<p>Max number of characters allowed in text input.</p>\n",
-          "default": null
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "type",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The type of the text input. This can be either &quot;default&quot; (for\na regular text input), or &quot;password&quot; (for a text input that\nmasks the user's typed value). Defaults to &quot;default&quot;.</p>\n",
-          "default": "s"
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "str",
-          "is_generator": false,
-          "description": "<p>The current value of the text input widget.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "DeltaGenerator.time_input": {
-      "name": "time_input",
-      "signature": "element.time_input(self, label, value=None, key=None, help=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nt = st.time_input('Set an alarm for', datetime.time(8, 45))\nst.write('Alarm is set for', t)\n</pre>\n</blockquote>\n",
-      "description": "Display a time input widget.",
-      "args": [
-        {
-          "name": "label",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short label explaining to the user what this time input is for.</p>\n",
-          "default": null
-        },
-        {
-          "name": "value",
-          "type_name": "datetime.time/datetime.datetime",
-          "is_optional": false,
-          "description": "<p>The value of this widget when it first renders. This will be\ncast to str internally. Defaults to the current time.</p>\n",
-          "default": "the"
-        },
-        {
-          "name": "key",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>An optional string to use as the unique key for the widget.\nIf this is omitted, a key will be generated for the widget\nbased on its content. Multiple widgets of the same type may\nnot share the same key.</p>\n",
-          "default": null
-        },
-        {
-          "name": "help",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A tooltip that gets displayed next to the input.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "datetime.time",
-          "is_generator": false,
-          "description": "<p>The current value of the time input widget.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "DeltaGenerator.title": {
-      "name": "title",
-      "signature": "element.title(self, body, anchor=None)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.title('This is a title')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=SFcBGANWd8kWXF28XnaEZj&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 100px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=SFcBGANWd8kWXF28XnaEZj\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Display text in title formatting.</p>\n<p>Each document should have a single <cite>st.title()</cite>, although this is not\nenforced.</p>\n",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The text to display.</p>\n",
-          "default": null
-        },
-        {
-          "name": "anchor",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The anchor name of the header that can be accessed with #anchor\nin the URL. If omitted, it generates an anchor using the body.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.vega_lite_chart": {
-      "name": "vega_lite_chart",
-      "signature": "element.vega_lite_chart(self, data=None, spec=None, use_container_width=False, **kwargs)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nimport pandas as pd\nimport numpy as np\n\ndf = pd.DataFrame(\n     np.random.randn(200, 3),\n     columns=['a', 'b', 'c'])\n\nst.vega_lite_chart(df, {\n     'mark': {'type': 'circle', 'tooltip': True},\n     'encoding': {\n         'x': {'field': 'a', 'type': 'quantitative'},\n         'y': {'field': 'b', 'type': 'quantitative'},\n         'size': {'field': 'c', 'type': 'quantitative'},\n         'color': {'field': 'c', 'type': 'quantitative'},\n     },\n })\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 200px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Examples of Vega-Lite usage without Streamlit can be found at\n<a class=\"reference external\" href=\"https://vega.github.io/vega-lite/examples/\">https://vega.github.io/vega-lite/examples/</a>. Most of those can be easily\ntranslated to the syntax shown above.</p>\n</blockquote>\n",
-      "description": "Display a chart using the Vega-Lite library.",
-      "args": [
-        {
-          "name": "data",
-          "type_name": "pandas.DataFrame, pandas.Styler, numpy.ndarray, Iterable, dict,",
-          "is_optional": false,
-          "description": "<p>or None\nEither the data to be plotted or a Vega-Lite spec containing the\ndata (which more closely follows the Vega-Lite API).</p>\n",
-          "default": null
-        },
-        {
-          "name": "spec",
-          "type_name": "dict or None",
-          "is_optional": false,
-          "description": "<p>The Vega-Lite spec for the chart. If the spec was already passed in\nthe previous argument, this must be set to None. See\n<a class=\"reference external\" href=\"https://vega.github.io/vega-lite/docs/\">https://vega.github.io/vega-lite/docs/</a> for more info.</p>\n",
-          "default": null
-        },
-        {
-          "name": "use_container_width",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, set the chart width to the column width. This takes\nprecedence over Vega-Lite's native <cite>width</cite> value.</p>\n",
-          "default": null
-        },
-        {
-          "name": "**kwargs",
-          "type_name": "any",
-          "is_optional": false,
-          "description": "<p>Same as spec, but as keywords.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.video": {
-      "name": "video",
-      "signature": "element.video(self, data, format=\"video/mp4\", start_time=0)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nvideo_file = open('myvideo.mp4', 'rb')\nvideo_bytes = video_file.read()\n\nst.video(video_bytes)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-2BLtg/index.html?id=DzAouvizGRAyuLjkPpR894&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 600px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-2BLtg/index.html?id=DzAouvizGRAyuLjkPpR894\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <div class=\"admonition note\">\n<p class=\"first admonition-title\">Note</p>\n<p class=\"last\">Some videos may not display if they are encoded using MP4V (which is an export option in OpenCV), as this codec is\nnot widely supported by browsers. Converting your video to H.264 will allow the video to be displayed in Streamlit.\nSee this <a class=\"reference external\" href=\"https://stackoverflow.com/a/49535220/2394542\">StackOverflow post</a> or this\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/st-video-doesnt-show-opencv-generated-mp4/3193/2\">Streamlit forum post</a>\nfor more information.</p>\n</div>\n</blockquote>\n",
-      "description": "Display a video player.",
-      "args": [
-        {
-          "name": "data",
-          "type_name": "str, bytes, BytesIO, numpy.ndarray, or file opened with",
-          "is_optional": false,
-          "description": "<p>io.open().\nRaw video data, filename, or URL pointing to a video to load.\nIncludes support for YouTube URLs.\nNumpy arrays and raw data formats must include all necessary file\nheaders to match specified file format.</p>\n",
-          "default": null
-        },
-        {
-          "name": "format",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The mime type for the video file. Defaults to 'video/mp4'.\nSee <a class=\"reference external\" href=\"https://tools.ietf.org/html/rfc4281\">https://tools.ietf.org/html/rfc4281</a> for more info.</p>\n",
-          "default": "s"
-        },
-        {
-          "name": "start_time",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The time from which this element should start playing.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.warning": {
-      "name": "warning",
-      "signature": "element.warning(self, body)",
-      "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.warning('This is a warning')\n</pre>\n</blockquote>\n",
-      "description": "Display warning message.",
-      "args": [
-        {
-          "name": "body",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The warning text to display.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": []
-    },
-    "DeltaGenerator.write": {
-      "name": "write",
-      "signature": "element.write(self, *args, **kwargs)",
-      "example": "<blockquote>\n<p>Its basic use case is to draw Markdown-formatted text, whenever the\ninput is a string:</p>\n<pre class=\"doctest-block\">\nwrite('Hello, *World!* :sunglasses:')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.50.2-ZWk9/index.html?id=Pn5sjhgNs4a8ZbiUoSTRxE&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 50px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.50.2-ZWk9/index.html?id=Pn5sjhgNs4a8ZbiUoSTRxE\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>As mentioned earlier, <cite>st.write()</cite> also accepts other data formats, such as\nnumbers, data frames, styled data frames, and assorted objects:</p>\n<pre class=\"doctest-block\">\nst.write(1234)\nst.write(pd.DataFrame({\n     'first column': [1, 2, 3, 4],\n     'second column': [10, 20, 30, 40],\n }))\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=FCp9AMJHwHRsWSiqMgUZGD&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 250px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=FCp9AMJHwHRsWSiqMgUZGD\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Finally, you can pass in multiple arguments to do things like:</p>\n<pre class=\"doctest-block\">\nst.write('1 + 1 = ', 2)\nst.write('Below is a DataFrame:', data_frame, 'Above is a dataframe.')\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=DHkcU72sxYcGarkFbf4kK1&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 300px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=DHkcU72sxYcGarkFbf4kK1\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Oh, one more thing: <cite>st.write</cite> accepts chart objects too! For example:</p>\n<pre class=\"doctest-block\">\nimport pandas as pd\nimport numpy as np\nimport altair as alt\n\ndf = pd.DataFrame(\n     np.random.randn(200, 3),\n     columns=['a', 'b', 'c'])\n\nc = alt.Chart(df).mark_circle().encode(\n     x='a', y='b', size='c', color='c', tooltip=['a', 'b', 'c'])\n\nst.write(c)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 200px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.25.0-2JkNY/index.html?id=8jmmXR8iKoZGV4kXaKGYV5\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
-      "description": "<p>Write arguments to the app.</p>\n<p>This is the Swiss Army knife of Streamlit commands: it does different\nthings depending on what you throw at it. Unlike other Streamlit commands,\nwrite() has some unique properties:</p>\n<ol class=\"arabic simple\">\n<li>You can pass in multiple arguments, all of which will be written.</li>\n<li>Its behavior depends on the input types as follows.</li>\n<li>It returns None, so its &quot;slot&quot; in the App cannot be reused.</li>\n</ol>\n",
-      "args": [
-        {
-          "name": "*args",
-          "type_name": "any",
-          "is_optional": false,
-          "description": "<p>One or many objects to print to the App.</p>\n<p>Arguments are handled as follows:</p>\n<ul class=\"simple\">\n<li><dl class=\"first docutils\">\n<dt>write(string) <span class=\"classifier-delimiter\">:</span> <span class=\"classifier\">Prints the formatted Markdown string, with</span></dt>\n<dd>support for LaTeX expression and emoji shortcodes.\nSee docs for st.markdown for more.</dd>\n</dl>\n</li>\n<li>write(data_frame) : Displays the DataFrame as a table.</li>\n<li>write(error)      : Prints an exception specially.</li>\n<li>write(func)       : Displays information about a function.</li>\n<li>write(module)     : Displays information about the module.</li>\n<li>write(dict)       : Displays dict in an interactive widget.</li>\n<li>write(mpl_fig)    : Displays a Matplotlib figure.</li>\n<li>write(altair)     : Displays an Altair chart.</li>\n<li>write(keras)      : Displays a Keras model.</li>\n<li>write(graphviz)   : Displays a Graphviz graph.</li>\n<li>write(plotly_fig) : Displays a Plotly figure.</li>\n<li>write(bokeh_fig)  : Displays a Bokeh figure.</li>\n<li>write(sympy_expr) : Prints SymPy expression using LaTeX.</li>\n<li>write(htmlable)   : Prints _repr_html_() for the object if available.</li>\n<li>write(obj)        : Prints str(obj) if otherwise unknown.</li>\n</ul>\n",
-          "default": null
-        },
-        {
-          "name": "unsafe_allow_html",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>This is a keyword-only argument that defaults to False.</p>\n<p>By default, any HTML tags found in strings will be escaped and\ntherefore treated as pure text. This behavior may be turned off by\nsetting this argument to True.</p>\n<p>That said, <em>we strongly advise against it</em>. It is hard to write secure\nHTML, so by using this argument you may be compromising your users'\nsecurity. For more information, see:</p>\n<p><a class=\"reference external\" href=\"https://github.com/streamlit/streamlit/issues/152\">https://github.com/streamlit/streamlit/issues/152</a></p>\n<p><strong>Also note that `unsafe_allow_html` is a temporary measure and may be\nremoved from Streamlit at any time.</strong></p>\n<p>If you decide to turn on HTML anyway, we ask you to please tell us your\nexact use case here:\n<a class=\"reference external\" href=\"https://discuss.streamlit.io/t/96\">https://discuss.streamlit.io/t/96</a> .</p>\n<p>This will help us come up with safe APIs that allow you to do what you\nwant.</p>\n",
-          "default": "False."
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.components.v1.declare_component": {
-      "name": "declare_component",
-      "signature": "st.components.v1.declare_component(name, path=None, url=None)",
-      "description": "Create and register a custom component.",
-      "args": [
-        {
-          "name": "name",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short, descriptive name for the component. Like, &quot;slider&quot;.</p>\n",
-          "default": null
-        },
-        {
-          "name": "path",
-          "type_name": "str or None",
-          "is_optional": false,
-          "description": "<p>The path to serve the component's frontend files from. Either\n<cite>path</cite> or <cite>url</cite> must be specified, but not both.</p>\n",
-          "default": null
-        },
-        {
-          "name": "url",
-          "type_name": "str or None",
-          "is_optional": false,
-          "description": "<p>The URL that the component is served from. Either <cite>path</cite> or <cite>url</cite>\nmust be specified, but not both.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "CustomComponent",
-          "is_generator": false,
-          "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
-          "return_name": null
-        }
-      ]
-    },
-    "streamlit.components.v1.html": {
-      "name": "html",
-      "signature": "st.components.v1.html(html, width=None, height=None, scrolling=False)",
-      "description": "Display an HTML string in an iframe.",
-      "args": [
-        {
-          "name": "html",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The HTML string to embed in the iframe.</p>\n",
-          "default": null
-        },
-        {
-          "name": "width",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The width of the frame in CSS pixels. Defaults to the report's\ndefault element width.</p>\n",
-          "default": "the"
-        },
-        {
-          "name": "height",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The height of the frame in CSS pixels. Defaults to 150.</p>\n",
-          "default": "150."
-        },
-        {
-          "name": "scrolling",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
-          "default": "False."
-        }
-      ],
-      "returns": []
-    },
-    "streamlit.components.v1.iframe": {
-      "name": "iframe",
-      "signature": "st.components.v1.iframe(src, width=None, height=None, scrolling=False)",
-      "description": "Load a remote URL in an iframe.",
-      "args": [
-        {
-          "name": "src",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The URL of the page to embed.</p>\n",
-          "default": null
-        },
-        {
-          "name": "width",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The width of the frame in CSS pixels. Defaults to the report's\ndefault element width.</p>\n",
-          "default": "the"
-        },
-        {
-          "name": "height",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The height of the frame in CSS pixels. Defaults to 150.</p>\n",
-          "default": "150."
-        },
-        {
-          "name": "scrolling",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
-          "default": "False."
-        }
-      ],
-      "returns": []
-    }
-  },
   "0.83.0": {
     "streamlit.altair_chart": {
       "name": "altair_chart",
@@ -3840,7 +21,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L181"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -3877,7 +59,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L83"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -3907,7 +90,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -3915,7 +99,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -3952,7 +137,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L132"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -3975,7 +161,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L67"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -3983,7 +170,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.beta_container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.beta_container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L24"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -4006,7 +194,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L168"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -4043,7 +232,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "streamlit.button": {
       "name": "button",
@@ -4080,7 +270,8 @@
           "description": "<p>If the button was clicked on the last run of the app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L32"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -4145,7 +336,8 @@
           "default": "None."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching.py#L357"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -4161,7 +353,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -4205,7 +398,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L24"
     },
     "streamlit.code": {
       "name": "code",
@@ -4228,7 +422,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -4272,7 +467,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L26"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -4302,7 +498,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L35"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -4360,7 +557,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L87"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -4376,7 +574,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L399"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -4384,7 +583,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.beta_container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -4400,7 +600,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -4416,7 +617,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -4431,14 +633,16 @@
           "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L282"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L511"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -4454,7 +658,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L313"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -4471,7 +676,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L213"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -4522,7 +728,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L31"
     },
     "streamlit.form": {
       "name": "form",
@@ -4545,7 +752,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -4574,7 +782,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L195"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -4589,7 +798,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -4612,7 +822,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "streamlit.header": {
       "name": "header",
@@ -4635,7 +846,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -4651,7 +863,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "streamlit.image": {
       "name": "image",
@@ -4709,7 +922,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "streamlit.info": {
       "name": "info",
@@ -4725,7 +939,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -4741,7 +956,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L23"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -4757,7 +973,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -4794,7 +1011,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L33"
     },
     "streamlit.map": {
       "name": "map",
@@ -4817,7 +1035,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -4840,7 +1059,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -4898,11 +1118,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L26"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7f82445fa7c0>, step=None, format=None, key=None, help=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7f6a785b8c70>, step=None, format=None, key=None, help=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -4970,7 +1191,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L27"
     },
     "streamlit.object_beta_warning": {
       "name": "object_beta_warning",
@@ -4999,7 +1221,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L57"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -5050,7 +1273,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -5066,7 +1290,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -5082,7 +1307,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -5113,7 +1339,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -5171,7 +1398,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L26"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -5229,7 +1457,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L27"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -5287,7 +1516,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L26"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -5309,7 +1539,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L179"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -5346,7 +1577,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L22"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -5418,7 +1650,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L28"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -5434,7 +1667,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L343"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -5442,7 +1676,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L491"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -5465,7 +1700,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -5481,7 +1717,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -5497,7 +1734,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L94"
     },
     "streamlit.text": {
       "name": "text",
@@ -5513,7 +1751,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -5571,7 +1810,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L87"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -5629,7 +1869,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L26"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -5673,7 +1914,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L29"
     },
     "streamlit.title": {
       "name": "title",
@@ -5696,7 +1938,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -5733,7 +1976,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/vega_lite.py#L30"
     },
     "streamlit.video": {
       "name": "video",
@@ -5763,7 +2007,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -5779,7 +2024,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -5802,7 +2048,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L37"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -5832,7 +2079,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/delta_generator.py#L454"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -5855,7 +2103,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L181"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -5892,7 +2141,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L83"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -5922,7 +2172,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -5930,7 +2181,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -5967,7 +2219,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L132"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -5990,7 +2243,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L67"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -5998,7 +2252,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.beta_container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.beta_container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L24"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -6021,7 +2276,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L168"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -6058,7 +2314,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -6095,7 +2352,8 @@
           "description": "<p>If the button was clicked on the last run of the app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L32"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -6111,7 +2369,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -6155,7 +2414,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L24"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -6178,7 +2438,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -6222,7 +2483,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L26"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -6252,7 +2514,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L35"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -6310,7 +2573,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L87"
     },
     "DeltaGenerator.empty": {
       "name": "empty",
@@ -6318,7 +2582,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.beta_container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -6334,7 +2599,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -6350,7 +2616,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -6401,7 +2668,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L31"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -6424,7 +2692,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -6453,7 +2722,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L195"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -6476,7 +2746,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -6499,7 +2770,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -6515,7 +2787,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -6573,7 +2846,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -6589,7 +2863,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.json": {
       "name": "json",
@@ -6605,7 +2880,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L23"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -6621,7 +2897,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -6658,7 +2935,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L33"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -6681,7 +2959,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -6704,7 +2983,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -6762,11 +3042,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L26"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7f82445fa7c0>, step=None, format=None, key=None, help=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7f6a785b8c70>, step=None, format=None, key=None, help=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -6834,7 +3115,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L27"
     },
     "DeltaGenerator.plotly_chart": {
       "name": "plotly_chart",
@@ -6885,7 +3167,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -6901,7 +3184,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -6917,7 +3201,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -6948,7 +3233,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -7006,7 +3292,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L26"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -7064,7 +3351,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L27"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -7122,7 +3410,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L26"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -7194,7 +3483,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L28"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -7217,7 +3507,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -7233,7 +3524,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -7249,7 +3541,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L94"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -7265,7 +3558,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -7323,7 +3617,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L87"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -7381,7 +3676,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L26"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -7425,7 +3721,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L29"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -7448,7 +3745,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -7485,7 +3783,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/vega_lite.py#L30"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -7515,7 +3814,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -7531,7 +3831,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -7554,7 +3855,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L37"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -7590,7 +3892,8 @@
           "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L252"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -7626,7 +3929,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -7662,7 +3966,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   },
   "0.84.0": {
@@ -7687,7 +3992,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L181"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -7724,7 +4030,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L83"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -7754,7 +4061,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -7762,7 +4070,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -7799,7 +4108,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L132"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -7822,7 +4132,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L69"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -7830,7 +4141,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.beta_container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.beta_container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L26"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -7853,7 +4165,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L170"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -7890,7 +4203,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "streamlit.button": {
       "name": "button",
@@ -7948,7 +4262,8 @@
           "description": "<p>If the button was clicked on the last run of the app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L39"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -8013,7 +4328,8 @@
           "default": "None."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching.py#L357"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -8029,7 +4345,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -8094,7 +4411,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L25"
     },
     "streamlit.code": {
       "name": "code",
@@ -8117,7 +4435,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -8182,7 +4501,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L27"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -8212,7 +4532,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L35"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -8291,7 +4612,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L128"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -8307,7 +4629,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L406"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -8315,7 +4638,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.beta_container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -8331,7 +4655,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -8347,7 +4672,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -8362,14 +4688,16 @@
           "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L289"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L518"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -8385,7 +4713,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L320"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -8402,7 +4731,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L220"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -8474,7 +4804,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L32"
     },
     "streamlit.form": {
       "name": "form",
@@ -8497,7 +4828,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -8547,7 +4879,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -8562,7 +4895,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -8585,7 +4919,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "streamlit.header": {
       "name": "header",
@@ -8608,7 +4943,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -8624,7 +4960,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "streamlit.image": {
       "name": "image",
@@ -8682,7 +5019,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "streamlit.info": {
       "name": "info",
@@ -8698,7 +5036,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -8714,7 +5053,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -8730,7 +5070,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -8767,7 +5108,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L33"
     },
     "streamlit.map": {
       "name": "map",
@@ -8790,7 +5132,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -8813,7 +5156,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -8892,11 +5236,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L27"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f8c083a5700>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f8d7f2fc6a0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -8985,7 +5330,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L28"
     },
     "streamlit.object_beta_warning": {
       "name": "object_beta_warning",
@@ -9014,7 +5360,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L57"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -9065,7 +5412,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -9081,7 +5429,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -9097,7 +5446,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -9128,7 +5478,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -9207,7 +5558,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L28"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -9286,7 +5638,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L28"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -9365,7 +5718,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L28"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -9387,7 +5741,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L186"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -9424,7 +5779,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L22"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -9517,7 +5873,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L30"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -9533,7 +5890,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L350"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -9541,7 +5899,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L498"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -9564,7 +5923,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -9580,7 +5940,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -9596,7 +5957,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L94"
     },
     "streamlit.text": {
       "name": "text",
@@ -9612,7 +5974,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -9691,7 +6054,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L135"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -9777,7 +6141,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L27"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -9842,7 +6207,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L30"
     },
     "streamlit.title": {
       "name": "title",
@@ -9865,7 +6231,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -9902,7 +6269,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/vega_lite.py#L30"
     },
     "streamlit.video": {
       "name": "video",
@@ -9932,7 +6300,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -9948,7 +6317,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -9971,7 +6341,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -10001,7 +6372,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/delta_generator.py#L454"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -10024,7 +6396,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L181"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -10061,7 +6434,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L83"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -10091,7 +6465,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -10099,7 +6474,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -10136,7 +6512,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L132"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -10159,7 +6536,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L69"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -10167,7 +6545,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.beta_container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.beta_container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L26"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -10190,7 +6569,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L170"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -10227,7 +6607,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -10285,7 +6666,8 @@
           "description": "<p>If the button was clicked on the last run of the app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L39"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -10301,7 +6683,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -10366,7 +6749,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L25"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -10389,7 +6773,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -10454,7 +6839,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L27"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -10484,7 +6870,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L35"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -10563,7 +6950,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L128"
     },
     "DeltaGenerator.empty": {
       "name": "empty",
@@ -10571,7 +6959,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.beta_container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -10587,7 +6976,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -10603,7 +6993,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -10675,7 +7066,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L32"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -10698,7 +7090,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -10748,7 +7141,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -10771,7 +7165,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -10794,7 +7189,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -10810,7 +7206,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -10868,7 +7265,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -10884,7 +7282,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.json": {
       "name": "json",
@@ -10900,7 +7299,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -10916,7 +7316,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -10953,7 +7354,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L33"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -10976,7 +7378,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -10999,7 +7402,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -11078,11 +7482,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L27"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f8c083a5700>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f8d7f2fc6a0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -11171,7 +7576,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L28"
     },
     "DeltaGenerator.plotly_chart": {
       "name": "plotly_chart",
@@ -11222,7 +7628,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -11238,7 +7645,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -11254,7 +7662,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -11285,7 +7694,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -11364,7 +7774,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L28"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -11443,7 +7854,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L28"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -11522,7 +7934,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L28"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -11615,7 +8028,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L30"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -11638,7 +8052,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -11654,7 +8069,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -11670,7 +8086,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L94"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -11686,7 +8103,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -11765,7 +8183,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L135"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -11851,7 +8270,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L27"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -11916,7 +8336,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L30"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -11939,7 +8360,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -11976,7 +8398,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/vega_lite.py#L30"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -12006,7 +8429,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -12022,7 +8446,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -12045,7 +8470,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -12081,7 +8507,8 @@
           "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L256"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -12117,7 +8544,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -12153,7 +8581,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   },
   "0.85.0": {
@@ -12178,7 +8607,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L255"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -12215,7 +8645,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L166"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -12245,7 +8676,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -12253,7 +8685,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -12290,7 +8723,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L210"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -12313,7 +8747,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L69"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -12321,7 +8756,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.beta_container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.beta_container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L26"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -12344,7 +8780,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L170"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -12381,7 +8818,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "streamlit.button": {
       "name": "button",
@@ -12439,7 +8877,8 @@
           "description": "<p>If the button was clicked on the last run of the app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L40"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -12504,7 +8943,8 @@
           "default": "None."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching.py#L327"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -12520,7 +8960,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -12585,7 +9026,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L26"
     },
     "streamlit.code": {
       "name": "code",
@@ -12608,7 +9050,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -12673,7 +9116,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L28"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -12703,7 +9147,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -12782,7 +9227,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L129"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -12798,7 +9244,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L423"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -12806,7 +9253,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.beta_container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -12822,7 +9270,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -12838,7 +9287,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -12853,14 +9303,16 @@
           "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L306"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L535"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -12876,7 +9328,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L337"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -12893,7 +9346,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L237"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -12965,7 +9419,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L33"
     },
     "streamlit.form": {
       "name": "form",
@@ -12988,7 +9443,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -13038,7 +9494,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -13053,7 +9510,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -13076,7 +9534,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "streamlit.header": {
       "name": "header",
@@ -13099,7 +9558,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -13115,7 +9575,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "streamlit.image": {
       "name": "image",
@@ -13173,7 +9634,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "streamlit.info": {
       "name": "info",
@@ -13189,7 +9651,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -13205,7 +9668,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -13221,7 +9685,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -13258,7 +9723,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "streamlit.map": {
       "name": "map",
@@ -13281,7 +9747,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -13304,7 +9771,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -13383,11 +9851,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L29"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f5b5fc0bfd0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7faef7496880>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -13476,7 +9945,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L29"
     },
     "streamlit.object_beta_warning": {
       "name": "object_beta_warning",
@@ -13505,7 +9975,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L57"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -13556,7 +10027,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -13572,7 +10044,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -13588,7 +10061,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -13619,7 +10093,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -13698,7 +10173,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L29"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -13777,7 +10253,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L29"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -13856,7 +10333,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L29"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -13878,7 +10356,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L203"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -13915,7 +10394,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L22"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -14008,7 +10488,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L31"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -14024,7 +10505,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L367"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -14032,7 +10514,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L515"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -14055,7 +10538,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -14071,7 +10555,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -14087,7 +10572,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "streamlit.text": {
       "name": "text",
@@ -14103,7 +10589,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -14182,7 +10669,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L137"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -14268,7 +10756,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L29"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -14333,7 +10822,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L31"
     },
     "streamlit.title": {
       "name": "title",
@@ -14356,7 +10846,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -14393,7 +10884,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L293"
     },
     "streamlit.video": {
       "name": "video",
@@ -14423,7 +10915,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -14439,7 +10932,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -14462,7 +10956,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -14485,7 +10980,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L362"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -14508,7 +11004,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L255"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -14545,7 +11042,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L166"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -14575,7 +11073,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -14583,7 +11082,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -14620,7 +11120,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L210"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -14643,7 +11144,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L69"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -14651,7 +11153,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.beta_container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.beta_container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L26"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -14674,7 +11177,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L170"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -14711,7 +11215,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -14769,7 +11274,8 @@
           "description": "<p>If the button was clicked on the last run of the app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L40"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -14785,7 +11291,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -14850,7 +11357,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L26"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -14873,7 +11381,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -14938,7 +11447,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L28"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -14968,7 +11478,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -15047,7 +11558,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L129"
     },
     "DeltaGenerator.empty": {
       "name": "empty",
@@ -15055,7 +11567,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.beta_container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -15071,7 +11584,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -15087,7 +11601,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -15159,7 +11674,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L33"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -15182,7 +11698,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -15232,7 +11749,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -15255,7 +11773,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -15278,7 +11797,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -15294,7 +11814,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -15352,7 +11873,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -15368,7 +11890,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.json": {
       "name": "json",
@@ -15384,7 +11907,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -15400,7 +11924,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -15437,7 +11962,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -15460,7 +11986,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -15483,7 +12010,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -15562,11 +12090,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L29"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f5b5fc0bfd0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7faef7496880>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -15655,7 +12184,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L29"
     },
     "DeltaGenerator.plotly_chart": {
       "name": "plotly_chart",
@@ -15706,7 +12236,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -15722,7 +12253,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -15738,7 +12270,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -15769,7 +12302,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -15848,7 +12382,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L29"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -15927,7 +12462,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L29"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -16006,7 +12542,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L29"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -16099,7 +12636,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L31"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -16122,7 +12660,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -16138,7 +12677,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -16154,7 +12694,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -16170,7 +12711,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -16249,7 +12791,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L137"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -16335,7 +12878,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L29"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -16400,7 +12944,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L31"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -16423,7 +12968,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -16460,7 +13006,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L293"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -16490,7 +13037,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -16506,7 +13054,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -16529,7 +13078,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -16565,7 +13115,8 @@
           "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -16601,7 +13152,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -16637,7 +13189,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   },
   "0.86.0": {
@@ -16662,7 +13215,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L255"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -16699,7 +13253,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L166"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -16729,7 +13284,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -16737,7 +13293,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -16774,7 +13331,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L210"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -16797,7 +13355,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -16805,7 +13364,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -16828,7 +13388,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -16865,7 +13426,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "streamlit.button": {
       "name": "button",
@@ -16923,7 +13485,8 @@
           "description": "<p>If the button was clicked on the last run of the app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L40"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -16988,7 +13551,8 @@
           "default": "None."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching.py#L327"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -17004,7 +13568,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -17069,7 +13634,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L31"
     },
     "streamlit.code": {
       "name": "code",
@@ -17092,7 +13658,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -17157,7 +13724,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L33"
     },
     "streamlit.columns": {
       "name": "columns",
@@ -17180,7 +13748,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "streamlit.container": {
       "name": "container",
@@ -17188,7 +13757,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -17218,7 +13788,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -17297,7 +13868,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L134"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -17313,7 +13885,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L424"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -17321,7 +13894,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -17337,7 +13911,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -17353,7 +13928,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
     },
     "streamlit.expander": {
       "name": "expander",
@@ -17376,7 +13952,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -17391,14 +13968,16 @@
           "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L307"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L536"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -17414,7 +13993,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L338"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -17431,7 +14011,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L238"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -17503,7 +14084,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L40"
     },
     "streamlit.form": {
       "name": "form",
@@ -17526,7 +14108,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -17576,7 +14159,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -17591,7 +14175,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -17614,7 +14199,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "streamlit.header": {
       "name": "header",
@@ -17637,7 +14223,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -17653,7 +14240,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "streamlit.image": {
       "name": "image",
@@ -17711,7 +14299,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "streamlit.info": {
       "name": "info",
@@ -17727,7 +14316,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -17743,7 +14333,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -17759,7 +14350,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -17796,7 +14388,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "streamlit.map": {
       "name": "map",
@@ -17819,7 +14412,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -17842,7 +14436,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -17921,11 +14516,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fbc21395b20>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f8216751340>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -18014,7 +14610,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L36"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -18065,7 +14662,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -18081,7 +14679,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -18097,7 +14696,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -18128,7 +14728,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -18207,7 +14808,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -18286,7 +14888,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -18365,7 +14968,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -18387,7 +14991,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L204"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -18424,7 +15029,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L22"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -18517,7 +15123,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L36"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -18533,7 +15140,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L368"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -18541,7 +15149,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L516"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -18564,7 +15173,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -18580,7 +15190,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -18596,7 +15207,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "streamlit.text": {
       "name": "text",
@@ -18612,7 +15224,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -18691,7 +15304,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L142"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -18777,7 +15391,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L34"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -18842,7 +15457,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L36"
     },
     "streamlit.title": {
       "name": "title",
@@ -18865,7 +15481,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -18902,7 +15519,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L293"
     },
     "streamlit.video": {
       "name": "video",
@@ -18932,7 +15550,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -18948,7 +15567,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -18971,7 +15591,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -18994,7 +15615,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L362"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -19017,7 +15639,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L255"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -19054,7 +15677,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L166"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -19084,7 +15708,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -19092,7 +15717,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -19129,7 +15755,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L210"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -19152,7 +15779,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -19160,7 +15788,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -19183,7 +15812,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -19220,7 +15850,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -19278,7 +15909,8 @@
           "description": "<p>If the button was clicked on the last run of the app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L40"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -19294,7 +15926,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -19359,7 +15992,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L31"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -19382,7 +16016,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -19447,7 +16082,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L33"
     },
     "DeltaGenerator.columns": {
       "name": "columns",
@@ -19470,7 +16106,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "DeltaGenerator.container": {
       "name": "container",
@@ -19478,7 +16115,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -19508,7 +16146,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -19587,7 +16226,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L134"
     },
     "DeltaGenerator.empty": {
       "name": "empty",
@@ -19595,7 +16235,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -19611,7 +16252,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -19627,7 +16269,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -19650,7 +16293,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -19722,7 +16366,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L40"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -19745,7 +16390,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -19795,7 +16441,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -19818,7 +16465,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -19841,7 +16489,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -19857,7 +16506,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -19915,7 +16565,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -19931,7 +16582,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.json": {
       "name": "json",
@@ -19947,7 +16599,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -19963,7 +16616,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -20000,7 +16654,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -20023,7 +16678,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -20046,7 +16702,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -20125,11 +16782,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fbc21395b20>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f8216751340>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -20218,7 +16876,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L36"
     },
     "DeltaGenerator.plotly_chart": {
       "name": "plotly_chart",
@@ -20269,7 +16928,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -20285,7 +16945,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -20301,7 +16962,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -20332,7 +16994,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -20411,7 +17074,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -20490,7 +17154,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -20569,7 +17234,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -20662,7 +17328,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L36"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -20685,7 +17352,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -20701,7 +17369,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -20717,7 +17386,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -20733,7 +17403,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -20812,7 +17483,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L142"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -20898,7 +17570,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L34"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -20963,7 +17636,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L36"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -20986,7 +17660,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -21023,7 +17698,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L293"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -21053,7 +17729,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -21069,7 +17746,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -21092,7 +17770,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -21128,7 +17807,8 @@
           "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -21164,7 +17844,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -21200,7 +17881,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   },
   "0.87.0": {
@@ -21225,7 +17907,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -21262,7 +17945,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -21292,7 +17976,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -21300,7 +17985,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -21337,7 +18023,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -21360,7 +18047,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -21368,7 +18056,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -21391,7 +18080,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -21428,7 +18118,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "streamlit.button": {
       "name": "button",
@@ -21486,7 +18177,8 @@
           "description": "<p>If the button was clicked on the last run of the app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L40"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -21551,7 +18243,8 @@
           "default": "None."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching.py#L327"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -21567,7 +18260,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -21632,7 +18326,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L31"
     },
     "streamlit.code": {
       "name": "code",
@@ -21655,7 +18350,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -21720,7 +18416,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L33"
     },
     "streamlit.columns": {
       "name": "columns",
@@ -21743,7 +18440,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "streamlit.container": {
       "name": "container",
@@ -21751,7 +18449,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -21781,7 +18480,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -21860,7 +18560,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L134"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -21876,7 +18577,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L425"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -21884,7 +18586,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -21900,7 +18603,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -21916,7 +18620,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
     },
     "streamlit.expander": {
       "name": "expander",
@@ -21939,7 +18644,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -21954,14 +18660,16 @@
           "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L308"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L537"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -21977,7 +18685,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L339"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -21994,7 +18703,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L239"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -22066,7 +18776,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L43"
     },
     "streamlit.form": {
       "name": "form",
@@ -22089,7 +18800,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -22139,7 +18851,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -22154,7 +18867,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -22177,7 +18891,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "streamlit.header": {
       "name": "header",
@@ -22200,7 +18915,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -22216,7 +18932,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "streamlit.image": {
       "name": "image",
@@ -22274,7 +18991,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "streamlit.info": {
       "name": "info",
@@ -22290,7 +19008,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -22306,7 +19025,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -22322,7 +19042,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -22359,7 +19080,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "streamlit.map": {
       "name": "map",
@@ -22382,7 +19104,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -22405,7 +19128,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.metric": {
       "name": "metric",
@@ -22442,7 +19166,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -22521,11 +19246,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fd14ff242b0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f387aadba00>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -22614,7 +19340,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L36"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -22665,7 +19392,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -22681,7 +19409,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -22697,7 +19426,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -22728,7 +19458,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -22807,7 +19538,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -22886,7 +19618,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -22965,7 +19698,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -22987,7 +19721,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L205"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -23024,7 +19759,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L22"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -23117,7 +19853,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L36"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -23133,7 +19870,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L369"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -23141,7 +19879,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L517"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -23164,7 +19903,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -23180,7 +19920,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -23196,7 +19937,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "streamlit.text": {
       "name": "text",
@@ -23212,7 +19954,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -23291,7 +20034,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L142"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -23377,7 +20121,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L34"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -23442,7 +20187,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L36"
     },
     "streamlit.title": {
       "name": "title",
@@ -23465,7 +20211,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -23502,7 +20249,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "streamlit.video": {
       "name": "video",
@@ -23532,7 +20280,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -23548,7 +20297,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -23571,7 +20321,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -23594,7 +20345,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -23617,7 +20369,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -23654,7 +20407,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -23684,7 +20438,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -23692,7 +20447,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -23729,7 +20485,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -23752,7 +20509,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -23760,7 +20518,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -23783,7 +20542,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -23820,7 +20580,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -23878,7 +20639,8 @@
           "description": "<p>If the button was clicked on the last run of the app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L40"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -23894,7 +20656,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -23959,7 +20722,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L31"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -23982,7 +20746,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -24047,7 +20812,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L33"
     },
     "DeltaGenerator.columns": {
       "name": "columns",
@@ -24070,7 +20836,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "DeltaGenerator.container": {
       "name": "container",
@@ -24078,7 +20845,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -24108,7 +20876,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -24187,7 +20956,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L134"
     },
     "DeltaGenerator.determine_delta_color_and_direction": {
       "name": "determine_delta_color_and_direction",
@@ -24199,7 +20969,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -24215,7 +20986,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -24231,7 +21003,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -24254,7 +21027,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -24326,7 +21100,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L43"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -24349,7 +21124,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -24399,7 +21175,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -24422,7 +21199,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -24445,7 +21223,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -24461,7 +21240,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -24519,7 +21299,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -24535,7 +21316,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.is_negative": {
       "name": "is_negative",
@@ -24555,7 +21337,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -24571,7 +21354,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -24608,7 +21392,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -24631,7 +21416,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -24654,7 +21440,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.metric": {
       "name": "metric",
@@ -24691,7 +21478,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -24770,11 +21558,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fd14ff242b0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f387aadba00>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -24863,7 +21652,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L36"
     },
     "DeltaGenerator.parse_delta": {
       "name": "parse_delta",
@@ -24926,7 +21716,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -24942,7 +21733,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -24958,7 +21750,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -24989,7 +21782,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -25068,7 +21862,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -25147,7 +21942,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -25226,7 +22022,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -25319,7 +22116,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L36"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -25342,7 +22140,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -25358,7 +22157,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -25374,7 +22174,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -25390,7 +22191,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -25469,7 +22271,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L142"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -25555,7 +22358,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L34"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -25620,7 +22424,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L36"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -25643,7 +22448,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -25680,7 +22486,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -25710,7 +22517,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -25726,7 +22534,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -25749,7 +22558,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -25785,7 +22595,8 @@
           "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -25821,7 +22632,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -25857,7 +22669,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   },
   "0.88.0": {
@@ -25882,7 +22695,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -25919,7 +22733,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -25949,7 +22764,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -25957,7 +22773,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -25994,7 +22811,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -26017,7 +22835,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -26025,7 +22844,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -26048,7 +22868,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -26085,7 +22906,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "streamlit.button": {
       "name": "button",
@@ -26143,7 +22965,8 @@
           "description": "<p>If the button was clicked on the last run of the app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -26208,7 +23031,8 @@
           "default": "None."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching.py#L327"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -26224,7 +23048,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -26289,7 +23114,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "streamlit.code": {
       "name": "code",
@@ -26312,7 +23138,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -26377,7 +23204,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "streamlit.columns": {
       "name": "columns",
@@ -26400,7 +23228,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "streamlit.container": {
       "name": "container",
@@ -26408,7 +23237,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -26438,7 +23268,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -26517,7 +23348,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "streamlit.download_button": {
       "name": "download_button",
@@ -26596,7 +23428,8 @@
           "description": "<p>If the button was clicked on the last run of the app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -26612,7 +23445,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L426"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -26620,7 +23454,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -26636,7 +23471,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -26652,7 +23488,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "streamlit.expander": {
       "name": "expander",
@@ -26675,7 +23512,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -26690,14 +23528,16 @@
           "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L309"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L538"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -26713,7 +23553,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L340"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -26730,7 +23571,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L240"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -26802,7 +23644,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "streamlit.form": {
       "name": "form",
@@ -26825,7 +23668,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -26875,7 +23719,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -26890,7 +23735,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -26913,7 +23759,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "streamlit.header": {
       "name": "header",
@@ -26936,7 +23783,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -26952,7 +23800,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "streamlit.image": {
       "name": "image",
@@ -27010,7 +23859,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "streamlit.info": {
       "name": "info",
@@ -27026,7 +23876,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -27042,7 +23893,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -27058,7 +23910,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -27095,7 +23948,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "streamlit.map": {
       "name": "map",
@@ -27118,7 +23972,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -27141,7 +23996,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.metric": {
       "name": "metric",
@@ -27178,7 +24034,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -27257,11 +24114,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f205740e8e0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fb6e2fb0190>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -27350,7 +24208,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -27401,7 +24260,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -27417,7 +24277,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -27433,7 +24294,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -27464,7 +24326,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -27543,7 +24406,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -27622,7 +24486,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -27701,7 +24566,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -27723,7 +24589,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L206"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -27760,7 +24627,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L22"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -27853,7 +24721,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -27869,7 +24738,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L370"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -27877,7 +24747,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L518"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -27900,7 +24771,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -27916,7 +24788,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -27932,7 +24805,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "streamlit.text": {
       "name": "text",
@@ -27948,7 +24822,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -28027,7 +24902,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -28113,7 +24989,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -28178,7 +25055,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "streamlit.title": {
       "name": "title",
@@ -28201,7 +25079,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -28238,7 +25117,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "streamlit.video": {
       "name": "video",
@@ -28268,7 +25148,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -28284,7 +25165,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -28307,7 +25189,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -28330,7 +25213,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -28353,7 +25237,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -28390,7 +25275,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -28420,7 +25306,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -28428,7 +25315,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -28465,7 +25353,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -28488,7 +25377,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -28496,7 +25386,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -28519,7 +25410,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -28556,7 +25448,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -28614,7 +25507,8 @@
           "description": "<p>If the button was clicked on the last run of the app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -28630,7 +25524,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -28695,7 +25590,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -28718,7 +25614,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -28783,7 +25680,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "DeltaGenerator.columns": {
       "name": "columns",
@@ -28806,7 +25704,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "DeltaGenerator.container": {
       "name": "container",
@@ -28814,7 +25713,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -28844,7 +25744,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -28923,7 +25824,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "DeltaGenerator.determine_delta_color_and_direction": {
       "name": "determine_delta_color_and_direction",
@@ -29006,7 +25908,8 @@
           "description": "<p>If the button was clicked on the last run of the app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "DeltaGenerator.empty": {
       "name": "empty",
@@ -29014,7 +25917,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -29030,7 +25934,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -29046,7 +25951,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -29069,7 +25975,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -29141,7 +26048,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -29164,7 +26072,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -29214,7 +26123,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -29237,7 +26147,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -29260,7 +26171,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -29276,7 +26188,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -29334,7 +26247,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -29350,7 +26264,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.is_negative": {
       "name": "is_negative",
@@ -29370,7 +26285,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -29386,7 +26302,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -29423,7 +26340,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -29446,7 +26364,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -29469,7 +26388,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.metric": {
       "name": "metric",
@@ -29506,7 +26426,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -29585,11 +26506,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f205740e8e0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fb6e2fb0190>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -29678,7 +26600,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "DeltaGenerator.parse_delta": {
       "name": "parse_delta",
@@ -29741,7 +26664,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -29757,7 +26681,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -29773,7 +26698,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -29804,7 +26730,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -29883,7 +26810,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -29962,7 +26890,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -30041,7 +26970,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -30134,7 +27064,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -30157,7 +27088,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -30173,7 +27105,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -30189,7 +27122,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -30205,7 +27139,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -30284,7 +27219,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -30370,7 +27306,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -30435,7 +27372,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -30458,7 +27396,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -30495,7 +27434,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -30525,7 +27465,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -30541,7 +27482,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -30564,7 +27506,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -30600,7 +27543,8 @@
           "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -30636,7 +27580,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -30672,7 +27617,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   },
   "0.89.0": {
@@ -30697,7 +27643,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -30734,7 +27681,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -30764,7 +27712,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -30772,7 +27721,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -30809,7 +27759,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -30832,7 +27783,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -30840,7 +27792,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -30863,7 +27816,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -30900,7 +27854,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "streamlit.button": {
       "name": "button",
@@ -30958,7 +27913,8 @@
           "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -31023,7 +27979,8 @@
           "default": "None."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/legacy_caching/caching.py#L327"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -31039,7 +27996,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -31104,7 +28062,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "streamlit.code": {
       "name": "code",
@@ -31127,7 +28086,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -31192,7 +28152,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "streamlit.columns": {
       "name": "columns",
@@ -31215,7 +28176,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "streamlit.container": {
       "name": "container",
@@ -31223,7 +28185,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -31253,7 +28216,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -31332,7 +28296,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "streamlit.download_button": {
       "name": "download_button",
@@ -31411,7 +28376,8 @@
           "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -31427,7 +28393,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L436"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -31435,7 +28402,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -31451,7 +28419,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -31467,7 +28436,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "streamlit.expander": {
       "name": "expander",
@@ -31490,7 +28460,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -31505,7 +28476,8 @@
           "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L315"
     },
     "streamlit.experimental_memo": {
       "name": "experimental_memo",
@@ -31556,14 +28528,16 @@
           "default": "None."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/memo_decorator.py#L118"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L548"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -31579,7 +28553,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L346"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -31596,7 +28571,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L242"
     },
     "streamlit.experimental_singleton": {
       "name": "experimental_singleton",
@@ -31626,7 +28602,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/singleton_decorator.py#L92"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -31698,7 +28675,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "streamlit.form": {
       "name": "form",
@@ -31721,7 +28699,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -31771,7 +28750,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -31786,7 +28766,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -31809,7 +28790,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "streamlit.header": {
       "name": "header",
@@ -31832,7 +28814,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -31848,7 +28831,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
     },
     "streamlit.image": {
       "name": "image",
@@ -31906,7 +28890,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
     },
     "streamlit.info": {
       "name": "info",
@@ -31922,7 +28907,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -31938,7 +28924,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -31954,7 +28941,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -31991,7 +28979,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "streamlit.map": {
       "name": "map",
@@ -32014,7 +29003,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -32037,7 +29027,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.metric": {
       "name": "metric",
@@ -32074,7 +29065,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -32153,11 +29145,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f656169e520>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fa3b6647d00>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -32246,7 +29239,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -32297,7 +29291,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -32313,7 +29308,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -32329,7 +29325,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -32360,7 +29357,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -32439,7 +29437,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -32518,7 +29517,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -32597,7 +29597,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -32619,7 +29620,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L208"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -32663,7 +29665,8 @@
           "default": "About"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L30"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -32756,7 +29759,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -32772,7 +29776,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L376"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -32780,7 +29785,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L528"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -32803,7 +29809,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -32819,7 +29826,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -32835,7 +29843,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "streamlit.text": {
       "name": "text",
@@ -32851,7 +29860,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -32930,7 +29940,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -33016,7 +30027,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -33081,7 +30093,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "streamlit.title": {
       "name": "title",
@@ -33104,7 +30117,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -33141,7 +30155,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "streamlit.video": {
       "name": "video",
@@ -33171,7 +30186,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -33187,7 +30203,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -33210,7 +30227,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -33233,7 +30251,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -33256,7 +30275,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -33293,7 +30313,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -33323,7 +30344,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -33331,7 +30353,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -33368,7 +30391,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -33391,7 +30415,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -33399,7 +30424,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -33422,7 +30448,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -33459,7 +30486,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -33517,7 +30545,8 @@
           "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -33533,7 +30562,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -33598,7 +30628,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -33621,7 +30652,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -33686,7 +30718,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "DeltaGenerator.columns": {
       "name": "columns",
@@ -33709,7 +30742,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "DeltaGenerator.container": {
       "name": "container",
@@ -33717,7 +30751,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -33747,7 +30782,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -33826,7 +30862,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "DeltaGenerator.determine_delta_color_and_direction": {
       "name": "determine_delta_color_and_direction",
@@ -33909,7 +30946,8 @@
           "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "DeltaGenerator.empty": {
       "name": "empty",
@@ -33917,7 +30955,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -33933,7 +30972,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -33949,7 +30989,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -33972,7 +31013,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -34044,7 +31086,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -34067,7 +31110,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -34117,7 +31161,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -34140,7 +31185,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -34163,7 +31209,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -34179,7 +31226,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -34237,7 +31285,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -34253,7 +31302,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.is_negative": {
       "name": "is_negative",
@@ -34273,7 +31323,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -34289,7 +31340,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -34326,7 +31378,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -34349,7 +31402,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -34372,7 +31426,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.metric": {
       "name": "metric",
@@ -34409,7 +31464,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -34488,11 +31544,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f656169e520>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fa3b6647d00>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -34581,7 +31638,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "DeltaGenerator.parse_delta": {
       "name": "parse_delta",
@@ -34644,7 +31702,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -34660,7 +31719,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -34676,7 +31736,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -34707,7 +31768,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -34786,7 +31848,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -34865,7 +31928,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -34944,7 +32008,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -35037,7 +32102,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -35060,7 +32126,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -35076,7 +32143,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -35092,7 +32160,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -35108,7 +32177,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -35187,7 +32257,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -35273,7 +32344,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -35338,7 +32410,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -35361,7 +32434,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -35398,7 +32472,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -35428,7 +32503,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -35444,7 +32520,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -35467,7 +32544,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -35503,7 +32581,8 @@
           "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -35539,7 +32618,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -35575,7 +32655,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   },
   "1.0.0": {
@@ -35600,7 +32681,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -35637,7 +32719,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -35667,7 +32750,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -35675,7 +32759,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -35712,7 +32797,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -35735,7 +32821,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -35743,7 +32830,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -35766,7 +32854,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -35803,7 +32892,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "streamlit.button": {
       "name": "button",
@@ -35861,7 +32951,8 @@
           "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -35926,7 +33017,8 @@
           "default": "None."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/legacy_caching/caching.py#L327"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -35942,7 +33034,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -36007,7 +33100,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "streamlit.code": {
       "name": "code",
@@ -36030,7 +33124,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -36095,7 +33190,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "streamlit.columns": {
       "name": "columns",
@@ -36118,7 +33214,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "streamlit.container": {
       "name": "container",
@@ -36126,7 +33223,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -36156,7 +33254,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -36235,7 +33334,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "streamlit.download_button": {
       "name": "download_button",
@@ -36314,7 +33414,8 @@
           "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -36330,7 +33431,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L436"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -36338,7 +33440,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -36354,7 +33457,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -36370,7 +33474,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "streamlit.expander": {
       "name": "expander",
@@ -36393,7 +33498,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -36408,7 +33514,8 @@
           "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L315"
     },
     "streamlit.experimental_memo": {
       "name": "experimental_memo",
@@ -36459,14 +33566,16 @@
           "default": "None."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/memo_decorator.py#L118"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L548"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -36482,7 +33591,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L346"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -36499,7 +33609,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L242"
     },
     "streamlit.experimental_singleton": {
       "name": "experimental_singleton",
@@ -36529,7 +33640,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/singleton_decorator.py#L92"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -36601,7 +33713,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "streamlit.form": {
       "name": "form",
@@ -36624,7 +33737,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -36674,7 +33788,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -36689,7 +33804,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -36712,7 +33828,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "streamlit.header": {
       "name": "header",
@@ -36735,7 +33852,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -36751,7 +33869,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
     },
     "streamlit.image": {
       "name": "image",
@@ -36809,7 +33928,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
     },
     "streamlit.info": {
       "name": "info",
@@ -36825,7 +33945,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -36841,7 +33962,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -36857,7 +33979,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -36894,7 +34017,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "streamlit.map": {
       "name": "map",
@@ -36917,7 +34041,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -36940,7 +34065,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.metric": {
       "name": "metric",
@@ -36977,7 +34103,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -37056,11 +34183,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f0135af9430>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f469f119b50>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -37149,7 +34277,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -37200,7 +34329,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -37216,7 +34346,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -37232,7 +34363,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -37263,7 +34395,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -37342,7 +34475,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -37421,7 +34555,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -37500,7 +34635,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -37522,7 +34658,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L208"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -37566,7 +34703,8 @@
           "default": "About"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L30"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -37659,7 +34797,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -37675,7 +34814,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L376"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -37683,7 +34823,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L528"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -37706,7 +34847,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -37722,7 +34864,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -37738,7 +34881,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "streamlit.text": {
       "name": "text",
@@ -37754,7 +34898,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -37833,7 +34978,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -37919,7 +35065,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -37984,7 +35131,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "streamlit.title": {
       "name": "title",
@@ -38007,7 +35155,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -38044,7 +35193,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "streamlit.video": {
       "name": "video",
@@ -38074,7 +35224,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -38090,7 +35241,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -38113,7 +35265,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -38136,7 +35289,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -38159,7 +35313,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -38196,7 +35351,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -38226,7 +35382,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -38234,7 +35391,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -38271,7 +35429,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -38294,7 +35453,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -38302,7 +35462,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -38325,7 +35486,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -38362,7 +35524,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -38420,7 +35583,8 @@
           "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -38436,7 +35600,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -38501,7 +35666,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -38524,7 +35690,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -38589,7 +35756,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "DeltaGenerator.columns": {
       "name": "columns",
@@ -38612,7 +35780,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "DeltaGenerator.container": {
       "name": "container",
@@ -38620,7 +35789,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -38650,7 +35820,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -38729,7 +35900,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "DeltaGenerator.determine_delta_color_and_direction": {
       "name": "determine_delta_color_and_direction",
@@ -38812,7 +35984,8 @@
           "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "DeltaGenerator.empty": {
       "name": "empty",
@@ -38820,7 +35993,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -38836,7 +36010,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -38852,7 +36027,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -38875,7 +36051,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -38947,7 +36124,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -38970,7 +36148,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -39020,7 +36199,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -39043,7 +36223,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -39066,7 +36247,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -39082,7 +36264,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -39140,7 +36323,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -39156,7 +36340,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.is_negative": {
       "name": "is_negative",
@@ -39176,7 +36361,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -39192,7 +36378,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -39229,7 +36416,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -39252,7 +36440,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -39275,7 +36464,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.metric": {
       "name": "metric",
@@ -39312,7 +36502,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -39391,11 +36582,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f0135af9430>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f469f119b50>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -39484,7 +36676,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "DeltaGenerator.parse_delta": {
       "name": "parse_delta",
@@ -39547,7 +36740,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -39563,7 +36757,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -39579,7 +36774,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -39610,7 +36806,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -39689,7 +36886,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -39768,7 +36966,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -39847,7 +37046,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -39940,7 +37140,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -39963,7 +37164,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -39979,7 +37181,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -39995,7 +37198,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -40011,7 +37215,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -40090,7 +37295,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -40176,7 +37382,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -40241,7 +37448,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -40264,7 +37472,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -40301,7 +37510,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -40331,7 +37541,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -40347,7 +37558,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -40370,7 +37582,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -40406,7 +37619,8 @@
           "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -40442,7 +37656,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -40478,7 +37693,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   },
   "1.1.0": {
@@ -40503,7 +37719,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -40540,7 +37757,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -40570,7 +37788,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -40578,7 +37797,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -40615,7 +37835,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -40638,7 +37859,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -40646,7 +37868,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -40669,7 +37892,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -40706,7 +37930,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "streamlit.button": {
       "name": "button",
@@ -40764,7 +37989,8 @@
           "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -40829,7 +38055,8 @@
           "default": "None."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/legacy_caching/caching.py#L327"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -40845,7 +38072,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -40910,7 +38138,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "streamlit.code": {
       "name": "code",
@@ -40933,7 +38162,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -40998,7 +38228,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "streamlit.columns": {
       "name": "columns",
@@ -41021,7 +38252,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "streamlit.container": {
       "name": "container",
@@ -41029,7 +38261,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -41059,7 +38292,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -41138,7 +38372,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "streamlit.download_button": {
       "name": "download_button",
@@ -41217,7 +38452,8 @@
           "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -41233,7 +38469,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L437"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -41241,7 +38478,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -41257,7 +38495,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -41273,7 +38512,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "streamlit.expander": {
       "name": "expander",
@@ -41296,7 +38536,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -41311,7 +38552,8 @@
           "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L316"
     },
     "streamlit.experimental_memo": {
       "name": "experimental_memo",
@@ -41362,14 +38604,16 @@
           "default": "None."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/memo_decorator.py#L95"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L549"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -41385,7 +38629,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L347"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -41402,7 +38647,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L243"
     },
     "streamlit.experimental_singleton": {
       "name": "experimental_singleton",
@@ -41432,7 +38678,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/singleton_decorator.py#L52"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -41504,7 +38751,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "streamlit.form": {
       "name": "form",
@@ -41527,7 +38775,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -41577,7 +38826,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -41592,7 +38842,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -41615,7 +38866,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "streamlit.header": {
       "name": "header",
@@ -41638,7 +38890,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -41654,7 +38907,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
     },
     "streamlit.image": {
       "name": "image",
@@ -41712,7 +38966,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
     },
     "streamlit.info": {
       "name": "info",
@@ -41728,7 +38983,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -41744,7 +39000,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -41760,7 +39017,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -41797,7 +39055,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "streamlit.map": {
       "name": "map",
@@ -41820,7 +39079,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -41843,7 +39103,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.metric": {
       "name": "metric",
@@ -41880,7 +39141,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -41959,11 +39221,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f32ccb85850>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f06c7d43070>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -42052,7 +39315,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -42103,7 +39367,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -42119,7 +39384,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -42135,7 +39401,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -42166,7 +39433,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -42245,7 +39513,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -42324,7 +39593,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -42403,7 +39673,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -42425,7 +39696,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L209"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -42469,7 +39741,8 @@
           "default": "About"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L30"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -42562,7 +39835,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -42578,7 +39852,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L377"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -42586,7 +39861,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L529"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -42609,7 +39885,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -42625,7 +39902,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -42641,7 +39919,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "streamlit.text": {
       "name": "text",
@@ -42657,7 +39936,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -42736,7 +40016,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -42822,7 +40103,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -42887,7 +40169,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "streamlit.title": {
       "name": "title",
@@ -42910,7 +40193,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -42947,7 +40231,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "streamlit.video": {
       "name": "video",
@@ -42977,7 +40262,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -42993,7 +40279,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -43016,7 +40303,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -43039,7 +40327,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -43062,7 +40351,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -43099,7 +40389,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -43129,7 +40420,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -43137,7 +40429,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -43174,7 +40467,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -43197,7 +40491,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -43205,7 +40500,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -43228,7 +40524,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -43265,7 +40562,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -43323,7 +40621,8 @@
           "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -43339,7 +40638,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -43404,7 +40704,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -43427,7 +40728,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -43492,7 +40794,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "DeltaGenerator.columns": {
       "name": "columns",
@@ -43515,7 +40818,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "DeltaGenerator.container": {
       "name": "container",
@@ -43523,7 +40827,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -43553,7 +40858,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -43632,7 +40938,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "DeltaGenerator.determine_delta_color_and_direction": {
       "name": "determine_delta_color_and_direction",
@@ -43715,7 +41022,8 @@
           "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "DeltaGenerator.empty": {
       "name": "empty",
@@ -43723,7 +41031,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -43739,7 +41048,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -43755,7 +41065,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -43778,7 +41089,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -43850,7 +41162,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -43873,7 +41186,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -43923,7 +41237,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -43946,7 +41261,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -43969,7 +41285,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -43985,7 +41302,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -44043,7 +41361,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -44059,7 +41378,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.is_negative": {
       "name": "is_negative",
@@ -44079,7 +41399,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -44095,7 +41416,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -44132,7 +41454,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -44155,7 +41478,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -44178,7 +41502,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.metric": {
       "name": "metric",
@@ -44215,7 +41540,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -44294,11 +41620,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f32ccb85850>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f06c7d43070>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -44387,7 +41714,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "DeltaGenerator.parse_delta": {
       "name": "parse_delta",
@@ -44450,7 +41778,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -44466,7 +41795,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -44482,7 +41812,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -44513,7 +41844,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -44592,7 +41924,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -44671,7 +42004,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -44750,7 +42084,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -44843,7 +42178,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -44866,7 +42202,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -44882,7 +42219,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -44898,7 +42236,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -44914,7 +42253,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -44993,7 +42333,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -45079,7 +42420,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -45144,7 +42486,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -45167,7 +42510,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -45204,7 +42548,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -45234,7 +42579,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -45250,7 +42596,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -45273,7 +42620,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -45309,7 +42657,8 @@
           "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -45345,7 +42694,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -45381,7 +42731,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   },
   "1.2.0": {
@@ -45406,7 +42757,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -45443,7 +42795,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -45473,7 +42826,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -45481,7 +42835,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -45518,7 +42873,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -45541,7 +42897,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -45549,7 +42906,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -45572,7 +42930,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -45609,7 +42968,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L28"
     },
     "streamlit.button": {
       "name": "button",
@@ -45667,7 +43027,8 @@
           "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -45732,7 +43093,8 @@
           "default": "None."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/legacy_caching/caching.py#L358"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -45748,7 +43110,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -45813,7 +43176,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "streamlit.code": {
       "name": "code",
@@ -45836,7 +43200,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -45901,7 +43266,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "streamlit.columns": {
       "name": "columns",
@@ -45924,7 +43290,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "streamlit.container": {
       "name": "container",
@@ -45932,7 +43299,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -45962,7 +43330,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -46041,7 +43410,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "streamlit.download_button": {
       "name": "download_button",
@@ -46120,7 +43490,8 @@
           "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -46136,7 +43507,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L437"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -46144,7 +43516,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -46160,7 +43533,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -46176,7 +43550,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "streamlit.expander": {
       "name": "expander",
@@ -46199,7 +43574,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -46214,7 +43590,8 @@
           "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L316"
     },
     "streamlit.experimental_memo": {
       "name": "experimental_memo",
@@ -46265,14 +43642,16 @@
           "default": "None."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/memo_decorator.py#L200"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L549"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -46288,7 +43667,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L347"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -46305,7 +43685,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L243"
     },
     "streamlit.experimental_singleton": {
       "name": "experimental_singleton",
@@ -46335,7 +43716,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/singleton_decorator.py#L114"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -46407,7 +43789,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "streamlit.form": {
       "name": "form",
@@ -46430,7 +43813,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -46480,7 +43864,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -46495,7 +43880,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -46518,7 +43904,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "streamlit.header": {
       "name": "header",
@@ -46541,7 +43928,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -46557,7 +43945,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
     },
     "streamlit.image": {
       "name": "image",
@@ -46615,7 +44004,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
     },
     "streamlit.info": {
       "name": "info",
@@ -46631,7 +44021,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -46647,7 +44038,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -46663,7 +44055,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -46700,7 +44093,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "streamlit.map": {
       "name": "map",
@@ -46723,7 +44117,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -46746,7 +44141,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.metric": {
       "name": "metric",
@@ -46783,7 +44179,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -46862,11 +44259,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fe57d651f70>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f15fe02d8e0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -46955,7 +44353,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -47006,7 +44405,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -47022,7 +44422,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -47038,7 +44439,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -47069,7 +44471,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -47148,7 +44551,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -47227,7 +44631,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -47306,7 +44711,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -47328,7 +44734,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L209"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -47372,7 +44779,8 @@
           "default": "About"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L30"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -47465,7 +44873,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -47481,7 +44890,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L377"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -47489,7 +44899,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L529"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -47512,7 +44923,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -47528,7 +44940,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -47544,7 +44957,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "streamlit.text": {
       "name": "text",
@@ -47560,7 +44974,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -47646,7 +45061,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L153"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -47739,7 +45155,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -47804,7 +45221,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "streamlit.title": {
       "name": "title",
@@ -47827,7 +45245,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -47864,7 +45283,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "streamlit.video": {
       "name": "video",
@@ -47894,7 +45314,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -47910,7 +45331,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -47933,7 +45355,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -47956,7 +45379,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -47979,7 +45403,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -48016,7 +45441,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -48046,7 +45472,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -48054,7 +45481,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -48091,7 +45519,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -48114,7 +45543,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -48122,7 +45552,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -48145,7 +45576,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -48182,7 +45614,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L28"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -48240,7 +45673,8 @@
           "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -48256,7 +45690,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -48321,7 +45756,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -48344,7 +45780,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -48409,7 +45846,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "DeltaGenerator.columns": {
       "name": "columns",
@@ -48432,7 +45870,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "DeltaGenerator.container": {
       "name": "container",
@@ -48440,7 +45879,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -48470,7 +45910,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -48549,7 +45990,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "DeltaGenerator.determine_delta_color_and_direction": {
       "name": "determine_delta_color_and_direction",
@@ -48632,7 +46074,8 @@
           "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "DeltaGenerator.empty": {
       "name": "empty",
@@ -48640,7 +46083,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -48656,7 +46100,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -48672,7 +46117,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -48695,7 +46141,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -48767,7 +46214,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -48790,7 +46238,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -48840,7 +46289,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -48863,7 +46313,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -48886,7 +46337,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -48902,7 +46354,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -48960,7 +46413,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -48976,7 +46430,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.is_negative": {
       "name": "is_negative",
@@ -48996,7 +46451,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -49012,7 +46468,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -49049,7 +46506,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -49072,7 +46530,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -49095,7 +46554,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.metric": {
       "name": "metric",
@@ -49132,7 +46592,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -49211,11 +46672,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fe57d651f70>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f15fe02d8e0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -49304,7 +46766,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "DeltaGenerator.parse_delta": {
       "name": "parse_delta",
@@ -49367,7 +46830,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -49383,7 +46847,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -49399,7 +46864,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -49430,7 +46896,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -49509,7 +46976,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -49588,7 +47056,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -49667,7 +47136,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -49760,7 +47230,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -49783,7 +47254,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -49799,7 +47271,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -49815,7 +47288,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -49831,7 +47305,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -49917,7 +47392,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L153"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -50010,7 +47486,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -50075,7 +47552,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -50098,7 +47576,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -50135,7 +47614,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -50165,7 +47645,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -50181,7 +47662,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -50204,7 +47686,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -50240,7 +47723,8 @@
           "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -50276,7 +47760,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -50312,7 +47797,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   },
   "1.3.0": {
@@ -50337,7 +47823,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -50374,7 +47861,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -50404,7 +47892,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -50412,7 +47901,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -50449,7 +47939,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -50472,7 +47963,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -50480,7 +47972,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -50503,7 +47996,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -50540,7 +48034,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L29"
     },
     "streamlit.button": {
       "name": "button",
@@ -50598,7 +48093,8 @@
           "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -50663,7 +48159,8 @@
           "default": "None."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/legacy_caching/caching.py#L358"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -50686,7 +48183,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -50751,7 +48249,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "streamlit.code": {
       "name": "code",
@@ -50774,7 +48273,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -50839,7 +48339,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "streamlit.columns": {
       "name": "columns",
@@ -50862,7 +48363,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "streamlit.container": {
       "name": "container",
@@ -50870,7 +48372,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -50900,7 +48403,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -50979,7 +48483,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "streamlit.download_button": {
       "name": "download_button",
@@ -51058,7 +48563,8 @@
           "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -51074,7 +48580,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L441"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -51082,7 +48589,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -51098,7 +48606,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -51114,7 +48623,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "streamlit.expander": {
       "name": "expander",
@@ -51137,7 +48647,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L172"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -51152,7 +48663,8 @@
           "description": "<p>The current query parameters as a dict. &quot;Query parameters&quot; are the part of the URL that comes\nafter the first &quot;?&quot;.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L316"
     },
     "streamlit.experimental_memo": {
       "name": "experimental_memo",
@@ -51203,14 +48715,16 @@
           "default": "None."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/memo_decorator.py#L224"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
       "signature": "st.experimental_rerun()",
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L553"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -51226,7 +48740,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L347"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -51243,7 +48758,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L243"
     },
     "streamlit.experimental_singleton": {
       "name": "experimental_singleton",
@@ -51273,7 +48789,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/singleton_decorator.py#L135"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -51345,7 +48862,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "streamlit.form": {
       "name": "form",
@@ -51368,7 +48886,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -51418,7 +48937,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -51433,7 +48953,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -51456,7 +48977,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L30"
     },
     "streamlit.header": {
       "name": "header",
@@ -51479,7 +49001,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -51495,7 +49018,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
     },
     "streamlit.image": {
       "name": "image",
@@ -51553,7 +49077,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
     },
     "streamlit.info": {
       "name": "info",
@@ -51569,7 +49094,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -51585,7 +49111,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -51601,7 +49128,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L252"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -51638,7 +49166,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "streamlit.map": {
       "name": "map",
@@ -51661,7 +49190,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -51684,7 +49214,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.metric": {
       "name": "metric",
@@ -51721,7 +49252,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -51800,11 +49332,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fb86815b3a0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f73fc4dd790>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -51893,7 +49426,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -51944,7 +49478,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -51960,7 +49495,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -51976,7 +49512,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -52007,7 +49544,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -52086,7 +49624,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -52165,7 +49704,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -52244,7 +49784,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -52266,7 +49807,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L209"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -52310,7 +49852,8 @@
           "default": "About"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L30"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -52403,7 +49946,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -52419,7 +49963,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L377"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -52427,7 +49972,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nname = st.text_input('Name')\nif not name:\n  st.warning('Please input a name.')\n  st.stop()\nst.success('Thank you for inputting a name.')\n</pre>\n</blockquote>\n",
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L533"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -52450,7 +49996,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -52466,7 +50013,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -52482,7 +50030,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "streamlit.text": {
       "name": "text",
@@ -52498,7 +50047,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -52584,7 +50134,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L153"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -52677,7 +50228,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -52742,7 +50294,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "streamlit.title": {
       "name": "title",
@@ -52765,7 +50318,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -52802,7 +50356,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "streamlit.video": {
       "name": "video",
@@ -52832,7 +50387,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -52848,7 +50404,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -52871,7 +50428,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L39"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -52894,7 +50452,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -52917,7 +50476,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -52954,7 +50514,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -52984,7 +50545,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -52992,7 +50554,8 @@
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nst.balloons()\n</pre>\n<p>...then watch your app and get ready for a celebration!</p>\n</blockquote>\n",
       "description": "Draw celebratory balloons.",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -53029,7 +50592,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -53052,7 +50616,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -53060,7 +50625,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -53083,7 +50649,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -53120,7 +50687,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L29"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -53178,7 +50746,8 @@
           "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -53201,7 +50770,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -53266,7 +50836,8 @@
           "description": "<p>Whether or not the checkbox is checked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -53289,7 +50860,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -53354,7 +50926,8 @@
           "description": "<p>The selected color as a hex string.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "DeltaGenerator.columns": {
       "name": "columns",
@@ -53377,7 +50950,8 @@
           "description": "<p>A list of container objects.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "DeltaGenerator.container": {
       "name": "container",
@@ -53385,7 +50959,8 @@
       "examples": "<blockquote>\n<p>Inserting elements using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nwith st.container():\n    st.write(&quot;This is inside the container&quot;)\n\n    # You can call any Streamlit command, including custom components:\n    st.bar_chart(np.random.randn(50, 3))\n\nst.write(&quot;This is outside the container&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 420px\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=Qj8PY3v3L8dgVjjQCreHux\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            <p>Inserting elements out of order:</p>\n<pre class=\"doctest-block\">\ncontainer = st.container()\ncontainer.write(&quot;This is inside the container&quot;)\nst.write(&quot;This is outside the container&quot;)\n\n# Now insert some more in the container\ncontainer.write(&quot;This is inside too&quot;)\n</pre>\n\n                <iframe\n                    loading=\"lazy\"\n                    src=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL&embed=true\"\n                    style=\"\n                        width: 100%;\n                        border: none;\n                        height: 10rem;\n                    \"\n                ></iframe>\n                <sup><a href=\"https://static.streamlit.io/0.66.0-Wnid/index.html?id=GsFVF5QYT3Ljr6jQjErPqL\" target=\"_blank\">\n                    (view standalone Streamlit app)\n                </a></sup>\n            </blockquote>\n",
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -53415,7 +50990,8 @@
           "default": "height"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -53494,7 +51070,8 @@
           "description": "<p>The current value of the date input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "DeltaGenerator.determine_delta_color_and_direction": {
       "name": "determine_delta_color_and_direction",
@@ -53577,7 +51154,8 @@
           "description": "<p>True if the button was clicked on the last run of the app,\nFalse otherwise.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "DeltaGenerator.empty": {
       "name": "empty",
@@ -53585,7 +51163,8 @@
       "examples": "<blockquote>\n<p>Overwriting elements in-place using &quot;with&quot; notation:</p>\n<pre class=\"doctest-block\">\nimport time\n\nwith st.empty():\n     for seconds in range(60):\n         st.write(f&quot;\u23f3 {seconds} seconds have passed&quot;)\n         time.sleep(1)\n     st.write(&quot;\u2714\ufe0f 1 minute over!&quot;)\n</pre>\n<p>Replacing several elements, then clearing them:</p>\n<pre class=\"doctest-block\">\nplaceholder = st.empty()\n\n# Replace the placeholder with some text:\nplaceholder.text(&quot;Hello&quot;)\n\n# Replace the text with a chart:\nplaceholder.line_chart({&quot;data&quot;: [1, 5, 2, 6]})\n\n# Replace the chart with several elements:\nwith placeholder.container():\n     st.write(&quot;This is one element&quot;)\n     st.write(&quot;This is another&quot;)\n\n# Clear all those elements:\nplaceholder.empty()\n</pre>\n</blockquote>\n",
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -53601,7 +51180,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -53617,7 +51197,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -53640,7 +51221,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L172"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -53712,7 +51294,8 @@
           "description": "<ul class=\"simple\">\n<li>If accept_multiple_files is False, returns either None or\nan UploadedFile object.</li>\n<li>If accept_multiple_files is True, returns a list with the\nuploaded files as UploadedFile objects. If no files were\nuploaded, returns an empty list.</li>\n</ul>\n<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -53735,7 +51318,8 @@
           "default": "values"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -53785,7 +51369,8 @@
           "description": "<p>True if the button was clicked.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -53808,7 +51393,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L30"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -53831,7 +51417,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -53847,7 +51434,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -53905,7 +51493,8 @@
           "default": "s"
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -53921,7 +51510,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.is_negative": {
       "name": "is_negative",
@@ -53941,7 +51531,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -53957,7 +51548,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L252"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -53994,7 +51586,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -54017,7 +51610,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -54040,7 +51634,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.metric": {
       "name": "metric",
@@ -54077,7 +51672,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -54156,11 +51752,12 @@
           "description": "<p>A list with the selected options</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fb86815b3a0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f73fc4dd790>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -54249,7 +51846,8 @@
           "description": "<p>The current value of the numeric input widget. The return type\nwill match the data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "DeltaGenerator.parse_delta": {
       "name": "parse_delta",
@@ -54312,7 +51910,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -54328,7 +51927,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -54344,7 +51944,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -54375,7 +51976,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -54454,7 +52056,8 @@
           "description": "<p>The selected option.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -54533,7 +52136,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -54612,7 +52216,8 @@
           "description": "<p>The selected option</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -54705,7 +52310,8 @@
           "description": "<p>The current value of the slider widget. The return type will match\nthe data type of the value parameter.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -54728,7 +52334,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -54744,7 +52351,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -54760,7 +52368,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -54776,7 +52385,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -54862,7 +52472,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L153"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -54955,7 +52566,8 @@
           "description": "<p>The current value of the text input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -55020,7 +52632,8 @@
           "description": "<p>The current value of the time input widget.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -55043,7 +52656,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -55080,7 +52694,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -55110,7 +52725,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -55126,7 +52742,8 @@
           "default": null
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -55149,7 +52766,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L39"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -55185,7 +52803,8 @@
           "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
           "return_name": null
         }
-      ]
+      ],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -55221,7 +52840,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -55257,7 +52877,8 @@
           "default": "False."
         }
       ],
-      "returns": []
+      "returns": [],
+      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   }
 }

--- a/python/streamlit.json
+++ b/python/streamlit.json
@@ -22,7 +22,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L181"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L181"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -60,7 +60,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L83"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L83"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -91,7 +91,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -100,7 +100,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -138,7 +138,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L132"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L132"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -162,7 +162,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L67"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L67"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -171,7 +171,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L24"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -195,7 +195,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L168"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L168"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -233,7 +233,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "streamlit.button": {
       "name": "button",
@@ -271,7 +271,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L32"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -337,7 +337,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching.py#L357"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching.py#L357"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -354,7 +354,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -399,7 +399,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L24"
     },
     "streamlit.code": {
       "name": "code",
@@ -423,7 +423,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -468,7 +468,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L26"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L26"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -499,7 +499,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L35"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L35"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -558,7 +558,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L87"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L87"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -575,7 +575,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L399"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L399"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -584,7 +584,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -601,7 +601,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -618,7 +618,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -634,7 +634,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L282"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L282"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
@@ -642,7 +642,7 @@
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L511"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L511"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -659,7 +659,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L313"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L313"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -677,7 +677,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L213"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L213"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -729,7 +729,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L31"
     },
     "streamlit.form": {
       "name": "form",
@@ -753,7 +753,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -783,7 +783,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L195"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L195"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -799,7 +799,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -823,7 +823,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "streamlit.header": {
       "name": "header",
@@ -847,7 +847,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -864,7 +864,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "streamlit.image": {
       "name": "image",
@@ -923,7 +923,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "streamlit.info": {
       "name": "info",
@@ -940,7 +940,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -957,7 +957,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L23"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -974,7 +974,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -1012,7 +1012,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L33"
     },
     "streamlit.map": {
       "name": "map",
@@ -1036,7 +1036,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -1060,7 +1060,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -1119,11 +1119,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L26"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L26"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7f6a785b8c70>, step=None, format=None, key=None, help=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7f467366c850>, step=None, format=None, key=None, help=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -1192,7 +1192,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L27"
     },
     "streamlit.object_beta_warning": {
       "name": "object_beta_warning",
@@ -1222,7 +1222,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L57"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L57"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -1274,7 +1274,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -1291,7 +1291,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -1308,7 +1308,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -1340,7 +1340,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -1399,7 +1399,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L26"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L26"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -1458,7 +1458,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L27"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -1517,7 +1517,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L26"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L26"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -1540,7 +1540,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L179"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L179"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -1578,7 +1578,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L22"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -1651,7 +1651,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L28"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L28"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -1668,7 +1668,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L343"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L343"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -1677,7 +1677,7 @@
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L491"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L491"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -1701,7 +1701,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -1718,7 +1718,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -1735,7 +1735,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L94"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L94"
     },
     "streamlit.text": {
       "name": "text",
@@ -1752,7 +1752,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -1811,7 +1811,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L87"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L87"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -1870,7 +1870,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L26"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L26"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -1915,7 +1915,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L29"
     },
     "streamlit.title": {
       "name": "title",
@@ -1939,7 +1939,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -1977,7 +1977,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/vega_lite.py#L30"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/vega_lite.py#L30"
     },
     "streamlit.video": {
       "name": "video",
@@ -2008,7 +2008,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -2025,7 +2025,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -2049,7 +2049,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L37"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -2080,7 +2080,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/delta_generator.py#L454"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/delta_generator.py#L454"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -2104,7 +2104,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L181"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L181"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -2142,7 +2142,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L83"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L83"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -2173,7 +2173,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -2182,7 +2182,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -2220,7 +2220,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L132"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L132"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -2244,7 +2244,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L67"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L67"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -2253,7 +2253,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L24"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -2277,7 +2277,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L168"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L168"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -2315,7 +2315,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -2353,7 +2353,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L32"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -2370,7 +2370,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -2415,7 +2415,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L24"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -2439,7 +2439,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -2484,7 +2484,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L26"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L26"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -2515,7 +2515,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L35"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L35"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -2574,7 +2574,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L87"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L87"
     },
     "DeltaGenerator.empty": {
       "name": "empty",
@@ -2583,7 +2583,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -2600,7 +2600,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -2617,7 +2617,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -2669,7 +2669,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L31"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -2693,7 +2693,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -2723,7 +2723,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L195"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L195"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -2747,7 +2747,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -2771,7 +2771,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -2788,7 +2788,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -2847,7 +2847,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -2864,7 +2864,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.json": {
       "name": "json",
@@ -2881,7 +2881,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L23"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -2898,7 +2898,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -2936,7 +2936,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L33"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -2960,7 +2960,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -2984,7 +2984,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -3043,11 +3043,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L26"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L26"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7f6a785b8c70>, step=None, format=None, key=None, help=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.widgets.NoValue object at 0x7f467366c850>, step=None, format=None, key=None, help=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -3116,7 +3116,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L27"
     },
     "DeltaGenerator.plotly_chart": {
       "name": "plotly_chart",
@@ -3168,7 +3168,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -3185,7 +3185,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -3202,7 +3202,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -3234,7 +3234,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -3293,7 +3293,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L26"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L26"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -3352,7 +3352,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L27"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -3411,7 +3411,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L26"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L26"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -3484,7 +3484,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L28"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L28"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -3508,7 +3508,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -3525,7 +3525,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -3542,7 +3542,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L94"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L94"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -3559,7 +3559,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -3618,7 +3618,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L87"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L87"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -3677,7 +3677,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L26"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L26"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -3722,7 +3722,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L29"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -3746,7 +3746,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -3784,7 +3784,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/vega_lite.py#L30"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/vega_lite.py#L30"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -3815,7 +3815,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -3832,7 +3832,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -3856,7 +3856,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L37"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -3893,7 +3893,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L252"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L252"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -3930,7 +3930,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -3967,7 +3967,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   },
   "0.84.0": {
@@ -3993,7 +3993,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L181"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L181"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -4031,7 +4031,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L83"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L83"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -4062,7 +4062,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -4071,7 +4071,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -4109,7 +4109,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L132"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L132"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -4133,7 +4133,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L69"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L69"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -4142,7 +4142,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L26"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L26"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -4166,7 +4166,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L170"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L170"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -4204,7 +4204,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "streamlit.button": {
       "name": "button",
@@ -4263,7 +4263,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L39"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L39"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -4329,7 +4329,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching.py#L357"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching.py#L357"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -4346,7 +4346,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -4412,7 +4412,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L25"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L25"
     },
     "streamlit.code": {
       "name": "code",
@@ -4436,7 +4436,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -4502,7 +4502,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L27"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -4533,7 +4533,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L35"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L35"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -4613,7 +4613,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L128"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L128"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -4630,7 +4630,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L406"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L406"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -4639,7 +4639,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -4656,7 +4656,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -4673,7 +4673,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -4689,7 +4689,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L289"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L289"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
@@ -4697,7 +4697,7 @@
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L518"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L518"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -4714,7 +4714,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L320"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L320"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -4732,7 +4732,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L220"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L220"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -4805,7 +4805,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L32"
     },
     "streamlit.form": {
       "name": "form",
@@ -4829,7 +4829,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -4880,7 +4880,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -4896,7 +4896,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -4920,7 +4920,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "streamlit.header": {
       "name": "header",
@@ -4944,7 +4944,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -4961,7 +4961,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "streamlit.image": {
       "name": "image",
@@ -5020,7 +5020,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "streamlit.info": {
       "name": "info",
@@ -5037,7 +5037,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -5054,7 +5054,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -5071,7 +5071,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -5109,7 +5109,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L33"
     },
     "streamlit.map": {
       "name": "map",
@@ -5133,7 +5133,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -5157,7 +5157,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -5237,11 +5237,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L27"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f8d7f2fc6a0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f1025165400>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -5331,7 +5331,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L28"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L28"
     },
     "streamlit.object_beta_warning": {
       "name": "object_beta_warning",
@@ -5361,7 +5361,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L57"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L57"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -5413,7 +5413,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -5430,7 +5430,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -5447,7 +5447,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -5479,7 +5479,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -5559,7 +5559,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L28"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L28"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -5639,7 +5639,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L28"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L28"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -5719,7 +5719,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L28"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L28"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -5742,7 +5742,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L186"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L186"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -5780,7 +5780,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L22"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -5874,7 +5874,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L30"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L30"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -5891,7 +5891,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L350"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L350"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -5900,7 +5900,7 @@
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L498"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L498"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -5924,7 +5924,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -5941,7 +5941,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -5958,7 +5958,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L94"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L94"
     },
     "streamlit.text": {
       "name": "text",
@@ -5975,7 +5975,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -6055,7 +6055,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L135"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L135"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -6142,7 +6142,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L27"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -6208,7 +6208,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L30"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L30"
     },
     "streamlit.title": {
       "name": "title",
@@ -6232,7 +6232,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -6270,7 +6270,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/vega_lite.py#L30"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/vega_lite.py#L30"
     },
     "streamlit.video": {
       "name": "video",
@@ -6301,7 +6301,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -6318,7 +6318,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -6342,7 +6342,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -6373,7 +6373,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/delta_generator.py#L454"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/delta_generator.py#L454"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -6397,7 +6397,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L181"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L181"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -6435,7 +6435,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L83"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L83"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -6466,7 +6466,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -6475,7 +6475,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -6513,7 +6513,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L132"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L132"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -6537,7 +6537,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L69"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L69"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -6546,7 +6546,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L26"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L26"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -6570,7 +6570,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L170"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L170"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -6608,7 +6608,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -6667,7 +6667,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L39"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L39"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -6684,7 +6684,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -6750,7 +6750,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L25"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L25"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -6774,7 +6774,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -6840,7 +6840,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L27"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -6871,7 +6871,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L35"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L35"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -6951,7 +6951,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L128"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L128"
     },
     "DeltaGenerator.empty": {
       "name": "empty",
@@ -6960,7 +6960,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -6977,7 +6977,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -6994,7 +6994,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -7067,7 +7067,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L32"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -7091,7 +7091,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -7142,7 +7142,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -7166,7 +7166,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -7190,7 +7190,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -7207,7 +7207,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -7266,7 +7266,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -7283,7 +7283,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.json": {
       "name": "json",
@@ -7300,7 +7300,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -7317,7 +7317,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -7355,7 +7355,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/altair.py#L33"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -7379,7 +7379,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -7403,7 +7403,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -7483,11 +7483,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L27"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f8d7f2fc6a0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f1025165400>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -7577,7 +7577,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L28"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L28"
     },
     "DeltaGenerator.plotly_chart": {
       "name": "plotly_chart",
@@ -7629,7 +7629,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -7646,7 +7646,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -7663,7 +7663,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -7695,7 +7695,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -7775,7 +7775,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L28"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L28"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -7855,7 +7855,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L28"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L28"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -7935,7 +7935,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L28"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L28"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -8029,7 +8029,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L30"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L30"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -8053,7 +8053,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -8070,7 +8070,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -8087,7 +8087,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L94"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/data_frame.py#L94"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -8104,7 +8104,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -8184,7 +8184,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L135"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L135"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -8271,7 +8271,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L27"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -8337,7 +8337,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L30"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L30"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -8361,7 +8361,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -8399,7 +8399,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/vega_lite.py#L30"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/vega_lite.py#L30"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -8430,7 +8430,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -8447,7 +8447,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -8471,7 +8471,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -8508,7 +8508,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L256"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L256"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -8545,7 +8545,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -8582,7 +8582,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   },
   "0.85.0": {
@@ -8608,7 +8608,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L255"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L255"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -8646,7 +8646,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L166"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L166"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -8677,7 +8677,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -8686,7 +8686,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -8724,7 +8724,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L210"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L210"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -8748,7 +8748,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L69"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L69"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -8757,7 +8757,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L26"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L26"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -8781,7 +8781,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L170"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L170"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -8819,7 +8819,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "streamlit.button": {
       "name": "button",
@@ -8878,7 +8878,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L40"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L40"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -8944,7 +8944,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching.py#L327"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching.py#L327"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -8961,7 +8961,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -9027,7 +9027,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L26"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L26"
     },
     "streamlit.code": {
       "name": "code",
@@ -9051,7 +9051,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -9117,7 +9117,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L28"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L28"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -9148,7 +9148,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -9228,7 +9228,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L129"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L129"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -9245,7 +9245,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L423"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L423"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -9254,7 +9254,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -9271,7 +9271,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -9288,7 +9288,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -9304,7 +9304,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L306"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L306"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
@@ -9312,7 +9312,7 @@
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L535"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L535"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -9329,7 +9329,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L337"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L337"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -9347,7 +9347,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L237"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L237"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -9420,7 +9420,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L33"
     },
     "streamlit.form": {
       "name": "form",
@@ -9444,7 +9444,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -9495,7 +9495,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -9511,7 +9511,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -9535,7 +9535,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "streamlit.header": {
       "name": "header",
@@ -9559,7 +9559,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -9576,7 +9576,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "streamlit.image": {
       "name": "image",
@@ -9635,7 +9635,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "streamlit.info": {
       "name": "info",
@@ -9652,7 +9652,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -9669,7 +9669,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -9686,7 +9686,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -9724,7 +9724,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "streamlit.map": {
       "name": "map",
@@ -9748,7 +9748,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -9772,7 +9772,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -9852,11 +9852,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L29"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7faef7496880>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f2909577760>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -9946,7 +9946,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L29"
     },
     "streamlit.object_beta_warning": {
       "name": "object_beta_warning",
@@ -9976,7 +9976,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L57"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L57"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -10028,7 +10028,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -10045,7 +10045,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -10062,7 +10062,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -10094,7 +10094,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -10174,7 +10174,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L29"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -10254,7 +10254,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L29"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -10334,7 +10334,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L29"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -10357,7 +10357,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L203"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L203"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -10395,7 +10395,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L22"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -10489,7 +10489,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L31"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -10506,7 +10506,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L367"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L367"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -10515,7 +10515,7 @@
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L515"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L515"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -10539,7 +10539,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -10556,7 +10556,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -10573,7 +10573,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "streamlit.text": {
       "name": "text",
@@ -10590,7 +10590,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -10670,7 +10670,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L137"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L137"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -10757,7 +10757,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L29"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -10823,7 +10823,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L31"
     },
     "streamlit.title": {
       "name": "title",
@@ -10847,7 +10847,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -10885,7 +10885,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L293"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L293"
     },
     "streamlit.video": {
       "name": "video",
@@ -10916,7 +10916,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -10933,7 +10933,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -10957,7 +10957,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -10981,7 +10981,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L362"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L362"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -11005,7 +11005,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L255"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L255"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -11043,7 +11043,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L166"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L166"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -11074,7 +11074,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -11083,7 +11083,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -11121,7 +11121,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L210"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L210"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -11145,7 +11145,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L69"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L69"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -11154,7 +11154,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L26"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L26"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -11178,7 +11178,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L170"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L170"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -11216,7 +11216,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -11275,7 +11275,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L40"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L40"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -11292,7 +11292,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -11358,7 +11358,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L26"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L26"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -11382,7 +11382,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -11448,7 +11448,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L28"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L28"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -11479,7 +11479,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -11559,7 +11559,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L129"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L129"
     },
     "DeltaGenerator.empty": {
       "name": "empty",
@@ -11568,7 +11568,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -11585,7 +11585,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -11602,7 +11602,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -11675,7 +11675,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L33"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -11699,7 +11699,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -11750,7 +11750,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -11774,7 +11774,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -11798,7 +11798,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -11815,7 +11815,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -11874,7 +11874,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -11891,7 +11891,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.json": {
       "name": "json",
@@ -11908,7 +11908,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -11925,7 +11925,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -11963,7 +11963,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -11987,7 +11987,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -12011,7 +12011,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -12091,11 +12091,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L29"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7faef7496880>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f2909577760>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -12185,7 +12185,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L29"
     },
     "DeltaGenerator.plotly_chart": {
       "name": "plotly_chart",
@@ -12237,7 +12237,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -12254,7 +12254,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -12271,7 +12271,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -12303,7 +12303,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -12383,7 +12383,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L29"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -12463,7 +12463,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L29"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -12543,7 +12543,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L29"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -12637,7 +12637,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L31"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -12661,7 +12661,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -12678,7 +12678,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -12695,7 +12695,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -12712,7 +12712,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -12792,7 +12792,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L137"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L137"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -12879,7 +12879,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L29"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -12945,7 +12945,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L31"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -12969,7 +12969,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -13007,7 +13007,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L293"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L293"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -13038,7 +13038,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -13055,7 +13055,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -13079,7 +13079,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -13116,7 +13116,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -13153,7 +13153,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -13190,7 +13190,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   },
   "0.86.0": {
@@ -13216,7 +13216,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L255"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L255"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -13254,7 +13254,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L166"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L166"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -13285,7 +13285,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -13294,7 +13294,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -13332,7 +13332,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L210"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L210"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -13356,7 +13356,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -13365,7 +13365,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -13389,7 +13389,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -13427,7 +13427,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "streamlit.button": {
       "name": "button",
@@ -13486,7 +13486,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L40"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L40"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -13552,7 +13552,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching.py#L327"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching.py#L327"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -13569,7 +13569,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -13635,7 +13635,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L31"
     },
     "streamlit.code": {
       "name": "code",
@@ -13659,7 +13659,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -13725,7 +13725,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L33"
     },
     "streamlit.columns": {
       "name": "columns",
@@ -13749,7 +13749,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "streamlit.container": {
       "name": "container",
@@ -13758,7 +13758,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -13789,7 +13789,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -13869,7 +13869,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L134"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L134"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -13886,7 +13886,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L424"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L424"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -13895,7 +13895,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -13912,7 +13912,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -13929,7 +13929,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
     },
     "streamlit.expander": {
       "name": "expander",
@@ -13953,7 +13953,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -13969,7 +13969,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L307"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L307"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
@@ -13977,7 +13977,7 @@
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L536"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L536"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -13994,7 +13994,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L338"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L338"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -14012,7 +14012,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L238"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L238"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -14085,7 +14085,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L40"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L40"
     },
     "streamlit.form": {
       "name": "form",
@@ -14109,7 +14109,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -14160,7 +14160,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -14176,7 +14176,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -14200,7 +14200,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "streamlit.header": {
       "name": "header",
@@ -14224,7 +14224,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -14241,7 +14241,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "streamlit.image": {
       "name": "image",
@@ -14300,7 +14300,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "streamlit.info": {
       "name": "info",
@@ -14317,7 +14317,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -14334,7 +14334,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -14351,7 +14351,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -14389,7 +14389,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "streamlit.map": {
       "name": "map",
@@ -14413,7 +14413,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -14437,7 +14437,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -14517,11 +14517,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f8216751340>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f5cb67462b0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -14611,7 +14611,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L36"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -14663,7 +14663,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -14680,7 +14680,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -14697,7 +14697,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -14729,7 +14729,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -14809,7 +14809,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -14889,7 +14889,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -14969,7 +14969,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -14992,7 +14992,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L204"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L204"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -15030,7 +15030,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L22"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -15124,7 +15124,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L36"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -15141,7 +15141,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L368"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L368"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -15150,7 +15150,7 @@
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L516"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L516"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -15174,7 +15174,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -15191,7 +15191,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -15208,7 +15208,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "streamlit.text": {
       "name": "text",
@@ -15225,7 +15225,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -15305,7 +15305,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L142"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L142"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -15392,7 +15392,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L34"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -15458,7 +15458,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L36"
     },
     "streamlit.title": {
       "name": "title",
@@ -15482,7 +15482,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -15520,7 +15520,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L293"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L293"
     },
     "streamlit.video": {
       "name": "video",
@@ -15551,7 +15551,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -15568,7 +15568,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -15592,7 +15592,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -15616,7 +15616,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L362"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L362"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -15640,7 +15640,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L255"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L255"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -15678,7 +15678,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L166"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L166"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -15709,7 +15709,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -15718,7 +15718,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -15756,7 +15756,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L210"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L210"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -15780,7 +15780,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -15789,7 +15789,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -15813,7 +15813,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -15851,7 +15851,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -15910,7 +15910,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L40"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L40"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -15927,7 +15927,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -15993,7 +15993,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L31"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -16017,7 +16017,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -16083,7 +16083,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L33"
     },
     "DeltaGenerator.columns": {
       "name": "columns",
@@ -16107,7 +16107,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "DeltaGenerator.container": {
       "name": "container",
@@ -16116,7 +16116,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -16147,7 +16147,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -16227,7 +16227,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L134"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L134"
     },
     "DeltaGenerator.empty": {
       "name": "empty",
@@ -16236,7 +16236,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -16253,7 +16253,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -16270,7 +16270,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -16294,7 +16294,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -16367,7 +16367,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L40"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L40"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -16391,7 +16391,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -16442,7 +16442,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -16466,7 +16466,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -16490,7 +16490,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -16507,7 +16507,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -16566,7 +16566,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -16583,7 +16583,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.json": {
       "name": "json",
@@ -16600,7 +16600,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -16617,7 +16617,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -16655,7 +16655,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -16679,7 +16679,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -16703,7 +16703,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -16783,11 +16783,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f8216751340>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f5cb67462b0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -16877,7 +16877,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L36"
     },
     "DeltaGenerator.plotly_chart": {
       "name": "plotly_chart",
@@ -16929,7 +16929,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -16946,7 +16946,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -16963,7 +16963,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -16995,7 +16995,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -17075,7 +17075,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -17155,7 +17155,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -17235,7 +17235,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -17329,7 +17329,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L36"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -17353,7 +17353,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -17370,7 +17370,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -17387,7 +17387,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -17404,7 +17404,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -17484,7 +17484,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L142"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L142"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -17571,7 +17571,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L34"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -17637,7 +17637,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L36"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -17661,7 +17661,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -17699,7 +17699,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L293"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L293"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -17730,7 +17730,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -17747,7 +17747,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -17771,7 +17771,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -17808,7 +17808,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -17845,7 +17845,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -17882,7 +17882,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   },
   "0.87.0": {
@@ -17908,7 +17908,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -17946,7 +17946,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -17977,7 +17977,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -17986,7 +17986,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -18024,7 +18024,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -18048,7 +18048,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -18057,7 +18057,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -18081,7 +18081,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -18119,7 +18119,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "streamlit.button": {
       "name": "button",
@@ -18178,7 +18178,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L40"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L40"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -18244,7 +18244,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching.py#L327"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching.py#L327"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -18261,7 +18261,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -18327,7 +18327,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L31"
     },
     "streamlit.code": {
       "name": "code",
@@ -18351,7 +18351,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -18417,7 +18417,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L33"
     },
     "streamlit.columns": {
       "name": "columns",
@@ -18441,7 +18441,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "streamlit.container": {
       "name": "container",
@@ -18450,7 +18450,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -18481,7 +18481,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -18561,7 +18561,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L134"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L134"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -18578,7 +18578,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L425"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L425"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -18587,7 +18587,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -18604,7 +18604,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -18621,7 +18621,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
     },
     "streamlit.expander": {
       "name": "expander",
@@ -18645,7 +18645,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -18661,7 +18661,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L308"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L308"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
@@ -18669,7 +18669,7 @@
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L537"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L537"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -18686,7 +18686,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L339"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L339"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -18704,7 +18704,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L239"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L239"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -18777,7 +18777,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L43"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L43"
     },
     "streamlit.form": {
       "name": "form",
@@ -18801,7 +18801,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -18852,7 +18852,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -18868,7 +18868,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -18892,7 +18892,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "streamlit.header": {
       "name": "header",
@@ -18916,7 +18916,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -18933,7 +18933,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "streamlit.image": {
       "name": "image",
@@ -18992,7 +18992,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "streamlit.info": {
       "name": "info",
@@ -19009,7 +19009,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -19026,7 +19026,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -19043,7 +19043,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -19081,7 +19081,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "streamlit.map": {
       "name": "map",
@@ -19105,7 +19105,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -19129,7 +19129,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.metric": {
       "name": "metric",
@@ -19167,7 +19167,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -19247,11 +19247,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f387aadba00>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f2908bfc970>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -19341,7 +19341,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L36"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -19393,7 +19393,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -19410,7 +19410,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -19427,7 +19427,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -19459,7 +19459,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -19539,7 +19539,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -19619,7 +19619,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -19699,7 +19699,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -19722,7 +19722,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L205"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -19760,7 +19760,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L22"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -19854,7 +19854,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L36"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -19871,7 +19871,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L369"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L369"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -19880,7 +19880,7 @@
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L517"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L517"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -19904,7 +19904,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -19921,7 +19921,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -19938,7 +19938,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "streamlit.text": {
       "name": "text",
@@ -19955,7 +19955,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -20035,7 +20035,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L142"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L142"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -20122,7 +20122,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L34"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -20188,7 +20188,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L36"
     },
     "streamlit.title": {
       "name": "title",
@@ -20212,7 +20212,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -20250,7 +20250,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "streamlit.video": {
       "name": "video",
@@ -20281,7 +20281,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -20298,7 +20298,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -20322,7 +20322,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -20346,7 +20346,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -20370,7 +20370,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -20408,7 +20408,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -20439,7 +20439,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -20448,7 +20448,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -20486,7 +20486,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -20510,7 +20510,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -20519,7 +20519,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -20543,7 +20543,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -20581,7 +20581,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -20640,7 +20640,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L40"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L40"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -20657,7 +20657,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -20723,7 +20723,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L31"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -20747,7 +20747,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -20813,7 +20813,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L33"
     },
     "DeltaGenerator.columns": {
       "name": "columns",
@@ -20837,7 +20837,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "DeltaGenerator.container": {
       "name": "container",
@@ -20846,7 +20846,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -20877,7 +20877,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -20957,7 +20957,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L134"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L134"
     },
     "DeltaGenerator.determine_delta_color_and_direction": {
       "name": "determine_delta_color_and_direction",
@@ -20970,7 +20970,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -20987,7 +20987,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -21004,7 +21004,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L31"
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -21028,7 +21028,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -21101,7 +21101,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L43"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L43"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -21125,7 +21125,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -21176,7 +21176,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -21200,7 +21200,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -21224,7 +21224,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -21241,7 +21241,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -21300,7 +21300,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -21317,7 +21317,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.is_negative": {
       "name": "is_negative",
@@ -21338,7 +21338,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -21355,7 +21355,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -21393,7 +21393,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -21417,7 +21417,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -21441,7 +21441,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.metric": {
       "name": "metric",
@@ -21479,7 +21479,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -21559,11 +21559,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f387aadba00>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f2908bfc970>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -21653,7 +21653,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L36"
     },
     "DeltaGenerator.parse_delta": {
       "name": "parse_delta",
@@ -21717,7 +21717,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -21734,7 +21734,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -21751,7 +21751,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -21783,7 +21783,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -21863,7 +21863,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -21943,7 +21943,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -22023,7 +22023,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -22117,7 +22117,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L36"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -22141,7 +22141,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -22158,7 +22158,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -22175,7 +22175,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -22192,7 +22192,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -22272,7 +22272,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L142"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L142"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -22359,7 +22359,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L34"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -22425,7 +22425,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L36"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -22449,7 +22449,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -22487,7 +22487,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -22518,7 +22518,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -22535,7 +22535,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -22559,7 +22559,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -22596,7 +22596,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -22633,7 +22633,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -22670,7 +22670,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   },
   "0.88.0": {
@@ -22696,7 +22696,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -22734,7 +22734,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -22765,7 +22765,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -22774,7 +22774,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -22812,7 +22812,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -22836,7 +22836,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -22845,7 +22845,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -22869,7 +22869,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -22907,7 +22907,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "streamlit.button": {
       "name": "button",
@@ -22966,7 +22966,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -23032,7 +23032,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching.py#L327"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching.py#L327"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -23049,7 +23049,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -23115,7 +23115,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "streamlit.code": {
       "name": "code",
@@ -23139,7 +23139,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -23205,7 +23205,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "streamlit.columns": {
       "name": "columns",
@@ -23229,7 +23229,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "streamlit.container": {
       "name": "container",
@@ -23238,7 +23238,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -23269,7 +23269,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -23349,7 +23349,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "streamlit.download_button": {
       "name": "download_button",
@@ -23429,7 +23429,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -23446,7 +23446,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L426"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L426"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -23455,7 +23455,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -23472,7 +23472,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -23489,7 +23489,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "streamlit.expander": {
       "name": "expander",
@@ -23513,7 +23513,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -23529,7 +23529,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L309"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L309"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
@@ -23537,7 +23537,7 @@
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L538"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L538"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -23554,7 +23554,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L340"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L340"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -23572,7 +23572,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L240"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L240"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -23645,7 +23645,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "streamlit.form": {
       "name": "form",
@@ -23669,7 +23669,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -23720,7 +23720,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -23736,7 +23736,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -23760,7 +23760,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "streamlit.header": {
       "name": "header",
@@ -23784,7 +23784,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -23801,7 +23801,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "streamlit.image": {
       "name": "image",
@@ -23860,7 +23860,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "streamlit.info": {
       "name": "info",
@@ -23877,7 +23877,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -23894,7 +23894,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -23911,7 +23911,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -23949,7 +23949,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "streamlit.map": {
       "name": "map",
@@ -23973,7 +23973,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -23997,7 +23997,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.metric": {
       "name": "metric",
@@ -24035,7 +24035,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -24115,11 +24115,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fb6e2fb0190>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f4351e17070>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -24209,7 +24209,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -24261,7 +24261,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -24278,7 +24278,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -24295,7 +24295,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -24327,7 +24327,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -24407,7 +24407,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -24487,7 +24487,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -24567,7 +24567,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -24590,7 +24590,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L206"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L206"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -24628,7 +24628,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L22"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -24722,7 +24722,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -24739,7 +24739,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L370"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L370"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -24748,7 +24748,7 @@
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L518"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L518"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -24772,7 +24772,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -24789,7 +24789,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -24806,7 +24806,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "streamlit.text": {
       "name": "text",
@@ -24823,7 +24823,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -24903,7 +24903,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -24990,7 +24990,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -25056,7 +25056,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "streamlit.title": {
       "name": "title",
@@ -25080,7 +25080,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -25118,7 +25118,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "streamlit.video": {
       "name": "video",
@@ -25149,7 +25149,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -25166,7 +25166,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -25190,7 +25190,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -25214,7 +25214,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -25238,7 +25238,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -25276,7 +25276,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -25307,7 +25307,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -25316,7 +25316,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -25354,7 +25354,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -25378,7 +25378,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -25387,7 +25387,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -25411,7 +25411,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -25449,7 +25449,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -25508,7 +25508,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -25525,7 +25525,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -25591,7 +25591,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -25615,7 +25615,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -25681,7 +25681,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "DeltaGenerator.columns": {
       "name": "columns",
@@ -25705,7 +25705,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "DeltaGenerator.container": {
       "name": "container",
@@ -25714,7 +25714,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -25745,7 +25745,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -25825,7 +25825,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "DeltaGenerator.determine_delta_color_and_direction": {
       "name": "determine_delta_color_and_direction",
@@ -25909,7 +25909,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "DeltaGenerator.empty": {
       "name": "empty",
@@ -25918,7 +25918,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -25935,7 +25935,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -25952,7 +25952,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -25976,7 +25976,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -26049,7 +26049,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -26073,7 +26073,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -26124,7 +26124,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -26148,7 +26148,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -26172,7 +26172,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -26189,7 +26189,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L34"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -26248,7 +26248,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L43"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -26265,7 +26265,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.is_negative": {
       "name": "is_negative",
@@ -26286,7 +26286,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -26303,7 +26303,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -26341,7 +26341,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -26365,7 +26365,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -26389,7 +26389,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.metric": {
       "name": "metric",
@@ -26427,7 +26427,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -26507,11 +26507,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fb6e2fb0190>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f4351e17070>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -26601,7 +26601,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "DeltaGenerator.parse_delta": {
       "name": "parse_delta",
@@ -26665,7 +26665,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -26682,7 +26682,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -26699,7 +26699,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -26731,7 +26731,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -26811,7 +26811,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -26891,7 +26891,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -26971,7 +26971,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -27065,7 +27065,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -27089,7 +27089,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -27106,7 +27106,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -27123,7 +27123,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -27140,7 +27140,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -27220,7 +27220,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -27307,7 +27307,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -27373,7 +27373,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -27397,7 +27397,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -27435,7 +27435,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -27466,7 +27466,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -27483,7 +27483,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -27507,7 +27507,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -27544,7 +27544,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -27581,7 +27581,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -27618,7 +27618,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   },
   "0.89.0": {
@@ -27644,7 +27644,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -27682,7 +27682,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -27713,7 +27713,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -27722,7 +27722,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -27760,7 +27760,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -27784,7 +27784,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -27793,7 +27793,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -27817,7 +27817,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -27855,7 +27855,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "streamlit.button": {
       "name": "button",
@@ -27914,7 +27914,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -27980,7 +27980,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/legacy_caching/caching.py#L327"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/legacy_caching/caching.py#L327"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -27997,7 +27997,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -28063,7 +28063,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "streamlit.code": {
       "name": "code",
@@ -28087,7 +28087,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -28153,7 +28153,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "streamlit.columns": {
       "name": "columns",
@@ -28177,7 +28177,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "streamlit.container": {
       "name": "container",
@@ -28186,7 +28186,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -28217,7 +28217,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -28297,7 +28297,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "streamlit.download_button": {
       "name": "download_button",
@@ -28377,7 +28377,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -28394,7 +28394,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L436"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L436"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -28403,7 +28403,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -28420,7 +28420,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -28437,7 +28437,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "streamlit.expander": {
       "name": "expander",
@@ -28461,7 +28461,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -28477,7 +28477,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L315"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L315"
     },
     "streamlit.experimental_memo": {
       "name": "experimental_memo",
@@ -28529,7 +28529,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/memo_decorator.py#L118"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/memo_decorator.py#L118"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
@@ -28537,7 +28537,7 @@
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L548"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L548"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -28554,7 +28554,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L346"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L346"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -28572,7 +28572,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L242"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L242"
     },
     "streamlit.experimental_singleton": {
       "name": "experimental_singleton",
@@ -28603,7 +28603,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/singleton_decorator.py#L92"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/singleton_decorator.py#L92"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -28676,7 +28676,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "streamlit.form": {
       "name": "form",
@@ -28700,7 +28700,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -28751,7 +28751,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -28767,7 +28767,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -28791,7 +28791,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "streamlit.header": {
       "name": "header",
@@ -28815,7 +28815,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -28832,7 +28832,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
     },
     "streamlit.image": {
       "name": "image",
@@ -28891,7 +28891,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
     },
     "streamlit.info": {
       "name": "info",
@@ -28908,7 +28908,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -28925,7 +28925,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -28942,7 +28942,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -28980,7 +28980,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "streamlit.map": {
       "name": "map",
@@ -29004,7 +29004,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -29028,7 +29028,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.metric": {
       "name": "metric",
@@ -29066,7 +29066,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -29146,11 +29146,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fa3b6647d00>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fe9fb3e3c10>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -29240,7 +29240,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -29292,7 +29292,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -29309,7 +29309,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -29326,7 +29326,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -29358,7 +29358,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -29438,7 +29438,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -29518,7 +29518,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -29598,7 +29598,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -29621,7 +29621,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L208"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L208"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -29666,7 +29666,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L30"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L30"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -29760,7 +29760,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -29777,7 +29777,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L376"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L376"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -29786,7 +29786,7 @@
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L528"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L528"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -29810,7 +29810,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -29827,7 +29827,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -29844,7 +29844,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "streamlit.text": {
       "name": "text",
@@ -29861,7 +29861,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -29941,7 +29941,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -30028,7 +30028,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -30094,7 +30094,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "streamlit.title": {
       "name": "title",
@@ -30118,7 +30118,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -30156,7 +30156,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "streamlit.video": {
       "name": "video",
@@ -30187,7 +30187,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -30204,7 +30204,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -30228,7 +30228,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -30252,7 +30252,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -30276,7 +30276,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -30314,7 +30314,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -30345,7 +30345,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -30354,7 +30354,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -30392,7 +30392,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -30416,7 +30416,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -30425,7 +30425,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -30449,7 +30449,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -30487,7 +30487,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -30546,7 +30546,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -30563,7 +30563,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -30629,7 +30629,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -30653,7 +30653,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -30719,7 +30719,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "DeltaGenerator.columns": {
       "name": "columns",
@@ -30743,7 +30743,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "DeltaGenerator.container": {
       "name": "container",
@@ -30752,7 +30752,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -30783,7 +30783,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -30863,7 +30863,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "DeltaGenerator.determine_delta_color_and_direction": {
       "name": "determine_delta_color_and_direction",
@@ -30947,7 +30947,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "DeltaGenerator.empty": {
       "name": "empty",
@@ -30956,7 +30956,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -30973,7 +30973,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -30990,7 +30990,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -31014,7 +31014,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -31087,7 +31087,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -31111,7 +31111,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -31162,7 +31162,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -31186,7 +31186,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -31210,7 +31210,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -31227,7 +31227,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -31286,7 +31286,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -31303,7 +31303,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.is_negative": {
       "name": "is_negative",
@@ -31324,7 +31324,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -31341,7 +31341,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -31379,7 +31379,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -31403,7 +31403,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -31427,7 +31427,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.metric": {
       "name": "metric",
@@ -31465,7 +31465,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -31545,11 +31545,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fa3b6647d00>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fe9fb3e3c10>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -31639,7 +31639,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "DeltaGenerator.parse_delta": {
       "name": "parse_delta",
@@ -31703,7 +31703,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -31720,7 +31720,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -31737,7 +31737,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -31769,7 +31769,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -31849,7 +31849,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -31929,7 +31929,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -32009,7 +32009,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -32103,7 +32103,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -32127,7 +32127,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -32144,7 +32144,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -32161,7 +32161,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -32178,7 +32178,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -32258,7 +32258,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -32345,7 +32345,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -32411,7 +32411,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -32435,7 +32435,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -32473,7 +32473,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -32504,7 +32504,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -32521,7 +32521,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -32545,7 +32545,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -32582,7 +32582,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -32619,7 +32619,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -32656,7 +32656,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   },
   "1.0.0": {
@@ -32682,7 +32682,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -32720,7 +32720,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -32751,7 +32751,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -32760,7 +32760,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -32798,7 +32798,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -32822,7 +32822,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -32831,7 +32831,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -32855,7 +32855,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -32893,7 +32893,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "streamlit.button": {
       "name": "button",
@@ -32952,7 +32952,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -33018,7 +33018,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/legacy_caching/caching.py#L327"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/legacy_caching/caching.py#L327"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -33035,7 +33035,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -33101,7 +33101,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "streamlit.code": {
       "name": "code",
@@ -33125,7 +33125,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -33191,7 +33191,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "streamlit.columns": {
       "name": "columns",
@@ -33215,7 +33215,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "streamlit.container": {
       "name": "container",
@@ -33224,7 +33224,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -33255,7 +33255,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -33335,7 +33335,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "streamlit.download_button": {
       "name": "download_button",
@@ -33415,7 +33415,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -33432,7 +33432,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L436"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L436"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -33441,7 +33441,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -33458,7 +33458,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -33475,7 +33475,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "streamlit.expander": {
       "name": "expander",
@@ -33499,7 +33499,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -33515,7 +33515,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L315"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L315"
     },
     "streamlit.experimental_memo": {
       "name": "experimental_memo",
@@ -33567,7 +33567,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/memo_decorator.py#L118"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/memo_decorator.py#L118"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
@@ -33575,7 +33575,7 @@
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L548"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L548"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -33592,7 +33592,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L346"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L346"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -33610,7 +33610,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L242"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L242"
     },
     "streamlit.experimental_singleton": {
       "name": "experimental_singleton",
@@ -33641,7 +33641,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/singleton_decorator.py#L92"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/singleton_decorator.py#L92"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -33714,7 +33714,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "streamlit.form": {
       "name": "form",
@@ -33738,7 +33738,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -33789,7 +33789,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -33805,7 +33805,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -33829,7 +33829,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "streamlit.header": {
       "name": "header",
@@ -33853,7 +33853,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -33870,7 +33870,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
     },
     "streamlit.image": {
       "name": "image",
@@ -33929,7 +33929,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
     },
     "streamlit.info": {
       "name": "info",
@@ -33946,7 +33946,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -33963,7 +33963,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -33980,7 +33980,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -34018,7 +34018,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "streamlit.map": {
       "name": "map",
@@ -34042,7 +34042,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -34066,7 +34066,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.metric": {
       "name": "metric",
@@ -34104,7 +34104,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -34184,11 +34184,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f469f119b50>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fdd3367da60>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -34278,7 +34278,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -34330,7 +34330,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -34347,7 +34347,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -34364,7 +34364,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -34396,7 +34396,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -34476,7 +34476,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -34556,7 +34556,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -34636,7 +34636,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -34659,7 +34659,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L208"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L208"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -34704,7 +34704,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L30"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L30"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -34798,7 +34798,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -34815,7 +34815,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L376"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L376"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -34824,7 +34824,7 @@
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L528"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L528"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -34848,7 +34848,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -34865,7 +34865,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -34882,7 +34882,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "streamlit.text": {
       "name": "text",
@@ -34899,7 +34899,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -34979,7 +34979,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -35066,7 +35066,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -35132,7 +35132,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "streamlit.title": {
       "name": "title",
@@ -35156,7 +35156,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -35194,7 +35194,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "streamlit.video": {
       "name": "video",
@@ -35225,7 +35225,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -35242,7 +35242,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -35266,7 +35266,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -35290,7 +35290,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -35314,7 +35314,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -35352,7 +35352,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -35383,7 +35383,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -35392,7 +35392,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -35430,7 +35430,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -35454,7 +35454,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -35463,7 +35463,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -35487,7 +35487,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -35525,7 +35525,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -35584,7 +35584,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -35601,7 +35601,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -35667,7 +35667,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -35691,7 +35691,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -35757,7 +35757,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "DeltaGenerator.columns": {
       "name": "columns",
@@ -35781,7 +35781,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "DeltaGenerator.container": {
       "name": "container",
@@ -35790,7 +35790,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -35821,7 +35821,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -35901,7 +35901,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "DeltaGenerator.determine_delta_color_and_direction": {
       "name": "determine_delta_color_and_direction",
@@ -35985,7 +35985,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "DeltaGenerator.empty": {
       "name": "empty",
@@ -35994,7 +35994,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -36011,7 +36011,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -36028,7 +36028,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -36052,7 +36052,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -36125,7 +36125,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -36149,7 +36149,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -36200,7 +36200,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -36224,7 +36224,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -36248,7 +36248,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -36265,7 +36265,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -36324,7 +36324,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -36341,7 +36341,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.is_negative": {
       "name": "is_negative",
@@ -36362,7 +36362,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -36379,7 +36379,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -36417,7 +36417,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -36441,7 +36441,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -36465,7 +36465,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.metric": {
       "name": "metric",
@@ -36503,7 +36503,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -36583,11 +36583,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f469f119b50>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7fdd3367da60>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -36677,7 +36677,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "DeltaGenerator.parse_delta": {
       "name": "parse_delta",
@@ -36741,7 +36741,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -36758,7 +36758,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -36775,7 +36775,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -36807,7 +36807,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -36887,7 +36887,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -36967,7 +36967,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -37047,7 +37047,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -37141,7 +37141,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -37165,7 +37165,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -37182,7 +37182,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -37199,7 +37199,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -37216,7 +37216,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -37296,7 +37296,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -37383,7 +37383,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -37449,7 +37449,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -37473,7 +37473,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -37511,7 +37511,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -37542,7 +37542,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -37559,7 +37559,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -37583,7 +37583,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -37620,7 +37620,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -37657,7 +37657,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -37694,7 +37694,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   },
   "1.1.0": {
@@ -37720,7 +37720,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -37758,7 +37758,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -37789,7 +37789,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -37798,7 +37798,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -37836,7 +37836,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -37860,7 +37860,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -37869,7 +37869,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -37893,7 +37893,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -37931,7 +37931,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "streamlit.button": {
       "name": "button",
@@ -37990,7 +37990,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -38056,7 +38056,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/legacy_caching/caching.py#L327"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/legacy_caching/caching.py#L327"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -38073,7 +38073,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -38139,7 +38139,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "streamlit.code": {
       "name": "code",
@@ -38163,7 +38163,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -38229,7 +38229,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "streamlit.columns": {
       "name": "columns",
@@ -38253,7 +38253,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "streamlit.container": {
       "name": "container",
@@ -38262,7 +38262,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -38293,7 +38293,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -38373,7 +38373,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "streamlit.download_button": {
       "name": "download_button",
@@ -38453,7 +38453,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -38470,7 +38470,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L437"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L437"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -38479,7 +38479,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -38496,7 +38496,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -38513,7 +38513,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "streamlit.expander": {
       "name": "expander",
@@ -38537,7 +38537,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -38553,7 +38553,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L316"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L316"
     },
     "streamlit.experimental_memo": {
       "name": "experimental_memo",
@@ -38605,7 +38605,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/memo_decorator.py#L95"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/memo_decorator.py#L95"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
@@ -38613,7 +38613,7 @@
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L549"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L549"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -38630,7 +38630,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L347"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L347"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -38648,7 +38648,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L243"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L243"
     },
     "streamlit.experimental_singleton": {
       "name": "experimental_singleton",
@@ -38679,7 +38679,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/singleton_decorator.py#L52"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/singleton_decorator.py#L52"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -38752,7 +38752,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "streamlit.form": {
       "name": "form",
@@ -38776,7 +38776,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -38827,7 +38827,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -38843,7 +38843,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -38867,7 +38867,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "streamlit.header": {
       "name": "header",
@@ -38891,7 +38891,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -38908,7 +38908,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
     },
     "streamlit.image": {
       "name": "image",
@@ -38967,7 +38967,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
     },
     "streamlit.info": {
       "name": "info",
@@ -38984,7 +38984,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -39001,7 +39001,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -39018,7 +39018,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -39056,7 +39056,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "streamlit.map": {
       "name": "map",
@@ -39080,7 +39080,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -39104,7 +39104,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.metric": {
       "name": "metric",
@@ -39142,7 +39142,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -39222,11 +39222,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f06c7d43070>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f6f3a960fd0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -39316,7 +39316,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -39368,7 +39368,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -39385,7 +39385,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -39402,7 +39402,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -39434,7 +39434,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -39514,7 +39514,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -39594,7 +39594,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -39674,7 +39674,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -39697,7 +39697,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L209"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L209"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -39742,7 +39742,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L30"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L30"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -39836,7 +39836,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -39853,7 +39853,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L377"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L377"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -39862,7 +39862,7 @@
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L529"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L529"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -39886,7 +39886,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -39903,7 +39903,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -39920,7 +39920,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "streamlit.text": {
       "name": "text",
@@ -39937,7 +39937,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -40017,7 +40017,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -40104,7 +40104,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -40170,7 +40170,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "streamlit.title": {
       "name": "title",
@@ -40194,7 +40194,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -40232,7 +40232,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "streamlit.video": {
       "name": "video",
@@ -40263,7 +40263,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -40280,7 +40280,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -40304,7 +40304,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -40328,7 +40328,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -40352,7 +40352,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -40390,7 +40390,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -40421,7 +40421,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -40430,7 +40430,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -40468,7 +40468,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -40492,7 +40492,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -40501,7 +40501,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -40525,7 +40525,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -40563,7 +40563,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L25"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -40622,7 +40622,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -40639,7 +40639,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -40705,7 +40705,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -40729,7 +40729,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -40795,7 +40795,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "DeltaGenerator.columns": {
       "name": "columns",
@@ -40819,7 +40819,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "DeltaGenerator.container": {
       "name": "container",
@@ -40828,7 +40828,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -40859,7 +40859,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -40939,7 +40939,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "DeltaGenerator.determine_delta_color_and_direction": {
       "name": "determine_delta_color_and_direction",
@@ -41023,7 +41023,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "DeltaGenerator.empty": {
       "name": "empty",
@@ -41032,7 +41032,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -41049,7 +41049,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -41066,7 +41066,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -41090,7 +41090,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -41163,7 +41163,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -41187,7 +41187,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -41238,7 +41238,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -41262,7 +41262,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -41286,7 +41286,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -41303,7 +41303,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -41362,7 +41362,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -41379,7 +41379,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.is_negative": {
       "name": "is_negative",
@@ -41400,7 +41400,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -41417,7 +41417,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -41455,7 +41455,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -41479,7 +41479,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -41503,7 +41503,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.metric": {
       "name": "metric",
@@ -41541,7 +41541,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -41621,11 +41621,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f06c7d43070>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f6f3a960fd0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -41715,7 +41715,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "DeltaGenerator.parse_delta": {
       "name": "parse_delta",
@@ -41779,7 +41779,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -41796,7 +41796,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -41813,7 +41813,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -41845,7 +41845,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -41925,7 +41925,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -42005,7 +42005,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -42085,7 +42085,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -42179,7 +42179,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -42203,7 +42203,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -42220,7 +42220,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -42237,7 +42237,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -42254,7 +42254,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -42334,7 +42334,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L144"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -42421,7 +42421,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -42487,7 +42487,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -42511,7 +42511,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -42549,7 +42549,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -42580,7 +42580,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -42597,7 +42597,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -42621,7 +42621,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -42658,7 +42658,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -42695,7 +42695,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -42732,7 +42732,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   },
   "1.2.0": {
@@ -42758,7 +42758,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -42796,7 +42796,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -42827,7 +42827,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -42836,7 +42836,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -42874,7 +42874,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -42898,7 +42898,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -42907,7 +42907,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -42931,7 +42931,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -42969,7 +42969,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L28"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L28"
     },
     "streamlit.button": {
       "name": "button",
@@ -43028,7 +43028,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -43094,7 +43094,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/legacy_caching/caching.py#L358"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/legacy_caching/caching.py#L358"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -43111,7 +43111,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -43177,7 +43177,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "streamlit.code": {
       "name": "code",
@@ -43201,7 +43201,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -43267,7 +43267,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "streamlit.columns": {
       "name": "columns",
@@ -43291,7 +43291,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "streamlit.container": {
       "name": "container",
@@ -43300,7 +43300,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -43331,7 +43331,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -43411,7 +43411,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "streamlit.download_button": {
       "name": "download_button",
@@ -43491,7 +43491,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -43508,7 +43508,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L437"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L437"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -43517,7 +43517,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -43534,7 +43534,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -43551,7 +43551,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "streamlit.expander": {
       "name": "expander",
@@ -43575,7 +43575,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -43591,7 +43591,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L316"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L316"
     },
     "streamlit.experimental_memo": {
       "name": "experimental_memo",
@@ -43643,7 +43643,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/memo_decorator.py#L200"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/memo_decorator.py#L200"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
@@ -43651,7 +43651,7 @@
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L549"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L549"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -43668,7 +43668,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L347"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L347"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -43686,7 +43686,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L243"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L243"
     },
     "streamlit.experimental_singleton": {
       "name": "experimental_singleton",
@@ -43717,7 +43717,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/singleton_decorator.py#L114"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/singleton_decorator.py#L114"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -43790,7 +43790,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "streamlit.form": {
       "name": "form",
@@ -43814,7 +43814,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -43865,7 +43865,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -43881,7 +43881,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -43905,7 +43905,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "streamlit.header": {
       "name": "header",
@@ -43929,7 +43929,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -43946,7 +43946,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
     },
     "streamlit.image": {
       "name": "image",
@@ -44005,7 +44005,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
     },
     "streamlit.info": {
       "name": "info",
@@ -44022,7 +44022,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -44039,7 +44039,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -44056,7 +44056,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -44094,7 +44094,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "streamlit.map": {
       "name": "map",
@@ -44118,7 +44118,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -44142,7 +44142,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.metric": {
       "name": "metric",
@@ -44180,7 +44180,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -44260,11 +44260,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f15fe02d8e0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f3d192a18e0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -44354,7 +44354,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -44406,7 +44406,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -44423,7 +44423,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -44440,7 +44440,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -44472,7 +44472,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -44552,7 +44552,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -44632,7 +44632,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -44712,7 +44712,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -44735,7 +44735,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L209"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L209"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -44780,7 +44780,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L30"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L30"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -44874,7 +44874,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -44891,7 +44891,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L377"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L377"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -44900,7 +44900,7 @@
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L529"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L529"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -44924,7 +44924,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -44941,7 +44941,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -44958,7 +44958,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "streamlit.text": {
       "name": "text",
@@ -44975,7 +44975,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -45062,7 +45062,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L153"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L153"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -45156,7 +45156,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -45222,7 +45222,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "streamlit.title": {
       "name": "title",
@@ -45246,7 +45246,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -45284,7 +45284,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "streamlit.video": {
       "name": "video",
@@ -45315,7 +45315,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -45332,7 +45332,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -45356,7 +45356,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -45380,7 +45380,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -45404,7 +45404,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -45442,7 +45442,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -45473,7 +45473,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -45482,7 +45482,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -45520,7 +45520,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -45544,7 +45544,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -45553,7 +45553,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -45577,7 +45577,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -45615,7 +45615,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L28"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L28"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -45674,7 +45674,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -45691,7 +45691,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -45757,7 +45757,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -45781,7 +45781,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -45847,7 +45847,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "DeltaGenerator.columns": {
       "name": "columns",
@@ -45871,7 +45871,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "DeltaGenerator.container": {
       "name": "container",
@@ -45880,7 +45880,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -45911,7 +45911,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -45991,7 +45991,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "DeltaGenerator.determine_delta_color_and_direction": {
       "name": "determine_delta_color_and_direction",
@@ -46075,7 +46075,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "DeltaGenerator.empty": {
       "name": "empty",
@@ -46084,7 +46084,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -46101,7 +46101,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -46118,7 +46118,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -46142,7 +46142,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L171"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -46215,7 +46215,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -46239,7 +46239,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -46290,7 +46290,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -46314,7 +46314,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L29"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -46338,7 +46338,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -46355,7 +46355,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -46414,7 +46414,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -46431,7 +46431,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.is_negative": {
       "name": "is_negative",
@@ -46452,7 +46452,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -46469,7 +46469,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L231"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -46507,7 +46507,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -46531,7 +46531,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -46555,7 +46555,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.metric": {
       "name": "metric",
@@ -46593,7 +46593,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -46673,11 +46673,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f15fe02d8e0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f3d192a18e0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -46767,7 +46767,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "DeltaGenerator.parse_delta": {
       "name": "parse_delta",
@@ -46831,7 +46831,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -46848,7 +46848,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -46865,7 +46865,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -46897,7 +46897,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -46977,7 +46977,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -47057,7 +47057,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -47137,7 +47137,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -47231,7 +47231,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -47255,7 +47255,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -47272,7 +47272,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -47289,7 +47289,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -47306,7 +47306,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -47393,7 +47393,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L153"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L153"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -47487,7 +47487,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -47553,7 +47553,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -47577,7 +47577,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -47615,7 +47615,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -47646,7 +47646,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -47663,7 +47663,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -47687,7 +47687,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L38"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -47724,7 +47724,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -47761,7 +47761,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -47798,7 +47798,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   },
   "1.3.0": {
@@ -47824,7 +47824,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "streamlit.area_chart": {
       "name": "area_chart",
@@ -47862,7 +47862,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "streamlit.audio": {
       "name": "audio",
@@ -47893,7 +47893,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "streamlit.balloons": {
       "name": "balloons",
@@ -47902,7 +47902,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "streamlit.bar_chart": {
       "name": "bar_chart",
@@ -47940,7 +47940,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "streamlit.beta_columns": {
       "name": "beta_columns",
@@ -47964,7 +47964,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_container": {
       "name": "beta_container",
@@ -47973,7 +47973,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.beta_expander": {
       "name": "beta_expander",
@@ -47997,7 +47997,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "streamlit.bokeh_chart": {
       "name": "bokeh_chart",
@@ -48035,7 +48035,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L29"
     },
     "streamlit.button": {
       "name": "button",
@@ -48094,7 +48094,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "streamlit.cache": {
       "name": "cache",
@@ -48160,7 +48160,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/legacy_caching/caching.py#L358"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/legacy_caching/caching.py#L358"
     },
     "streamlit.caption": {
       "name": "caption",
@@ -48184,7 +48184,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "streamlit.checkbox": {
       "name": "checkbox",
@@ -48250,7 +48250,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "streamlit.code": {
       "name": "code",
@@ -48274,7 +48274,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "streamlit.color_picker": {
       "name": "color_picker",
@@ -48340,7 +48340,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "streamlit.columns": {
       "name": "columns",
@@ -48364,7 +48364,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "streamlit.container": {
       "name": "container",
@@ -48373,7 +48373,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "streamlit.dataframe": {
       "name": "dataframe",
@@ -48404,7 +48404,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "streamlit.date_input": {
       "name": "date_input",
@@ -48484,7 +48484,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "streamlit.download_button": {
       "name": "download_button",
@@ -48564,7 +48564,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "streamlit.echo": {
       "name": "echo",
@@ -48581,7 +48581,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L441"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L441"
     },
     "streamlit.empty": {
       "name": "empty",
@@ -48590,7 +48590,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "streamlit.error": {
       "name": "error",
@@ -48607,7 +48607,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "streamlit.exception": {
       "name": "exception",
@@ -48624,7 +48624,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "streamlit.expander": {
       "name": "expander",
@@ -48648,7 +48648,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L172"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L172"
     },
     "streamlit.experimental_get_query_params": {
       "name": "experimental_get_query_params",
@@ -48664,7 +48664,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L316"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L316"
     },
     "streamlit.experimental_memo": {
       "name": "experimental_memo",
@@ -48716,7 +48716,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/memo_decorator.py#L224"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/memo_decorator.py#L224"
     },
     "streamlit.experimental_rerun": {
       "name": "experimental_rerun",
@@ -48724,7 +48724,7 @@
       "description": "<p>Rerun the script immediately.</p>\n<p>When <cite>st.experimental_rerun()</cite> is called, the script is halted - no\nmore statements will be run, and the script will be queued to re-run\nfrom the top.</p>\n<p>If this function is called outside of Streamlit, it will raise an\nException.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L553"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L553"
     },
     "streamlit.experimental_set_query_params": {
       "name": "experimental_set_query_params",
@@ -48741,7 +48741,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L347"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L347"
     },
     "streamlit.experimental_show": {
       "name": "experimental_show",
@@ -48759,7 +48759,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L243"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L243"
     },
     "streamlit.experimental_singleton": {
       "name": "experimental_singleton",
@@ -48790,7 +48790,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/singleton_decorator.py#L135"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/singleton_decorator.py#L135"
     },
     "streamlit.file_uploader": {
       "name": "file_uploader",
@@ -48863,7 +48863,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "streamlit.form": {
       "name": "form",
@@ -48887,7 +48887,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "streamlit.form_submit_button": {
       "name": "form_submit_button",
@@ -48938,7 +48938,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "streamlit.get_option": {
       "name": "get_option",
@@ -48954,7 +48954,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/config.py#L91"
     },
     "streamlit.graphviz_chart": {
       "name": "graphviz_chart",
@@ -48978,7 +48978,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L30"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L30"
     },
     "streamlit.header": {
       "name": "header",
@@ -49002,7 +49002,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "streamlit.help": {
       "name": "help",
@@ -49019,7 +49019,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
     },
     "streamlit.image": {
       "name": "image",
@@ -49078,7 +49078,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
     },
     "streamlit.info": {
       "name": "info",
@@ -49095,7 +49095,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "streamlit.json": {
       "name": "json",
@@ -49112,7 +49112,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "streamlit.latex": {
       "name": "latex",
@@ -49129,7 +49129,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L252"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L252"
     },
     "streamlit.line_chart": {
       "name": "line_chart",
@@ -49167,7 +49167,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "streamlit.map": {
       "name": "map",
@@ -49191,7 +49191,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "streamlit.markdown": {
       "name": "markdown",
@@ -49215,7 +49215,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "streamlit.metric": {
       "name": "metric",
@@ -49253,7 +49253,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "streamlit.multiselect": {
       "name": "multiselect",
@@ -49333,11 +49333,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f73fc4dd790>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f73b53e96a0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -49427,7 +49427,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "streamlit.plotly_chart": {
       "name": "plotly_chart",
@@ -49479,7 +49479,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "streamlit.progress": {
       "name": "progress",
@@ -49496,7 +49496,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "streamlit.pydeck_chart": {
       "name": "pydeck_chart",
@@ -49513,7 +49513,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "streamlit.pyplot": {
       "name": "pyplot",
@@ -49545,7 +49545,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "streamlit.radio": {
       "name": "radio",
@@ -49625,7 +49625,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "streamlit.select_slider": {
       "name": "select_slider",
@@ -49705,7 +49705,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "streamlit.selectbox": {
       "name": "selectbox",
@@ -49785,7 +49785,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "streamlit.set_option": {
       "name": "set_option",
@@ -49808,7 +49808,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L209"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L209"
     },
     "streamlit.set_page_config": {
       "name": "set_page_config",
@@ -49853,7 +49853,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L30"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/page_config.py#L30"
     },
     "streamlit.slider": {
       "name": "slider",
@@ -49947,7 +49947,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "streamlit.spinner": {
       "name": "spinner",
@@ -49964,7 +49964,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L377"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L377"
     },
     "streamlit.stop": {
       "name": "stop",
@@ -49973,7 +49973,7 @@
       "description": "<p>Stops execution immediately.</p>\n<p>Streamlit will not run any statements after <cite>st.stop()</cite>.\nWe recommend rendering a message to explain why the script has stopped.\nWhen run outside of Streamlit, this will raise an Exception.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L533"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L533"
     },
     "streamlit.subheader": {
       "name": "subheader",
@@ -49997,7 +49997,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "streamlit.success": {
       "name": "success",
@@ -50014,7 +50014,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "streamlit.table": {
       "name": "table",
@@ -50031,7 +50031,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "streamlit.text": {
       "name": "text",
@@ -50048,7 +50048,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "streamlit.text_area": {
       "name": "text_area",
@@ -50135,7 +50135,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L153"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L153"
     },
     "streamlit.text_input": {
       "name": "text_input",
@@ -50229,7 +50229,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "streamlit.time_input": {
       "name": "time_input",
@@ -50295,7 +50295,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "streamlit.title": {
       "name": "title",
@@ -50319,7 +50319,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "streamlit.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -50357,7 +50357,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "streamlit.video": {
       "name": "video",
@@ -50388,7 +50388,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "streamlit.warning": {
       "name": "warning",
@@ -50405,7 +50405,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "streamlit.write": {
       "name": "write",
@@ -50429,7 +50429,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L39"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L39"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -50453,7 +50453,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L378"
     },
     "DeltaGenerator.altair_chart": {
       "name": "altair_chart",
@@ -50477,7 +50477,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L267"
     },
     "DeltaGenerator.area_chart": {
       "name": "area_chart",
@@ -50515,7 +50515,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L170"
     },
     "DeltaGenerator.audio": {
       "name": "audio",
@@ -50546,7 +50546,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L29"
     },
     "DeltaGenerator.balloons": {
       "name": "balloons",
@@ -50555,7 +50555,7 @@
       "description": "Draw celebratory balloons.",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/balloons.py#L22"
     },
     "DeltaGenerator.bar_chart": {
       "name": "bar_chart",
@@ -50593,7 +50593,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L218"
     },
     "DeltaGenerator.beta_columns": {
       "name": "beta_columns",
@@ -50617,7 +50617,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_container": {
       "name": "beta_container",
@@ -50626,7 +50626,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.beta_expander": {
       "name": "beta_expander",
@@ -50650,7 +50650,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/beta_util.py#L44"
     },
     "DeltaGenerator.bokeh_chart": {
       "name": "bokeh_chart",
@@ -50688,7 +50688,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L29"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/bokeh_chart.py#L29"
     },
     "DeltaGenerator.button": {
       "name": "button",
@@ -50747,7 +50747,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L47"
     },
     "DeltaGenerator.caption": {
       "name": "caption",
@@ -50771,7 +50771,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L205"
     },
     "DeltaGenerator.checkbox": {
       "name": "checkbox",
@@ -50837,7 +50837,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/checkbox.py#L32"
     },
     "DeltaGenerator.code": {
       "name": "code",
@@ -50861,7 +50861,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L140"
     },
     "DeltaGenerator.color_picker": {
       "name": "color_picker",
@@ -50927,7 +50927,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/color_picker.py#L34"
     },
     "DeltaGenerator.columns": {
       "name": "columns",
@@ -50951,7 +50951,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L70"
     },
     "DeltaGenerator.container": {
       "name": "container",
@@ -50960,7 +50960,7 @@
       "description": "<p>Insert a multi-element container.</p>\n<p>Inserts an invisible container into your app that can be used to hold\nmultiple elements. This allows you to, for example, insert multiple\nelements into your app out of order.</p>\n<p>To add elements to the returned container, you can use &quot;with&quot; notation\n(preferred) or just call methods directly on the returned object. See\nexamples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L27"
     },
     "DeltaGenerator.dataframe": {
       "name": "dataframe",
@@ -50991,7 +50991,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L32"
     },
     "DeltaGenerator.date_input": {
       "name": "date_input",
@@ -51071,7 +51071,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L136"
     },
     "DeltaGenerator.determine_delta_color_and_direction": {
       "name": "determine_delta_color_and_direction",
@@ -51155,7 +51155,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/button.py#L101"
     },
     "DeltaGenerator.empty": {
       "name": "empty",
@@ -51164,7 +51164,7 @@
       "description": "<p>Insert a single-element container.</p>\n<p>Inserts a container into your app that can be used to hold a single element.\nThis allows you to, for example, remove elements at any point, or replace\nseveral elements at once (using a child multi-element container).</p>\n<p>To insert/replace/clear an element on the returned container, you can\nuse &quot;with&quot; notation or just call methods directly on the returned object.\nSee examples below.</p>\n",
       "args": [],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/empty.py#L22"
     },
     "DeltaGenerator.error": {
       "name": "error",
@@ -51181,7 +51181,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L23"
     },
     "DeltaGenerator.exception": {
       "name": "exception",
@@ -51198,7 +51198,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/exception.py#L36"
     },
     "DeltaGenerator.expander": {
       "name": "expander",
@@ -51222,7 +51222,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L172"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/layouts.py#L172"
     },
     "DeltaGenerator.file_uploader": {
       "name": "file_uploader",
@@ -51295,7 +51295,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/file_uploader.py#L44"
     },
     "DeltaGenerator.form": {
       "name": "form",
@@ -51319,7 +51319,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L112"
     },
     "DeltaGenerator.form_submit_button": {
       "name": "form_submit_button",
@@ -51370,7 +51370,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/form.py#L198"
     },
     "DeltaGenerator.graphviz_chart": {
       "name": "graphviz_chart",
@@ -51394,7 +51394,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L30"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/graphviz_chart.py#L30"
     },
     "DeltaGenerator.header": {
       "name": "header",
@@ -51418,7 +51418,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L81"
     },
     "DeltaGenerator.help": {
       "name": "help",
@@ -51435,7 +51435,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/doc_string.py#L37"
     },
     "DeltaGenerator.image": {
       "name": "image",
@@ -51494,7 +51494,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/image.py#L44"
     },
     "DeltaGenerator.info": {
       "name": "info",
@@ -51511,7 +51511,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L59"
     },
     "DeltaGenerator.is_negative": {
       "name": "is_negative",
@@ -51532,7 +51532,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/json.py#L24"
     },
     "DeltaGenerator.latex": {
       "name": "latex",
@@ -51549,7 +51549,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L252"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L252"
     },
     "DeltaGenerator.line_chart": {
       "name": "line_chart",
@@ -51587,7 +51587,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L122"
     },
     "DeltaGenerator.map": {
       "name": "map",
@@ -51611,7 +51611,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/map.py#L31"
     },
     "DeltaGenerator.markdown": {
       "name": "markdown",
@@ -51635,7 +51635,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L24"
     },
     "DeltaGenerator.metric": {
       "name": "metric",
@@ -51673,7 +51673,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/metric.py#L33"
     },
     "DeltaGenerator.multiselect": {
       "name": "multiselect",
@@ -51753,11 +51753,11 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/multiselect.py#L34"
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f73fc4dd790>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f73b53e96a0>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -51847,7 +51847,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/number_input.py#L37"
     },
     "DeltaGenerator.parse_delta": {
       "name": "parse_delta",
@@ -51911,7 +51911,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/plotly_chart.py#L42"
     },
     "DeltaGenerator.progress": {
       "name": "progress",
@@ -51928,7 +51928,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/progress.py#L23"
     },
     "DeltaGenerator.pydeck_chart": {
       "name": "pydeck_chart",
@@ -51945,7 +51945,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/deck_gl_json_chart.py#L23"
     },
     "DeltaGenerator.pyplot": {
       "name": "pyplot",
@@ -51977,7 +51977,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/pyplot.py#L31"
     },
     "DeltaGenerator.radio": {
       "name": "radio",
@@ -52057,7 +52057,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/radio.py#L34"
     },
     "DeltaGenerator.select_slider": {
       "name": "select_slider",
@@ -52137,7 +52137,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/select_slider.py#L34"
     },
     "DeltaGenerator.selectbox": {
       "name": "selectbox",
@@ -52217,7 +52217,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/selectbox.py#L34"
     },
     "DeltaGenerator.slider": {
       "name": "slider",
@@ -52311,7 +52311,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/slider.py#L37"
     },
     "DeltaGenerator.subheader": {
       "name": "subheader",
@@ -52335,7 +52335,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L110"
     },
     "DeltaGenerator.success": {
       "name": "success",
@@ -52352,7 +52352,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L77"
     },
     "DeltaGenerator.table": {
       "name": "table",
@@ -52369,7 +52369,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L89"
     },
     "DeltaGenerator.text": {
       "name": "text",
@@ -52386,7 +52386,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text.py#L23"
     },
     "DeltaGenerator.text_area": {
       "name": "text_area",
@@ -52473,7 +52473,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L153"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L153"
     },
     "DeltaGenerator.text_input": {
       "name": "text_input",
@@ -52567,7 +52567,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/text_widgets.py#L35"
     },
     "DeltaGenerator.time_input": {
       "name": "time_input",
@@ -52633,7 +52633,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/time_widgets.py#L37"
     },
     "DeltaGenerator.title": {
       "name": "title",
@@ -52657,7 +52657,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/markdown.py#L173"
     },
     "DeltaGenerator.vega_lite_chart": {
       "name": "vega_lite_chart",
@@ -52695,7 +52695,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/dataframe_selector.py#L309"
     },
     "DeltaGenerator.video": {
       "name": "video",
@@ -52726,7 +52726,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/media.py#L62"
     },
     "DeltaGenerator.warning": {
       "name": "warning",
@@ -52743,7 +52743,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/alert.py#L41"
     },
     "DeltaGenerator.write": {
       "name": "write",
@@ -52767,7 +52767,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L39"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L39"
     },
     "streamlit.components.v1.declare_component": {
       "name": "declare_component",
@@ -52804,7 +52804,7 @@
           "return_name": null
         }
       ],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
     },
     "streamlit.components.v1.html": {
       "name": "html",
@@ -52841,7 +52841,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
     },
     "streamlit.components.v1.iframe": {
       "name": "iframe",
@@ -52878,7 +52878,7 @@
         }
       ],
       "returns": [],
-      "source_file": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   }
 }

--- a/styles/components/blocks/autofunction.scss
+++ b/styles/components/blocks/autofunction.scss
@@ -125,9 +125,4 @@
       }
     }
   }
-
-  // Hide duplicated helpful component when rendering an autofunction page
-  & ~ .block-helpful {
-    display: none;
-  }
 }

--- a/styles/components/blocks/autofunction.scss
+++ b/styles/components/blocks/autofunction.scss
@@ -125,4 +125,9 @@
       }
     }
   }
+
+  // Hide duplicated helpful component when rendering an autofunction page
+  & ~ .block-helpful {
+    display: none;
+  }
 }


### PR DESCRIPTION
This PR is a very early WIP to make the Suggest edits button on API reference pages link to the original source of the docstring in the core Streamlit repo.

[#71f8d97](https://github.com/streamlit/docs/commit/71f8d9789c53a3632409a2a85c0cb206f001f850) creates an **additional** "Suggest edits" button at the bottom of API reference pages. This is not the desired behavior. Ideally, for API reference pages, we need to override the Helpful component and pass it the GitHub URL instead of `sourcefile`.

@imjuangarcia The Python part of this PR is complete. I could use your input on the JS side of this PR. We need to pass the `functionObject.source` object (containing a Streamlit GitHub URL) from `autofunction.js` to either the Helpful or SuggestEdits component. This should be done only for API reference pages containing docstrings. i.e. pages whose Markdown filename ends with `/library/api/*/*.md`, where * is an alphanumeric string; or equivalently, pages that use the Autofunction component.