### PR TITLE
Remove references to old Streamlit versions

### DIFF
--- a/content/kb/deployments/upgrade-streamlit-version.md
+++ b/content/kb/deployments/upgrade-streamlit-version.md
@@ -17,7 +17,7 @@ You may want to avoid getting into this situation if your app depends on a speci
 
 1. If the Streamlit version is not pinned (i.e., the requirements file contains a line with `streamlit` and nothing else):
    - Reboot the app as described above.
-2. If the Streamlit version is pinned (e.g., `streamlit==1.0.0`):
+2. If the Streamlit version is pinned (e.g., `streamlit==1.4.0`):
    - Adapt the pinned version in the requirements file and push it to GitHub.
    - The app on Streamlit Cloud will reboot automatically as soon as it detects these changes.
 

--- a/content/kb/using-streamlit/how-download-file-streamlit.md
+++ b/content/kb/using-streamlit/how-download-file-streamlit.md
@@ -5,7 +5,7 @@ slug: /knowledge-base/using-streamlit/how-download-file-streamlit
 
 # How to download a file in Streamlit?
 
-Starting with v0.88, [`st.download_button`](/library/api-reference/widgets/st.download_button) is natively built into Streamlit. Check out the [release notes](https://blog.streamlit.io/0-88-0-release-notes/), [API](/library/api-reference/widgets/st.download_button), and a [sample app](https://share.streamlit.io/streamlit/release-demos/0.88/0.88/streamlit_app.py).
+Use the [`st.download_button`](/library/api-reference/widgets/st.download_button) widget that is natively built into Streamlit. Check out a [sample app](https://share.streamlit.io/streamlit/release-demos/0.88/0.88/streamlit_app.py) demonstrating how you can use `st.download_button` to download common file formats.
 
 ## Example usage
 

--- a/content/kb/using-streamlit/how-download-pandas-dataframe-csv.md
+++ b/content/kb/using-streamlit/how-download-pandas-dataframe-csv.md
@@ -5,7 +5,7 @@ slug: /knowledge-base/using-streamlit/how-download-pandas-dataframe-csv
 
 # How to download a Pandas DataFrame as a CSV?
 
-Starting with v0.88, [`st.download_button`](/library/api-reference/widgets/st.download_button) is natively built into Streamlit. Check out the [release notes](https://blog.streamlit.io/0-88-0-release-notes/), [API](/library/api-reference/widgets/st.download_button), and a [sample app](https://share.streamlit.io/streamlit/release-demos/0.88/0.88/streamlit_app.py).
+Use the [`st.download_button`](/library/api-reference/widgets/st.download_button) widget that is natively built into Streamlit. Check out a [sample app](https://share.streamlit.io/streamlit/release-demos/0.88/0.88/streamlit_app.py) demonstrating how you can use `st.download_button` to download common file formats.
 
 ## Example usage
 

--- a/content/kb/using-streamlit/sanity-checks.md
+++ b/content/kb/using-streamlit/sanity-checks.md
@@ -83,7 +83,7 @@ working, you can downgrade at any time using this command:
 pip install --upgrade streamlit==1.0.0
 ```
 
-...where `0.1.0` is the version you'd like to downgrade to. See
+...where `1.0.0` is the version you'd like to downgrade to. See
 [Changelog](/library/changelog) for a complete list of Streamlit versions.
 
 ## Check #6 [Windows]: Is Python added to your PATH?

--- a/content/kb/using-streamlit/sanity-checks.md
+++ b/content/kb/using-streamlit/sanity-checks.md
@@ -39,7 +39,7 @@ pip install --upgrade streamlit
 streamlit version
 ```
 
-...and then verify that the version number printed is `1.2.0`.
+...and then verify that the version number printed corresponds to the version number displayed on [PyPI](https://pypi.org/project/streamlit/).
 
 **Try reproducing the issue now.** If not fixed, keep reading on.
 
@@ -80,10 +80,10 @@ If you've upgraded to the latest version of Streamlit and things aren't
 working, you can downgrade at any time using this command:
 
 ```bash
-pip install --upgrade streamlit==0.50
+pip install --upgrade streamlit==1.0.0
 ```
 
-...where `0.50` is the version you'd like to downgrade to. See
+...where `0.1.0` is the version you'd like to downgrade to. See
 [Changelog](/library/changelog) for a complete list of Streamlit versions.
 
 ## Check #6 [Windows]: Is Python added to your PATH?
@@ -119,9 +119,7 @@ After adding Python to your Windows PATH, you should then be able to follow the 
 
 ## Check #7 [Windows]: Do you need Build Tools for Visual Studio installed?
 
-Starting with version [0.63](/library/changelog#version-0630) (July 2020), Streamlit added [pyarrow](https://arrow.apache.org/docs/python/) as an install dependency
-as part of the [Streamlit Components](/library/components) feature release. Occasionally, when trying to install Streamlit from
-PyPI, you may see errors such as the following:
+Streamlit includes [pyarrow](https://arrow.apache.org/docs/python/) as an install dependency. Occasionally, when trying to install Streamlit from PyPI, you may see errors such as the following:
 
 ```shell
 Using cached pyarrow-1.0.1.tar.gz (1.3 MB)

--- a/content/library/api-cheat-sheet.md
+++ b/content/library/api-cheat-sheet.md
@@ -5,7 +5,7 @@ slug: /library/cheatsheet
 
 # Cheat Sheet
 
-This is a summary of the docs, as of [Streamlit v1.2.0](https://pypi.org/project/streamlit/1.2.0/).
+This is a summary of the docs, as of [Streamlit v1.4.0](https://pypi.org/project/streamlit/1.4.0/).
 
 <Masonry>
 
@@ -156,8 +156,12 @@ st.video(data)
 #### Control flow
 
 ```python
+# Stop execution immediately:
 st.stop()
+# Rerun script immediately:
+st.experimental_rerun()
 
+# Group multiple widgets:
 >>> with st.form(key='my_form'):
 >>>   username = st.text_input('Username')
 >>>   password = st.text_input('Password')
@@ -185,6 +189,7 @@ st.date_input('Your birthday')
 st.time_input('Meeting time')
 st.file_uploader('Upload a photo')
 st.download_button('Download file', data)
+st.camera_input("Take a picture")
 st.color_picker('Pick a color')
 
 # Use widgets' returned values in variables:
@@ -194,6 +199,9 @@ st.color_picker('Pick a color')
 >>>   b()
 >>> my_slider_val = st.slider('Quinn Mallory', 1, 88)
 >>> st.write(slider_val)
+
+# Disable widgets to remove interactivity:
+>>> st.slider('Pick a number', 0, 100, disabled=True)
 ```
 
 </CodeTile>
@@ -247,6 +255,9 @@ st.help(pandas.DataFrame)
 st.get_option(key)
 st.set_option(key, value)
 st.set_page_config(layout='wide')
+st.experimental_show(objects)
+st.experimental_get_query_params()
+st.experimental_set_query_params(**params)
 ```
 
 </CodeTile>
@@ -286,6 +297,10 @@ st.set_page_config(layout='wide')
 >>> d2 = foo(ref1)
 # Different arg, so function foo executes
 >>> d3 = foo(ref2)
+# Clear all cached entries for this function
+>>> foo.clear()
+# Clear values from *all* memoized functions
+>>> st.experimental_memo.clear()
 ```
 
 ###### Cache non-data objects
@@ -303,6 +318,10 @@ st.set_page_config(layout='wide')
 >>> s2 = foo(ref1)
 # Different arg, so function foo executes
 >>> s3 = foo(ref2)
+# Clear all cached entries for this function
+>>> foo.clear()
+# Clear all singleton caches
+>>> st.experimental_singleton.clear()
 ```
 
 </CodeTile>

--- a/content/library/components/create-component.md
+++ b/content/library/components/create-component.md
@@ -13,18 +13,18 @@ components created by the community!
 
 </Note>
 
-Starting with version [0.63.0](/library/changelog#version-0630), developers can write JavaScript and HTML "components" that can be rendered in Streamlit apps. Streamlit Components can receive data from, and also send data to, Streamlit Python scripts.
+Developers can write JavaScript and HTML "components" that can be rendered in Streamlit apps. Streamlit Components can receive data from, and also send data to, Streamlit Python scripts.
 
-Streamlit Components let you expand the functionality provided in the base Streamlit package. Use Streamlit Components to create the needed functionality for your use case, then wrap it up in a Python package and share with the broader Streamlit community!
+Streamlit Components let you expand the functionality provided in the base Streamlit package. Use Streamlit Components to create the needed functionality for your use-case, then wrap it up in a Python package and share with the broader Streamlit community!
 
 **Types of Streamlit Components you could create include:**
 
-- Custom versions of existing Streamlit elements and widgets, such as `st.slider` or `st.file_uploader`
-- Completely new Streamlit elements and widgets by wrapping existing React.js, Vue.js, or other JavaScript widget toolkits
-- Rendering Python objects having methods that output HTML, such as IPython [`__repr_html__`](https://ipython.readthedocs.io/en/stable/config/integrating.html#rich-display)
-- Convenience functions for commonly-used web features like [GitHub gists and Pastebin](https://github.com/randyzwitch/streamlit-embedcode)
+- Custom versions of existing Streamlit elements and widgets, such as `st.slider` or `st.file_uploader`.
+- Completely new Streamlit elements and widgets by wrapping existing React.js, Vue.js, or other JavaScript widget toolkits.
+- Rendering Python objects having methods that output HTML, such as IPython [`__repr_html__`](https://ipython.readthedocs.io/en/stable/config/integrating.html#rich-display).
+- Convenience functions for commonly-used web features like [GitHub gists and Pastebin](https://github.com/randyzwitch/streamlit-embedcode).
 
-Check out these Streamlit Components Tutorial videos by Streamlit engineer Tim Conkling to get started:
+Check out these Streamlit Components tutorial videos by Streamlit engineer Tim Conkling to get started:
 
 ## Part 1: Setup and Architecture
 

--- a/content/streamlit-cloud/get-started/deploy-an-app/app-dependencies.md
+++ b/content/streamlit-cloud/get-started/deploy-an-app/app-dependencies.md
@@ -32,8 +32,8 @@ Streamlit looks at your requirements file's filename to determine which Python d
 
 Only include packages in your requirements file that are not distributed with a standard Python
 installation. If [any of the modules from base Python](https://docs.python.org/3/py-modindex.html)
-are included in the requirements file, you will get an error when you try to deploy. Additionally,
-use versions **0.69.2+** of Streamlit to ensure full Streamlit Cloud functionality.
+are included in the requirements file, you will get an error when you try to deploy. Additionally, we recommend that you
+use the latest version of Streamlit to ensure full Streamlit Cloud functionality.
 
 </Note>
 


### PR DESCRIPTION
### :books: Context
Especially post 1.0, highlighting when a feature occurred is increasingly [unnecessary](https://www.notion.so/streamlit/Scrub-docs-of-references-to-since-really-old-version-534a0d949e8845ae89e0ef3f86eb5101). E.g. _"Starting with version 0.63.0, developers can write JavaScript and HTML "components" that can be rendered in..."_.

### :brain: Description of Changes
This PR finds anywhere that implies that a feature’s importance is relative to when it became part of the product, removes the reference, and makes sure that the feature itself has a coherent story relative to other features. 

- Scrubs references to old versions of Streamlit in `./content/`, with the exception of the changelog.
- Updates the cheatsheet to Streamlit v1.4.0.