### PR TITLE
Fix on Header background

### DIFF
--- a/styles/components/navigation/header.scss
+++ b/styles/components/navigation/header.scss
@@ -9,6 +9,7 @@ header {
 
   .container {
     transition: $normal;
+    background: #fff;
   }
 
   h4 {

--- a/styles/global/dark.scss
+++ b/styles/global/dark.scss
@@ -24,9 +24,10 @@ body[data-theme="dark-mode"] {
       border-bottom: 1px solid $gray-80;
     }
     .container {
+      background: $off-black;
+
       &::before {
         border-bottom: 1px solid rgba(255, 255, 255, 0);
-        background: $off-black;
       }
       .hot-key > * {
         color: $white;


### PR DESCRIPTION
This small PR fixes [this issue](https://share.getcloudapp.com/qGurg67r) that happens when you refresh a page that was scrolled:

1. If you scroll, the header becomes sticky, because you've scrolled `20px` from the top of the window;
2. If you refresh the page, those `20px` you scrolled are now gone, causing the layout of the header to break;
3. This PR adds a background to the elements by default, to ensure the header won't overlap with the content underneath it.