### PR TITLE
Fix on ordered list style type

### DIFF
--- a/styles/global/global.scss
+++ b/styles/global/global.scss
@@ -69,6 +69,14 @@ ul {
   }
 }
 
+ol {
+  list-style-type: decimal;
+
+  ol {
+    list-style-type: lower-roman;
+  }
+}
+
 ul {
   list-style: disc;
 


### PR DESCRIPTION
## Description
This small PR fixes a bug whereby ordered lists were rendered without numbers because the `list-style-type` property is `unset`. See the "Current" screenshot below. 

## Solution
The solution is to set the property to `decimal` for the parent ordered list and `lower-roman` for nested children.

### Revised
![image](https://user-images.githubusercontent.com/20672874/148345853-241539ef-8ae8-4551-aee1-c0d7608b6c50.png)

### Current
![image](https://user-images.githubusercontent.com/20672874/148345886-11210023-0013-4558-a871-3804ae4ce7aa.png)



