### PR TITLE
Fix on sidebar z-index

### DIFF
--- a/styles/components/navigation/sideBar.scss
+++ b/styles/components/navigation/sideBar.scss
@@ -4,7 +4,7 @@
   top: 0;
   height: calc(100vh - #{$header-height});
   width: 314px;
-  z-index: 11;
+  z-index: 0;
 
   * {
     transition: $slow;
@@ -37,6 +37,7 @@
     pointer-events: none;
     box-shadow: 4px 4px 10px rgba(0, 0, 0, 0.08);
     opacity: 0;
+    z-index: 11;
 
     &.open {
       pointer-events: all;


### PR DESCRIPTION
This PR fixes a regression on https://github.com/streamlit/docs/issues/175. Now we lower the `z-index` on desktop resolutions (to allow links to be clicked when the sidebar opens on hover) and raise it on mobile (to ensure expanding the hamburger menu also works as expected).