### PR TITLE
Query param to remove old styles

### DIFF
--- a/components/utilities/breadCrumbs.module.css
+++ b/components/utilities/breadCrumbs.module.css
@@ -14,6 +14,10 @@
 }
 
 .Separator {
-  @apply dark:text-gray-70 ml-2;
+  @apply ml-2;
   @apply text-gray-50 !important;
+}
+
+:global(.dark) .Separator {
+  @apply text-gray-70 !important;
 }

--- a/components/utilities/themeToggle.js
+++ b/components/utilities/themeToggle.js
@@ -10,6 +10,8 @@ const ThemeToggle = () => {
 
   useEffect(() => {
     document.body.dataset.theme = activeTheme;
+    if (!activeTheme) return;
+
     if (activeTheme === "light-mode") {
       document.documentElement.classList.add("light");
       document.documentElement.classList.remove("dark");

--- a/components/utilities/themeToggle.js
+++ b/components/utilities/themeToggle.js
@@ -1,16 +1,18 @@
 import React, { useState, useEffect } from "react";
 
 const ThemeToggle = () => {
-  const [activeTheme, setActiveTheme] = useState(document.body.dataset.theme);
-  const [tailwindTheme, setTailwindTheme] = useState("light-mode");
+  const [activeThemeV1, setActiveThemeV1] = useState(
+    document.body.dataset.theme
+  );
+  const [activeThemeV2, setActiveThemeV2] = useState("light-mode");
   let inactiveTheme;
-  if (activeTheme !== undefined) {
-    inactiveTheme = activeTheme === "light-mode" ? "dark-mode" : "light-mode";
+  if (activeThemeV1 !== undefined) {
+    inactiveTheme = activeThemeV1 === "light-mode" ? "dark-mode" : "light-mode";
   }
   const changeTheme = new Event("ChangeTheme");
 
   const changeTailwindTheme = (theme) => {
-    setTailwindTheme(theme);
+    setActiveThemeV2(theme);
 
     if (theme === "light-mode") {
       document.documentElement.classList.add("light");
@@ -22,10 +24,10 @@ const ThemeToggle = () => {
   };
 
   useEffect(() => {
-    if (!activeTheme) return;
-    document.body.dataset.theme = activeTheme;
+    if (!activeThemeV1) return;
+    document.body.dataset.theme = activeThemeV1;
 
-    if (activeTheme === "light-mode") {
+    if (activeThemeV1 === "light-mode") {
       document.documentElement.classList.add("light");
       document.documentElement.classList.remove("dark");
     } else {
@@ -35,12 +37,12 @@ const ThemeToggle = () => {
     window.addEventListener(
       "ChangeTheme",
       function (e) {
-        window.localStorage.setItem("theme", activeTheme);
+        window.localStorage.setItem("theme", activeThemeV1);
       },
       false
     );
     window.dispatchEvent(changeTheme);
-  }, [activeTheme]);
+  }, [activeThemeV1]);
 
   return (
     <React.Fragment>
@@ -48,17 +50,17 @@ const ThemeToggle = () => {
         aria-label={`Change to ${inactiveTheme} mode`}
         title={`Change to ${inactiveTheme} mode`}
         type="button"
-        onClick={() => setActiveTheme(inactiveTheme)}
+        onClick={() => setActiveThemeV1(inactiveTheme)}
         className="toggleTheme"
       >
         {/* <span activeTheme={activeTheme} /> */}
         <i className="dark">dark_mode</i>
         <i className="light">light_mode</i>
       </button>
-      {activeTheme === undefined && (
+      {activeThemeV1 === undefined && (
         <div
           onClick={
-            tailwindTheme === "light-mode"
+            activeThemeV2 === "light-mode"
               ? () => changeTailwindTheme("dark-mode")
               : () => changeTailwindTheme("light-mode")
           }

--- a/components/utilities/themeToggle.js
+++ b/components/utilities/themeToggle.js
@@ -2,8 +2,10 @@ import { useState, useEffect } from "react";
 
 const ThemeToggle = () => {
   const [activeTheme, setActiveTheme] = useState(document.body.dataset.theme);
-  const inactiveTheme =
-    activeTheme === "light-mode" ? "dark-mode" : "light-mode";
+  let inactiveTheme;
+  if (activeTheme !== undefined) {
+    inactiveTheme = activeTheme === "light-mode" ? "dark-mode" : "light-mode";
+  }
   const changeTheme = new Event("ChangeTheme");
 
   useEffect(() => {

--- a/components/utilities/themeToggle.js
+++ b/components/utilities/themeToggle.js
@@ -1,16 +1,29 @@
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 
 const ThemeToggle = () => {
   const [activeTheme, setActiveTheme] = useState(document.body.dataset.theme);
+  const [tailwindTheme, setTailwindTheme] = useState("light-mode");
   let inactiveTheme;
   if (activeTheme !== undefined) {
     inactiveTheme = activeTheme === "light-mode" ? "dark-mode" : "light-mode";
   }
   const changeTheme = new Event("ChangeTheme");
 
+  const changeTailwindTheme = (theme) => {
+    setTailwindTheme(theme);
+
+    if (theme === "light-mode") {
+      document.documentElement.classList.add("light");
+      document.documentElement.classList.remove("dark", "bg-gray-100");
+    } else {
+      document.documentElement.classList.add("dark", "bg-gray-100");
+      document.documentElement.classList.remove("light");
+    }
+  };
+
   useEffect(() => {
-    document.body.dataset.theme = activeTheme;
     if (!activeTheme) return;
+    document.body.dataset.theme = activeTheme;
 
     if (activeTheme === "light-mode") {
       document.documentElement.classList.add("light");
@@ -30,17 +43,30 @@ const ThemeToggle = () => {
   }, [activeTheme]);
 
   return (
-    <button
-      aria-label={`Change to ${inactiveTheme} mode`}
-      title={`Change to ${inactiveTheme} mode`}
-      type="button"
-      onClick={() => setActiveTheme(inactiveTheme)}
-      className="toggleTheme"
-    >
-      {/* <span activeTheme={activeTheme} /> */}
-      <i className="dark">dark_mode</i>
-      <i className="light">light_mode</i>
-    </button>
+    <React.Fragment>
+      <button
+        aria-label={`Change to ${inactiveTheme} mode`}
+        title={`Change to ${inactiveTheme} mode`}
+        type="button"
+        onClick={() => setActiveTheme(inactiveTheme)}
+        className="toggleTheme"
+      >
+        {/* <span activeTheme={activeTheme} /> */}
+        <i className="dark">dark_mode</i>
+        <i className="light">light_mode</i>
+      </button>
+      {activeTheme === undefined && (
+        <div
+          onClick={
+            tailwindTheme === "light-mode"
+              ? () => changeTailwindTheme("dark-mode")
+              : () => changeTailwindTheme("light-mode")
+          }
+        >
+          Change Tailwind theme
+        </div>
+      )}
+    </React.Fragment>
   );
 };
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -12,20 +12,16 @@ export default function StreamlitDocument() {
     }
 
     
-    if(query !== '?oldStyles=false') {
-      if(getUserPreference() == 'undefined') {
-        document.body.dataset.theme = 'light-mode';
-      } else {
-        document.body.dataset.theme = getUserPreference();
-      }
-      
+     if (query !== '?oldStyles=false') {
       if(getUserPreference() === 'dark-mode') {
-        document.documentElement.classList.add('dark');
+        document.documentElement.classList.add('dark')
       } else {
-        document.documentElement.classList.add('light');
+        document.documentElement.classList.add('light')
       }
+      document.body.dataset.theme = getUserPreference()
     }
-    window.initial = { prism: false };
+
+    window.initial = { prism: false }
   `;
 
   return (

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,23 +1,25 @@
-// pages/_document.js
-
 import Document, { Html, Head, Main, NextScript } from "next/document";
 
 export default function StreamlitDocument() {
   const setInitialTheme = `
-        function getUserPreference() {
-          if(window.localStorage.getItem('theme')) {
-            return window.localStorage.getItem('theme')
-          }
-          return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark-mode' : 'light-mode';
+    const query = window.location.search;
+    function getUserPreference() {
+        if(window.localStorage.getItem('theme')) {
+          return window.localStorage.getItem('theme')
         }
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark-mode' : 'light-mode';
+      }
 
-        if(getUserPreference() === 'dark-mode') {
-          document.documentElement.classList.add('dark');
-        } else {
-          document.documentElement.classList.add('light');
-        }
+      if(getUserPreference() === 'dark-mode') {
+        document.documentElement.classList.add('dark');
+      } else {
+        document.documentElement.classList.add('light');
+      }
+
+      if(query !== '?oldStyles=false') {
         document.body.dataset.theme = getUserPreference();
-        window.initial = { prism: false };
+      }
+      window.initial = { prism: false };
     `;
 
   return (

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -4,23 +4,24 @@ export default function StreamlitDocument() {
   const setInitialTheme = `
     const query = window.location.search;
     function getUserPreference() {
-        if(window.localStorage.getItem('theme')) {
-          return window.localStorage.getItem('theme')
-        }
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark-mode' : 'light-mode';
+      if(window.localStorage.getItem('theme')) {
+        return window.localStorage.getItem('theme');
       }
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark-mode' : 'light-mode';
+    }
 
+    
+    if(query !== '?oldStyles=false') {
+      document.body.dataset.theme = getUserPreference();
+      
       if(getUserPreference() === 'dark-mode') {
         document.documentElement.classList.add('dark');
       } else {
         document.documentElement.classList.add('light');
       }
-
-      if(query !== '?oldStyles=false') {
-        document.body.dataset.theme = getUserPreference();
-      }
-      window.initial = { prism: false };
-    `;
+    }
+    window.initial = { prism: false };
+  `;
 
   return (
     <Html>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,6 +1,7 @@
 import Document, { Html, Head, Main, NextScript } from "next/document";
 
 export default function StreamlitDocument() {
+  // TODO: Refactor this using useEffect()
   const setInitialTheme = `
     const query = window.location.search;
     function getUserPreference() {

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -12,7 +12,11 @@ export default function StreamlitDocument() {
 
     
     if(query !== '?oldStyles=false') {
-      document.body.dataset.theme = getUserPreference();
+      if(getUserPreference() == 'undefined') {
+        document.body.dataset.theme = 'light-mode';
+      } else {
+        document.body.dataset.theme = getUserPreference();
+      }
       
       if(getUserPreference() === 'dark-mode') {
         document.documentElement.classList.add('dark');


### PR DESCRIPTION
This PR adds support to remove the global styles, conflicting with our new Tailwind refactor, using the `?oldStyles=false` query param.

It removes both the `data-theme=[theme]` on the `<body>` (used for the global styles on the `scss` files) _and_ the `class=[theme]` on the `<html>` tag (used for Tailwind's dark styles) on first render, but allows the Tailwind theme to be changed via a button on the navigation.