### PR TITLE
Add component to embed arbitrary Cloud apps in articles

### DIFF
--- a/components/blocks/cloud.js
+++ b/components/blocks/cloud.js
@@ -1,0 +1,50 @@
+import React from "react";
+
+const Cloud = ({ src, height }) => {
+  let CloudBlock;
+
+  if (height) {
+    CloudBlock = (
+      <section className="block-cloud">
+        <section className="cloud-app">
+          <iframe
+            loading="lazy"
+            src={`${src}&embed=true`}
+            height={height}
+            width={`100%`}
+          ></iframe>
+        </section>
+        <section>
+          <sup>
+            <a href={src} target="_blank">
+              (view standalone Streamlit app)
+            </a>
+          </sup>
+        </section>
+      </section>
+    );
+  } else {
+    CloudBlock = (
+      <section className="block-cloud">
+        <section className="cloud-app">
+          <iframe
+            loading="lazy"
+            src={`${src}&embed=true`}
+            height={`200rem`}
+            width={`100%`}
+          ></iframe>
+        </section>
+        <section>
+          <sup>
+            <a href={src} target="_blank">
+              (view standalone Streamlit app)
+            </a>
+          </sup>
+        </section>
+      </section>
+    );
+  }
+  return CloudBlock;
+};
+
+export default Cloud;

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -51,6 +51,7 @@ import InlineCallout from "../components/blocks/inlineCallout";
 import Tip from "../components/blocks/tip";
 import Warning from "../components/blocks/warning";
 import YouTube from "../components/blocks/youTube";
+import Cloud from "../components/blocks/cloud";
 
 export default function Article({
   data,
@@ -87,6 +88,7 @@ export default function Article({
     Code,
     Warning,
     YouTube,
+    Cloud,
     Masonry,
     CodeTile,
     InlineCalloutContainer,

--- a/styles/components/blocks/cloud.scss
+++ b/styles/components/blocks/cloud.scss
@@ -1,0 +1,13 @@
+.cloud-app {
+  margin: 0;
+  padding: 0;
+  display: inline-block;
+  width: 100%;
+  max-width: 100%;
+
+  iframe {
+    width: calc(100% - 2px) !important;
+    border: 1px solid $gray-40 !important;
+    border-radius: 5px;
+  }
+}

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -44,3 +44,4 @@
 @import "./components/blocks/table.scss";
 @import "./components/blocks/tile.scss";
 @import "./components/blocks/youTube.scss";
+@import "./components/blocks/cloud.scss";


### PR DESCRIPTION
### :books: Context
We are currently unable to embed arbitrary Streamlit Cloud apps into articles. The `Autofunction` component allows us to embed specific apps that are associated with Streamlit commands. We want to be able to embed **_any public Cloud app in any page_** of our docs to augment user experience.  

For example, we may want to embed an app in the [Create an app](https://docs.streamlit.io/library/get-started/create-an-app) article in the Get Started section so that users are able to interact with a live app right from our docs, instead of having to look at static images or create and run an app themselves.

### :brain: Description of Changes
This PR creates a `Cloud` component with associated styling, inspired by the `YouTube` component, allowing us to embed arbitrary Cloud apps on any page. Fixes #97.

E.g. To embed this [demo `st.number_input`` app](https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.number_input.py) on any page, include the following in the page's Markdown file:

```
<Cloud src="https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/widget.number_input.py" height="260" />
```

![image](https://user-images.githubusercontent.com/20672874/151761111-fba01815-af05-4941-89da-1bcca8ad8600.png)
