### PR TITLE
Fix on helpful and suggestEdits spacing on mobile

### DIFF
--- a/components/utilities/helpful.module.css
+++ b/components/utilities/helpful.module.css
@@ -23,6 +23,10 @@
   @apply text-gray-90 !important;
 }
 
+.Button:last-child {
+  @apply ml-6;
+}
+
 :global(.dark) .Button {
   @apply bg-gray-80;
   @apply text-white !important;

--- a/components/utilities/suggestEdits.module.css
+++ b/components/utilities/suggestEdits.module.css
@@ -1,5 +1,5 @@
 .Container {
-  @apply flex items-center cursor-pointer;
+  @apply mt-6 sm:mt-0 flex items-center cursor-pointer;
 }
 
 .Icon {


### PR DESCRIPTION
This PR fixes some visual regressions on the `helpful` and `suggestEdits` components on mobile, caused by the refactoring that's currently happening.

**Before:**

![Screen Shot 2022-01-28 at 11 00 04](https://user-images.githubusercontent.com/34423371/151560698-7711abca-cca3-45ef-8980-945ec2a9430f.png)

**After:**

![Screen Shot 2022-01-28 at 11 02 57](https://user-images.githubusercontent.com/34423371/151560733-60733710-d3bb-42e3-a47b-514e18839de3.png)

