### PR TITLE
Fix on reference card margins

### DIFF
--- a/styles/components/blocks/refCard.scss
+++ b/styles/components/blocks/refCard.scss
@@ -31,7 +31,6 @@
     height: 12rem;
     object-fit: cover;
     border-bottom: 1px solid $gray-40;
-    margin-bottom: 1rem;
   }
   p,
   a {
@@ -47,6 +46,10 @@
   > h4 {
     margin: 0 1rem;
     padding: 0;
+  }
+
+  h4 {
+    margin-top: 1rem;
   }
 
   .block-code {


### PR DESCRIPTION
This PR fixes an issue reported by Johannes, where the padding for cards without images was too small

Example:

![image](https://user-images.githubusercontent.com/34423371/149576021-17911df4-316b-44fb-ad96-23d8def4b27d.png)

