### PR TITLE
Resize SOC logo and remove padding

### DIFF
--- a/content/streamlit-cloud/security-model.md
+++ b/content/streamlit-cloud/security-model.md
@@ -75,8 +75,8 @@ Streamlit is committed to meeting industry security standards so that you can fe
 
 <a href="https://www.aicpa.org/soc4so" target="\_blank" style={{ borderBottom: 0 }}>
 
-<div style={{ maxWidth: '45%', marginBottom: '-2em', marginLeft: '10em' }}>
-<Image alt="SOC 2 logo" src="/images/streamlit-cloud/soc-logo.png" />
+<div style={{ maxWidth: '15%', marginLeft: '35%' }}>
+<Image alt="SOC 2 logo" src="/images/streamlit-cloud/soc-logo.png" pure />
 </div>
 </a>
 


### PR DESCRIPTION
This small PR resizes the SOC logo and removes the gray padding around it.