### PR TITLE
Fix on indentation for navbar

### DIFF
--- a/components/utilities/floatingNav.module.css
+++ b/components/utilities/floatingNav.module.css
@@ -57,10 +57,14 @@
   @apply pl-10;
 }
 
-.headingH5 {
+.headingH4 {
   @apply pl-12;
 }
 
-.headingH6 {
+.headingH5 {
   @apply pl-14;
+}
+
+.headingH6 {
+  @apply pl-16;
 }


### PR DESCRIPTION
This PR fixes an issue where `<h4>` tags on the `floatingNav` component aren't indenting properly.

**Before:**
![Screen Shot 2022-02-01 at 17 05 44](https://user-images.githubusercontent.com/34423371/152043250-6f3cdf86-02e7-4f3b-8e99-50fc5af63477.png)

**After:**
![Screen Shot 2022-02-01 at 17 08 25](https://user-images.githubusercontent.com/34423371/152043313-807d8168-0710-42e3-a3bc-993a75800afd.png)

