### PR TITLE
Fix on code blocks scroll overflow

### DIFF
--- a/styles/components/blocks/code.scss
+++ b/styles/components/blocks/code.scss
@@ -13,8 +13,6 @@
     white-space: pre;
     max-width: 100%;
     overflow: auto;
-    overflow-x: scroll;
-    overflow-x: overlay;
   }
 
   code.undefined {

--- a/styles/components/blocks/code.scss
+++ b/styles/components/blocks/code.scss
@@ -12,7 +12,7 @@
   pre {
     white-space: pre;
     max-width: 100%;
-    overflow: hidden;
+    overflow: auto;
     overflow-x: scroll;
     overflow-x: overlay;
   }


### PR DESCRIPTION
This small PR makes the horizontal scrollbar at the bottom of code blocks visible when content overflows on the x-axis.