### PR TITLE
Update Changelog with v1.4.0 release notes

### DIFF
--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -28,9 +28,9 @@ _Release date: Jan 13, 2022_
 **Notable Changes**
 
 - 🚦 Widgets now have the `disabled` parameter that removes interactivity.
+- 🚮 Clear `st.experimental_memo` and `st.experimental_singleton` programmatically by using the `clear()` method on a cached function.
 - 📨 Developers can now configure the maximum size of a message to accommodate larger messages within the Streamlit application. See `server.maxMessageSize`.
 - 🐍 We formally added support for Python 3.10.
-- 🚮 Clear `st.experimental_memo` and `st.experimental_singleton` programmatically by using the `clear()` method on a cached function.
 
 **Other Changes**
 

--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -17,6 +17,27 @@ $ pip install --upgrade streamlit
 
 </Tip>
 
+## **Version 1.4.0**
+
+_Release date: Jan 13, 2022_
+
+**Highlights**
+
+- 📸 Introducing `st.camera_input` for uploading images straight from your camera.
+
+**Notable Changes**
+
+- 🚦 Widgets now have the `disabled` parameter that removes interactivity.
+- 📨 Developers can now configure the maximum size of a message to accommodate larger messages within the Streamlit application. See `server.maxMessageSize`.
+- 🐍 We formally added support for Python 3.10.
+- 🚮 Clear `st.experimental_memo` and `st.experimental_singleton` programmatically by using the `clear()` method on a cached function.
+
+**Other Changes**
+
+- 😵‍💫 Calling `str` or `repr` on `threading.current_thread()` does not cause a RecursionError ([#4172](https://github.com/streamlit/streamlit/issues/4172)).
+- 📹 Gracefully stop screencast recording when user removes permission to record ([#4180](https://github.com/streamlit/streamlit/pull/4180)).
+- 🌇 Better scale images by using a higher-quality image bilinear resampling algorithm ([#4159](https://github.com/streamlit/streamlit/pull/4159)).
+
 ## Version 1.3.0
 
 _Release date: Dec 16, 2021_


### PR DESCRIPTION
- [x] Update the Changelog with release notes from Streamlit v1.3.0.
-  [x] Merge this PR _after_ the 1.4.0 release on Thursday, Jan 13, 2022.