### PR TITLE
Add User-Agent header to fix unresponsive audio app

### DIFF
--- a/python/api-examples-source/charts.audio.py
+++ b/python/api-examples-source/charts.audio.py
@@ -2,9 +2,12 @@ import requests
 import streamlit as st
 
 
-@st.experimental_singleton
+@st.experimental_memo
 def read_file_from_url(url):
-    return requests.get(url).content
+    headers = {
+        "User-Agent": "StreamlitDocs/1.5.0 (https://docs.streamlit.io; hello@streamlit.io)"
+    }
+    return requests.get(url, headers=headers).content
 
 
 file_bytes = read_file_from_url(


### PR DESCRIPTION
### :books: Context
The [Cloud app for `st.audio`](https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/charts.audio.py) is unresponsive and does not play the audio. The reason being that the app's GET request violates [Wikimedia's User-Agent policy](https://meta.wikimedia.org/wiki/User-Agent_policy), and is hence blocked.

### :brain: Description of Changes
- Include a unique User-Agent string that complies with [Wikimedia's User-Agent policy](https://meta.wikimedia.org/wiki/User-Agent_policy) as a header with the GET request.
- Replace singleton with memo as the function returns a data object.