### PR TITLE
Add a tip mentioning Python module invocation of Streamlit

### DIFF
--- a/content/kb/using-streamlit/how-run-my-streamlit-script.md
+++ b/content/kb/using-streamlit/how-run-my-streamlit-script.md
@@ -1,0 +1,48 @@
+---
+title: How do I run my Streamlit script?
+slug: /knowledge-base/using-streamlit/how-do-i-run-my-streamlit-script
+---
+
+# How do I run my Streamlit script?
+
+Working with Streamlit is simple. First you sprinkle a few Streamlit commands into a normal Python script, and then you run it. We list few ways to run your script, depending on your use case.
+
+## Use streamlit run
+
+Once you've created your script, say `your_script.py`, the easiest way to run it is with `streamlit run`:
+
+```bash
+streamlit run your_script.py
+```
+
+As soon as you run the script as shown above, a local Streamlit server will spin up and your app will open in a new tab your default web browser.
+
+### Pass arguments to your script
+
+When passing your script some custom arguments, they must be passed after two dashes. Otherwise the arguments get interpreted as arguments to Streamlit itself:
+
+```bash
+streamlit run your_script.py [-- script args]
+```
+
+### Pass a URL to streamlit run
+
+You can also pass a URL to `streamlit run`! This is great when your script is hosted remotely, such as a Github Gist. For example:
+
+```bash
+streamlit run https://raw.githubusercontent.com/streamlit/demo-uber-nyc-pickups/master/streamlit_app.py
+```
+
+## Run Streamlit as a Python module
+
+Another way of running Streamlit is to run it as a Python module. This is useful when configuring an IDE like PyCharm to work with Streamlit:
+
+```bash
+# Running
+python -m streamlit your_script.py
+```
+
+```bash
+# is equivalent to:
+streamlit run your_script.py
+```

--- a/content/kb/using-streamlit/index.md
+++ b/content/kb/using-streamlit/index.md
@@ -10,6 +10,7 @@ Here are some frequently asked questions about using Streamlit. If you feel some
 - [Sanity checks](/knowledge-base/using-streamlit/sanity-checks)
 - [Caching issues](/knowledge-base/using-streamlit/caching-issues)
 - [Batch elements and input widgets with `st.form`](/knowledge-base/using-streamlit/batch-elements-input-widgets-form)
+- [How do I run my Streamlit script?](/knowledge-base/using-streamlit/how-do-i-run-my-streamlit-script)
 - [How can I make Streamlit watch for changes in other modules I'm importing in my app?](/knowledge-base/using-streamlit/streamlit-watch-changes-other-modules-importing-app)
 - [What browsers does Streamlit support?](/knowledge-base/using-streamlit/supported-browsers)
 - [What is the path of Streamlit’s `config.toml` file?](/knowledge-base/using-streamlit/path-streamlit-config-toml)

--- a/content/library/get-started/main-concepts.md
+++ b/content/library/get-started/main-concepts.md
@@ -40,6 +40,21 @@ $ streamlit run https://raw.githubusercontent.com/streamlit/demo-uber-nyc-pickup
 
 </Tip>
 
+<Tip>
+
+Another way of running Streamlit is to run it as a Python module. This can be
+useful when configuring an IDE like PyCharm to work with Streamlit.
+
+```bash
+# Running
+$ python -m streamlit your_script.py
+
+# is equivalent to:
+$ streamlit run your_script.py
+```
+
+</Tip>
+
 ## Development flow
 
 Every time you want to update your app, save the source file. When you do

--- a/content/library/get-started/main-concepts.md
+++ b/content/library/get-started/main-concepts.md
@@ -29,21 +29,8 @@ arguments get interpreted as arguments to Streamlit itself.
 
 </Note>
 
-<Tip>
-
-You can also pass a URL to `streamlit run`! This is great when combined with
-Github Gists. For example:
-
-```bash
-$ streamlit run https://raw.githubusercontent.com/streamlit/demo-uber-nyc-pickups/master/streamlit_app.py
-```
-
-</Tip>
-
-<Tip>
-
 Another way of running Streamlit is to run it as a Python module. This can be
-useful when configuring an IDE like PyCharm to work with Streamlit.
+useful when configuring an IDE like PyCharm to work with Streamlit:
 
 ```bash
 # Running
@@ -51,6 +38,15 @@ $ python -m streamlit your_script.py
 
 # is equivalent to:
 $ streamlit run your_script.py
+```
+
+<Tip>
+
+You can also pass a URL to `streamlit run`! This is great when combined with
+Github Gists. For example:
+
+```bash
+$ streamlit run https://raw.githubusercontent.com/streamlit/demo-uber-nyc-pickups/master/streamlit_app.py
 ```
 
 </Tip>


### PR DESCRIPTION
Along with the upcoming knowledge base articles dedicated to describing
how to configure Streamlit with popular IDEs/editors, it may be useful
to also add a small snippet briefly mentioning Python module invocation
of Streamlit. This PR does this in the main-concepts doc.

It feels a bit weird to me that we have two tips back to back, so
suggestions on a better place to put this are appreciated 🙂 
