### PR TITLE
Fix on Prism rendering issues

### DIFF
--- a/components/blocks/code.js
+++ b/components/blocks/code.js
@@ -1,4 +1,5 @@
-import React, { useEffect } from "react";
+import { debounce } from "lodash";
+import React, { useState, useEffect } from "react";
 import Prism from "prismjs";
 import "prismjs/components/prism-jsx";
 import "prismjs/components/prism-python";
@@ -15,16 +16,30 @@ import "prismjs/plugins/normalize-whitespace/prism-normalize-whitespace";
 import Image from "./image";
 
 const Code = ({ code, children, language, img, lines }) => {
-  useEffect(() => {
-    if (!window.initial.prism) {
-      window.initial.prism = true;
+  const [windowWidth, setWindowWidth] = useState();
+
+  const handleHighlight = () => {
+    if (
+      windowWidth === undefined ||
+      (windowWidth !== undefined && windowWidth !== window.innerWidth)
+    ) {
       Prism.highlightAll();
+      setWindowWidth(window.innerWidth);
+    } else {
+      return;
     }
+  };
+
+  const debouncedHandleHighlight = debounce(handleHighlight, 200);
+
+  useEffect(() => {
+    handleHighlight();
+    window.addEventListener("resize", debouncedHandleHighlight);
 
     return () => {
-      window.initial.prism = false;
+      window.removeEventListener("resize", debouncedHandleHighlight);
     };
-  }, []);
+  }, [windowWidth]);
 
   let ConditionalRendering;
   let customCode = code !== undefined ? code : children;

--- a/components/blocks/code.js
+++ b/components/blocks/code.js
@@ -1,5 +1,4 @@
-import { debounce } from "lodash";
-import React, { useState, useEffect } from "react";
+import React, { useEffect } from "react";
 import Prism from "prismjs";
 import "prismjs/components/prism-jsx";
 import "prismjs/components/prism-python";
@@ -16,30 +15,16 @@ import "prismjs/plugins/normalize-whitespace/prism-normalize-whitespace";
 import Image from "./image";
 
 const Code = ({ code, children, language, img, lines }) => {
-  const [windowWidth, setWindowWidth] = useState();
-
-  const handleHighlight = () => {
-    if (
-      windowWidth === undefined ||
-      (windowWidth !== undefined && windowWidth !== window.innerWidth)
-    ) {
-      Prism.highlightAll();
-      setWindowWidth(window.innerWidth);
-    } else {
-      return;
-    }
-  };
-
-  const debouncedHandleHighlight = debounce(handleHighlight, 200);
-
   useEffect(() => {
-    handleHighlight();
-    window.addEventListener("resize", debouncedHandleHighlight);
+    if (!window.initial.prism) {
+      window.initial.prism = true;
+      Prism.highlightAll();
+    }
 
     return () => {
-      window.removeEventListener("resize", debouncedHandleHighlight);
+      window.initial.prism = false;
     };
-  }, [windowWidth]);
+  }, []);
 
   let ConditionalRendering;
   let customCode = code !== undefined ? code : children;

--- a/styles/components/blocks/autofunction.scss
+++ b/styles/components/blocks/autofunction.scss
@@ -91,7 +91,7 @@
       }
     }
 
-    pre.line-numbers {
+    pre {
       margin: 0;
 
       .table {

--- a/styles/components/blocks/code.scss
+++ b/styles/components/blocks/code.scss
@@ -7,20 +7,20 @@
     position: relative;
   }
 
-  code.undefined,
-  code[class*="language-"],
-  pre[class*="language-"] {
+  code,
+  pre {
     white-space: pre;
     max-width: 100%;
     overflow: hidden;
     overflow-x: scroll;
     overflow-x: overlay;
   }
+
   code.undefined {
     white-space: pre-line;
   }
 
-  pre.line-numbers {
+  pre {
     background: $gray-90;
     padding: 1em;
     color: $white;

--- a/styles/global/dark.scss
+++ b/styles/global/dark.scss
@@ -321,7 +321,7 @@ body[data-theme="dark-mode"] {
     color: $white;
     border-bottom-color: $gray-80;
 
-    pre.line-numbers {
+    pre {
       background-color: transparent;
     }
   }

--- a/styles/global/light.scss
+++ b/styles/global/light.scss
@@ -235,7 +235,7 @@ body[data-theme="light-mode"] {
   .code-tile,
   .reference-card {
     .block-code {
-      pre.line-numbers {
+      pre {
         background-color: transparent;
         color: $gray-80;
 
@@ -277,7 +277,7 @@ body[data-theme="light-mode"] {
     }
 
     &.featured {
-      pre.line-numbers {
+      pre {
         background-color: transparent;
       }
     }
@@ -285,7 +285,7 @@ body[data-theme="light-mode"] {
 
   .reference-card {
     .block-code {
-      pre.line-numbers {
+      pre {
         background-color: $gray-10;
       }
     }


### PR DESCRIPTION
This PR fixes the layout shifting caused by the Prism.js re-renders on iOS Safari by making the styles for code blocks less specific. See the bug report [here](https://www.notion.so/streamlit/Serious-rendering-problem-with-docs-on-iPhone-03b468ca813c4aa2a01ef83291640f3c).

See [this video recording](https://share.getcloudapp.com/2Nuv2DKb) where the issue is resolved by the changes on this PR.