### PR TITLE
Add memo.clear and singleton.clear to API reference

### DIFF
--- a/content/library/advanced-features/experimental-cache-primitives.md
+++ b/content/library/advanced-features/experimental-cache-primitives.md
@@ -158,7 +158,7 @@ Pressing the "Clear Square" button will clear `square()`'s memoized values. Pres
 In summary:
 
 - Any function annotated with `@st.experimental_memo` or `@st.experimental_singleton` gets its own `clear()` function automatically.
-- Additionally, you can use `st.experimental_memo.clear()` and `st.experimental_singleton.clear()` to clear _all_ memo and singleton caches, respectively.
+- Additionally, you can use [`st.experimental_memo.clear()`](/library/api-reference/performance/st.experimental_memo.clear) and [`st.experimental_singleton.clear()`](/library/api-reference/performance/st.experimental_singleton.clear) to clear _all_ memo and singleton caches, respectively.
 
 <Note>
 

--- a/content/library/api/api-reference.md
+++ b/content/library/api/api-reference.md
@@ -963,4 +963,43 @@ def get_database_session(url):
 ```
 
 </RefCard>
+
+<RefCard href="/library/api-reference/performance/st.experimental_memo.clear">
+
+#### Clear memo
+
+Clear all in-memory and on-disk memo caches.
+
+```python
+@st.experimental_memo
+def fetch_and_clean_data(url):
+  # Fetch data from URL here, and then clean it up.
+  return data
+
+if st.checkbox("Clear All"):
+  # Clear values from *all* memoized functions
+  st.experimental_memo.clear()
+```
+
+</RefCard>
+
+<RefCard href="/library/api-reference/performance/st.experimental_singleton.clear">
+
+#### Clear singleton
+
+Clear all singleton caches.
+
+```python
+@st.experimental_singleton
+def get_database_session(url):
+  # Create a database session object that points to the URL.
+  return session
+
+if st.button("Clear All"):
+  # Clears all singleton caches:
+  st.experimental_singleton.clear()
+```
+
+</RefCard>
+
 </TileContainer>

--- a/content/library/api/performance/experimental-memo-clear.md
+++ b/content/library/api/performance/experimental-memo-clear.md
@@ -1,0 +1,28 @@
+---
+title: st.experimental_memo.clear
+slug: /library/api-reference/performance/st.experimental_memo.clear
+description: st.experimental_memo.clear clears all in-memory and on-disk memo caches.
+---
+
+<Autofunction function="streamlit.experimental_memo.clear" />
+
+#### Example
+
+In the example below, pressing the "Clear All" button will clear memoized values from all functions decorated with `@st.experimental_memo`.
+
+```python
+import streamlit as st
+
+@st.experimental_memo
+def square(x):
+    return x**2
+
+@st.experimental_memo
+def cube(x):
+    return x**3
+
+if st.button("Clear All"):
+    # Clear values from *all* memoized functions:
+    # i.e. clear values from both square and cube
+    st.experimental_memo.clear()
+```

--- a/content/library/api/performance/experimental-singleton-clear.md
+++ b/content/library/api/performance/experimental-singleton-clear.md
@@ -1,0 +1,30 @@
+---
+title: st.experimental_singleton.clear
+slug: /library/api-reference/performance/st.experimental_singleton.clear
+description: st.experimental_singleton.clear clears all singleton caches.
+---
+
+<Autofunction function="streamlit.experimental_singleton.clear" />
+
+#### Example
+
+In the example below, pressing the "Clear All" button will clear _all_ singleton caches. i.e. Clears cached singleton objects from all functions decorated with `@st.experimental_singleton`.
+
+```python
+import streamlit as st
+from transformers import BertModel
+
+@st.experimental_singleton
+ def get_database_session(url):
+     # Create a database session object that points to the URL.
+     return session
+
+@st.experimental_singleton
+def get_model(model_type):
+    # Create a model of the specified type.
+    return BertModel.from_pretrained(model_type)
+
+if st.button("Clear All"):
+    # Clears all singleton caches:
+    st.experimental_singleton.clear()
+```

--- a/content/menu.md
+++ b/content/menu.md
@@ -238,8 +238,14 @@ site_menu:
   - category: Streamlit library / API reference / Performance / st.experimental_memo
     url: /library/api-reference/performance/st.experimental_memo
     isVersioned: true
+  - category: Streamlit library / API reference / Performance / Clear memo
+    url: /library/api-reference/performance/st.experimental_memo.clear
+    isVersioned: true
   - category: Streamlit library / API reference / Performance / st.experimental_singleton
     url: /library/api-reference/performance/st.experimental_singleton
+    isVersioned: true
+  - category: Streamlit library / API reference / Performance / Clear singleton
+    url: /library/api-reference/performance/st.experimental_singleton.clear
     isVersioned: true
   - category: Streamlit library / Advanced features
     url: /library/advanced-features

--- a/python/generate.py
+++ b/python/generate.py
@@ -54,6 +54,11 @@ def get_function_docstring_dict(func, funcname, signature_prefix):
         description['name'] = funcname.lstrip('_')
         description['signature'] = f'{signature_prefix}.{description["name"]}({arguments})'
 
+    # Edge case for .clear() method on st.experimental_memo and st.experimental_singleton
+    # Prepend "experimental_[memo | singleton]." to the name "clear"
+    if 'experimental' in signature_prefix:
+        description['name'] = f'{signature_prefix}.{funcname}'.lstrip('st.')
+
     if docstring:
         try:
             # Explicitly create the 'Example' section which Streamlit seems to use a lot of.
@@ -191,11 +196,15 @@ def get_obj_docstring_dict(obj, key_prefix, signature_prefix):
 
 def get_streamlit_docstring_dict():
     module_docstring_dict = get_obj_docstring_dict(streamlit, 'streamlit', 'st')
+    memo_clear_docstring_dict = get_obj_docstring_dict(streamlit.caching.memo, 'streamlit.experimental_memo', 'st.experimental_memo')
+    singleton_clear_docstring_dict = get_obj_docstring_dict(streamlit.caching.singleton, 'streamlit.experimental_singleton', 'st.experimental_singleton')
     components_docstring_dict = get_obj_docstring_dict(components, 'streamlit.components.v1', 'st.components.v1')
     delta_docstring_dict = get_obj_docstring_dict(streamlit._DeltaGenerator, 'DeltaGenerator', 'element')
 
-    module_docstring_dict.update(delta_docstring_dict)
+    module_docstring_dict.update(memo_clear_docstring_dict)
+    module_docstring_dict.update(singleton_clear_docstring_dict)
     module_docstring_dict.update(components_docstring_dict)
+    module_docstring_dict.update(delta_docstring_dict)
 
     return module_docstring_dict
 

--- a/python/streamlit.json
+++ b/python/streamlit.json
@@ -53252,7 +53252,6 @@
     "streamlit.camera_input": {
       "name": "camera_input",
       "signature": "st.camera_input(label, key=None, help=None, on_change=None, args=None, kwargs=None, *, disabled=False)",
-      "examples": "<blockquote>\n<pre class=\"doctest-block\">\nimport streamlit as st\n\npicture = st.camera_input(\"Take a picture\")\n\nif picture:\n     st.image(picture)\n</pre>\n</blockquote>\n",
       "description": "Display a widget that returns pictures from the user's webcam.",
       "args": [
         {
@@ -53310,6 +53309,54 @@
           "type_name": "None or UploadedFile",
           "is_generator": false,
           "description": "<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
+          "return_name": null
+        },
+        {
+          "type_name": "Examples",
+          "is_generator": false,
+          "description": "",
+          "return_name": null
+        },
+        {
+          "type_name": "-------",
+          "is_generator": false,
+          "description": "",
+          "return_name": null
+        },
+        {
+          "type_name": ">>> import streamlit as st",
+          "is_generator": false,
+          "description": "",
+          "return_name": null
+        },
+        {
+          "type_name": ">>>",
+          "is_generator": false,
+          "description": "",
+          "return_name": null
+        },
+        {
+          "type_name": ">>> picture = st.camera_input(\"Take a picture\")",
+          "is_generator": false,
+          "description": "",
+          "return_name": null
+        },
+        {
+          "type_name": ">>>",
+          "is_generator": false,
+          "description": "",
+          "return_name": null
+        },
+        {
+          "type_name": "",
+          "is_generator": false,
+          "description": "",
+          "return_name": ">>> if picture"
+        },
+        {
+          "type_name": "...     st.image(picture)",
+          "is_generator": false,
+          "description": "",
           "return_name": null
         }
       ],
@@ -54532,7 +54579,7 @@
     },
     "streamlit.number_input": {
       "name": "number_input",
-      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7ff526958790>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None, *, disabled=False)",
+      "signature": "st.number_input(label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f6dd7336a90>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None, *, disabled=False)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -55660,6 +55707,133 @@
       ],
       "returns": [],
       "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L39"
+    },
+    "streamlit.experimental_memo.clear": {
+      "name": "experimental_memo.clear",
+      "signature": "st.experimental_memo.clear()",
+      "description": "Clear all in-memory and on-disk memo caches.",
+      "args": [],
+      "returns": [],
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/memo_decorator.py#L352"
+    },
+    "streamlit.experimental_singleton.clear": {
+      "name": "experimental_singleton.clear",
+      "signature": "st.experimental_singleton.clear()",
+      "description": "Clear all singleton caches.",
+      "args": [],
+      "returns": [],
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/caching/singleton_decorator.py#L238"
+    },
+    "streamlit.components.v1.declare_component": {
+      "name": "declare_component",
+      "signature": "st.components.v1.declare_component(name, path=None, url=None)",
+      "description": "Create and register a custom component.",
+      "args": [
+        {
+          "name": "name",
+          "type_name": "str",
+          "is_optional": false,
+          "description": "<p>A short, descriptive name for the component. Like, &quot;slider&quot;.</p>\n",
+          "default": null
+        },
+        {
+          "name": "path",
+          "type_name": "str or None",
+          "is_optional": false,
+          "description": "<p>The path to serve the component's frontend files from. Either\n<cite>path</cite> or <cite>url</cite> must be specified, but not both.</p>\n",
+          "default": null
+        },
+        {
+          "name": "url",
+          "type_name": "str or None",
+          "is_optional": false,
+          "description": "<p>The URL that the component is served from. Either <cite>path</cite> or <cite>url</cite>\nmust be specified, but not both.</p>\n",
+          "default": null
+        }
+      ],
+      "returns": [
+        {
+          "type_name": "CustomComponent",
+          "is_generator": false,
+          "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
+          "return_name": null
+        }
+      ],
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
+    },
+    "streamlit.components.v1.html": {
+      "name": "html",
+      "signature": "st.components.v1.html(html, width=None, height=None, scrolling=False)",
+      "description": "Display an HTML string in an iframe.",
+      "args": [
+        {
+          "name": "html",
+          "type_name": "str",
+          "is_optional": false,
+          "description": "<p>The HTML string to embed in the iframe.</p>\n",
+          "default": null
+        },
+        {
+          "name": "width",
+          "type_name": "int",
+          "is_optional": false,
+          "description": "<p>The width of the frame in CSS pixels. Defaults to the report's\ndefault element width.</p>\n",
+          "default": "the"
+        },
+        {
+          "name": "height",
+          "type_name": "int",
+          "is_optional": false,
+          "description": "<p>The height of the frame in CSS pixels. Defaults to 150.</p>\n",
+          "default": "150."
+        },
+        {
+          "name": "scrolling",
+          "type_name": "bool",
+          "is_optional": false,
+          "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
+          "default": "False."
+        }
+      ],
+      "returns": [],
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
+    },
+    "streamlit.components.v1.iframe": {
+      "name": "iframe",
+      "signature": "st.components.v1.iframe(src, width=None, height=None, scrolling=False)",
+      "description": "Load a remote URL in an iframe.",
+      "args": [
+        {
+          "name": "src",
+          "type_name": "str",
+          "is_optional": false,
+          "description": "<p>The URL of the page to embed.</p>\n",
+          "default": null
+        },
+        {
+          "name": "width",
+          "type_name": "int",
+          "is_optional": false,
+          "description": "<p>The width of the frame in CSS pixels. Defaults to the report's\ndefault element width.</p>\n",
+          "default": "the"
+        },
+        {
+          "name": "height",
+          "type_name": "int",
+          "is_optional": false,
+          "description": "<p>The height of the frame in CSS pixels. Defaults to 150.</p>\n",
+          "default": "150."
+        },
+        {
+          "name": "scrolling",
+          "type_name": "bool",
+          "is_optional": false,
+          "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
+          "default": "False."
+        }
+      ],
+      "returns": [],
+      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     },
     "DeltaGenerator.add_rows": {
       "name": "add_rows",
@@ -57149,7 +57323,7 @@
     },
     "DeltaGenerator.number_input": {
       "name": "number_input",
-      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7ff526958790>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None, *, disabled=False)",
+      "signature": "element.number_input(self, label, min_value=None, max_value=None, value=<streamlit.state.widgets.NoValue object at 0x7f6dd7336a90>, step=None, format=None, key=None, help=None, on_change=None, args=None, kwargs=None, *, disabled=False)",
       "example": "<blockquote>\n<pre class=\"doctest-block\">\nnumber = st.number_input('Insert a number')\nst.write('The current number is ', number)\n</pre>\n</blockquote>\n",
       "description": "Display a numeric input widget.",
       "args": [
@@ -58195,117 +58369,6 @@
       ],
       "returns": [],
       "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/write.py#L39"
-    },
-    "streamlit.components.v1.declare_component": {
-      "name": "declare_component",
-      "signature": "st.components.v1.declare_component(name, path=None, url=None)",
-      "description": "Create and register a custom component.",
-      "args": [
-        {
-          "name": "name",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>A short, descriptive name for the component. Like, &quot;slider&quot;.</p>\n",
-          "default": null
-        },
-        {
-          "name": "path",
-          "type_name": "str or None",
-          "is_optional": false,
-          "description": "<p>The path to serve the component's frontend files from. Either\n<cite>path</cite> or <cite>url</cite> must be specified, but not both.</p>\n",
-          "default": null
-        },
-        {
-          "name": "url",
-          "type_name": "str or None",
-          "is_optional": false,
-          "description": "<p>The URL that the component is served from. Either <cite>path</cite> or <cite>url</cite>\nmust be specified, but not both.</p>\n",
-          "default": null
-        }
-      ],
-      "returns": [
-        {
-          "type_name": "CustomComponent",
-          "is_generator": false,
-          "description": "<p>A CustomComponent that can be called like a function.\nCalling the component will create a new instance of the component\nin the Streamlit app.</p>\n",
-          "return_name": null
-        }
-      ],
-      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/components/v1/components.py#L242"
-    },
-    "streamlit.components.v1.html": {
-      "name": "html",
-      "signature": "st.components.v1.html(html, width=None, height=None, scrolling=False)",
-      "description": "Display an HTML string in an iframe.",
-      "args": [
-        {
-          "name": "html",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The HTML string to embed in the iframe.</p>\n",
-          "default": null
-        },
-        {
-          "name": "width",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The width of the frame in CSS pixels. Defaults to the report's\ndefault element width.</p>\n",
-          "default": "the"
-        },
-        {
-          "name": "height",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The height of the frame in CSS pixels. Defaults to 150.</p>\n",
-          "default": "150."
-        },
-        {
-          "name": "scrolling",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
-          "default": "False."
-        }
-      ],
-      "returns": [],
-      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L56"
-    },
-    "streamlit.components.v1.iframe": {
-      "name": "iframe",
-      "signature": "st.components.v1.iframe(src, width=None, height=None, scrolling=False)",
-      "description": "Load a remote URL in an iframe.",
-      "args": [
-        {
-          "name": "src",
-          "type_name": "str",
-          "is_optional": false,
-          "description": "<p>The URL of the page to embed.</p>\n",
-          "default": null
-        },
-        {
-          "name": "width",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The width of the frame in CSS pixels. Defaults to the report's\ndefault element width.</p>\n",
-          "default": "the"
-        },
-        {
-          "name": "height",
-          "type_name": "int",
-          "is_optional": false,
-          "description": "<p>The height of the frame in CSS pixels. Defaults to 150.</p>\n",
-          "default": "150."
-        },
-        {
-          "name": "scrolling",
-          "type_name": "bool",
-          "is_optional": false,
-          "description": "<p>If True, show a scrollbar when the content is larger than the iframe.\nOtherwise, do not show a scrollbar. Defaults to False.</p>\n",
-          "default": "False."
-        }
-      ],
-      "returns": [],
-      "source": "https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/elements/iframe.py#L23"
     }
   }
 }

--- a/python/streamlit.json
+++ b/python/streamlit.json
@@ -53252,6 +53252,7 @@
     "streamlit.camera_input": {
       "name": "camera_input",
       "signature": "st.camera_input(label, key=None, help=None, on_change=None, args=None, kwargs=None, *, disabled=False)",
+      "examples": "<blockquote>\n<pre class=\"doctest-block\">\nimport streamlit as st\n\npicture = st.camera_input(\"Take a picture\")\n\nif picture:\n     st.image(picture)\n</pre>\n</blockquote>\n",
       "description": "Display a widget that returns pictures from the user's webcam.",
       "args": [
         {
@@ -53309,54 +53310,6 @@
           "type_name": "None or UploadedFile",
           "is_generator": false,
           "description": "<p>The UploadedFile class is a subclass of BytesIO, and therefore\nit is &quot;file-like&quot;. This means you can pass them anywhere where\na file is expected.</p>\n",
-          "return_name": null
-        },
-        {
-          "type_name": "Examples",
-          "is_generator": false,
-          "description": "",
-          "return_name": null
-        },
-        {
-          "type_name": "-------",
-          "is_generator": false,
-          "description": "",
-          "return_name": null
-        },
-        {
-          "type_name": ">>> import streamlit as st",
-          "is_generator": false,
-          "description": "",
-          "return_name": null
-        },
-        {
-          "type_name": ">>>",
-          "is_generator": false,
-          "description": "",
-          "return_name": null
-        },
-        {
-          "type_name": ">>> picture = st.camera_input(\"Take a picture\")",
-          "is_generator": false,
-          "description": "",
-          "return_name": null
-        },
-        {
-          "type_name": ">>>",
-          "is_generator": false,
-          "description": "",
-          "return_name": null
-        },
-        {
-          "type_name": "",
-          "is_generator": false,
-          "description": "",
-          "return_name": ">>> if picture"
-        },
-        {
-          "type_name": "...     st.image(picture)",
-          "is_generator": false,
-          "description": "",
           "return_name": null
         }
       ],


### PR DESCRIPTION
### Description
Add memo.clear and singleton.clear to API reference.

Streamlit 1.4.0 implements two new functions `st.memo.clear()` and `st.singleton.clear()` , which clear the caches for all functions with memo and singleton, respectively. [MADE has requested](https://www.notion.so/streamlit/Make-st-memo-clear-show-up-in-API-reference-c0f25db960da42d598e3ed295aa51e30) that we include them in the API reference.

### Changes
- Modifies `generate.py` to include docstrings for the `clear()` method. We usually get docstrings of `st.command`. This PR makes an exception for `st.command.clear`.
- Creates cards for both functions on the API reference landing page.
- Creates API reference pages for both functions.