### PR TITLE
Embed Session State basics tutorial video

### DIFF
--- a/content/kb/tutorials/index.md
+++ b/content/kb/tutorials/index.md
@@ -8,4 +8,4 @@ slug: /knowledge-base/tutorials
 Our tutorials include step-by-step examples of building different types of apps in Streamlit.
 
 - [Connect to data sources](/knowledge-base/tutorials/databases)
-- [Session State basic](/knowledge-base/tutorials/session-state)
+- [Session State basics](/knowledge-base/tutorials/session-state)

--- a/content/kb/tutorials/index.md
+++ b/content/kb/tutorials/index.md
@@ -8,3 +8,4 @@ slug: /knowledge-base/tutorials
 Our tutorials include step-by-step examples of building different types of apps in Streamlit.
 
 - [Connect to data sources](/knowledge-base/tutorials/databases)
+- [Session State basic](/knowledge-base/tutorials/session-state)

--- a/content/kb/tutorials/session-state.md
+++ b/content/kb/tutorials/session-state.md
@@ -1,0 +1,10 @@
+---
+title: Session State basics
+slug: /knowledge-base/tutorials/session-state
+---
+
+# Session State basics
+
+Check out this Session State basics tutorial video by Streamlit Developer Advocate Dr. Marisa Smith to get started:
+
+<YouTube videoId="92jUAXBmZyU" />

--- a/content/library/advanced-features/session-state.md
+++ b/content/library/advanced-features/session-state.md
@@ -15,6 +15,10 @@ In this guide, we will illustrate the usage of **Session State** and **Callbacks
 
 For details on the Session State and Callbacks API, please refer to our [Session State API Reference Guide](/library/api-reference/session-state).
 
+Also, check out this Session State basics tutorial video by Streamlit Developer Advocate Dr. Marisa Smith to get started:
+
+<YouTube videoId="92jUAXBmZyU" />
+
 ## Build a Counter
 
 Let's call our script `counter.py`. It initializes a `count` variable and has a button to increment the value stored in the `count` variable:

--- a/content/library/api/state/state.md
+++ b/content/library/api/state/state.md
@@ -8,6 +8,10 @@ description: st.session_state is a way to share variables between reruns, for ea
 
 Session State is a way to share variables between reruns, for each user session. In addition to the ability to store and persist state, Streamlit also exposes the ability to manipulate state using Callbacks.
 
+Check out this Session State basics tutorial video by Streamlit Developer Advocate Dr. Marisa Smith to get started:
+
+<YouTube videoId="92jUAXBmZyU" />
+
 ### Initialize values in Session State
 
 The Session State API follows a field-based API, which is very similar to Python dictionaries:

--- a/content/menu.md
+++ b/content/menu.md
@@ -380,6 +380,8 @@ site_menu:
     url: /knowledge-base/tutorials/databases/public-gsheet
   - category: Knowledge base / Tutorials / Connect to data sources / TigerGraph
     url: /knowledge-base/tutorials/databases/tigergraph
+  - category: Knowledge base / Tutorials / Session State basics
+    url: /knowledge-base/tutorials/session-state
   - category: Knowledge base / Using Streamlit
     url: /knowledge-base/using-streamlit
   - category: Knowledge base / Streamlit Components


### PR DESCRIPTION
### :books: Context
We recently published a [Session State basics video on YouTube](https://www.youtube.com/watch?v=92jUAXBmZyU). We need to embed it in relevant sections of our docs.

### :brain: Description of Changes
- Embedded video in Session State API
- Embedded video in Advanced features section
- Created a KB entry in Tutorials and embedded the video there