### PR TITLE
Fix on sidebar alignment on desktop screens

### DIFF
--- a/components/layouts/container.module.css
+++ b/components/layouts/container.module.css
@@ -1,0 +1,7 @@
+.Container {
+  @apply grid grid-cols-1 lg:grid-cols-4 gap-4 container mx-auto px-2 xl:px-4;
+}
+
+.InnerContainer {
+  @apply col-span-full lg:col-start-2 lg:col-end-5;
+}

--- a/components/navigation/header.module.css
+++ b/components/navigation/header.module.css
@@ -24,7 +24,7 @@
 }
 
 .Navigation {
-  @apply container px-4 flex items-center justify-between relative transition-all mx-auto h-full;
+  @apply container px-2 xl:px-4 flex items-center justify-between relative transition-all mx-auto h-full left-auto xl:-left-2;
 }
 
 .LogoContainer {

--- a/components/navigation/navItem.module.css
+++ b/components/navigation/navItem.module.css
@@ -1,5 +1,5 @@
 .HeadingContainer {
-  @apply flex items-center xl:justify-start xl:flex-nowrap xl:text-left xl:w-auto transition-all;
+  @apply relative flex items-center xl:justify-start xl:flex-nowrap xl:text-left xl:w-auto transition-all left-auto lg:left-2 xl:left-auto;
 }
 
 .HeadingIconContainer {

--- a/components/navigation/sideBar.module.css
+++ b/components/navigation/sideBar.module.css
@@ -1,5 +1,5 @@
 .Container {
-  @apply fixed top-0 left-0 py-24 px-4 sm:px-24 lg:px-5 lg:py-24 h-screen z-10 w-10/12 md:w-9/12 xl:w-screen lg:max-w-none xl:max-w-xs overflow-y-auto shadow-lg lg:shadow-none transition-all;
+  @apply fixed left-0 top-0 py-24 px-4 sm:px-24 md:px-4 xl:px-2 xl:left-auto h-screen z-10 w-10/12 md:w-9/12 xl:w-screen lg:max-w-none xl:max-w-xs overflow-y-auto shadow-lg lg:shadow-none transition-all;
   @apply bg-white !important;
 }
 

--- a/components/navigation/sideBar.module.css
+++ b/components/navigation/sideBar.module.css
@@ -1,5 +1,5 @@
 .Container {
-  @apply fixed left-0 top-0 py-24 px-4 sm:px-24 md:px-4 xl:px-2 xl:left-auto h-screen z-10 w-10/12 md:w-9/12 xl:w-screen lg:max-w-none xl:max-w-xs overflow-y-auto shadow-lg lg:shadow-none transition-all;
+  @apply fixed lg:sticky top-auto lg:top-16 left-0 xl:left-auto px-0 h-screen z-10 w-10/12 md:w-9/12 xl:w-screen max-w-xs md:max-w-none overflow-y-auto shadow-lg lg:shadow-none transition-all;
   @apply bg-white !important;
 }
 
@@ -8,7 +8,8 @@
 }
 
 .OpenNav {
-  @apply block;
+  @apply block md:max-w-xs;
+  @apply md:w-full !important;
 }
 
 .ClosedNav {
@@ -16,11 +17,11 @@
 }
 
 .CollapsedNav {
-  @apply lg:w-36 xl:w-full;
+  @apply w-full md:w-36 lg:w-full;
 }
 
 .OverNav {
-  @apply lg:shadow-lg;
+  @apply md:w-full;
 }
 
 .OverNavItem {
@@ -28,5 +29,5 @@
 }
 
 .NavList {
-  @apply list-none overscroll-contain m-0;
+  @apply list-none overscroll-contain m-0 px-2 lg:px-0;
 }

--- a/components/utilities/gdpr.module.css
+++ b/components/utilities/gdpr.module.css
@@ -1,5 +1,5 @@
 .Container {
-  @apply fixed bottom-6 w-full z-10;
+  @apply fixed bottom-6 w-full z-20;
 }
 
 .BannerBackground {

--- a/pages/404.js
+++ b/pages/404.js
@@ -5,6 +5,8 @@ import SideBar from "../components/navigation/sideBar";
 import Spacer from "../components/utilities/spacer";
 import SummaryTiles from "../components/summaryTiles";
 
+import styles from "../components/layouts/container.module.css";
+
 export default function Home({ window, menu }) {
   return (
     <Layout window={window}>
@@ -39,9 +41,9 @@ export default function Home({ window, menu }) {
           content={`https://${process.env.NEXT_PUBLIC_HOSTNAME}/sharing-image-twitter.jpg`}
         />
       </Head>
-      <section className="page container template-expanded-wide">
+      <section className={styles.Container}>
         <SideBar menu={menu} slug={["404"]} />
-        <section className="content wide">
+        <section className={styles.InnerContainer}>
           <article>
             <h1>Page not found</h1>
 

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -53,6 +53,8 @@ import Warning from "../components/blocks/warning";
 import YouTube from "../components/blocks/youTube";
 import Cloud from "../components/blocks/cloud";
 
+import styles from "../components/layouts/container.module.css";
+
 export default function Article({
   data,
   source,
@@ -177,7 +179,7 @@ export default function Article({
     >
       <Layout>
         <GDPRBanner {...gdpr_data} />
-        <section className="page container template-standard">
+        <section className={styles.Container}>
           <SideBar slug={slug} menu={menu} />
           <Head>
             <title>{data.title} - Streamlit Docs</title>
@@ -227,7 +229,7 @@ export default function Article({
               content={`https://${process.env.NEXT_PUBLIC_HOSTNAME}/sharing-image-twitter.jpg`}
             />
           </Head>
-          <section className="content wide" id="documentation">
+          <section className={styles.InnerContainer} id="documentation">
             {versionWarning}
             <BreadCrumbs slug={slug} menu={menu} version={version} />
             <article className="leaf-page">

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import MediaQuery from "react-responsive";
+import classNames from "classnames";
 import Head from "next/head";
 
 import { getMenu, getGDPRBanner } from "../lib/api";
@@ -26,6 +26,8 @@ import InlineCallout from "../components/blocks/inlineCallout";
 import NoteSplit from "../components/blocks/noteSplit";
 
 import { attributes } from "../content/index.md";
+
+import styles from "../components/layouts/container.module.css";
 
 export default function Home({ window, menu, gdpr_data }) {
   let { description } = attributes;
@@ -62,10 +64,10 @@ export default function Home({ window, menu, gdpr_data }) {
           content={`https://${process.env.NEXT_PUBLIC_HOSTNAME}/sharing-image-twitter.jpg`}
         />
       </Head>
-      <section className="page container template-expanded-wide">
+      <section className={styles.Container}>
         <GDPRBanner {...gdpr_data} />
         <SideBar menu={menu} slug={[]} />
-        <section className="content wide">
+        <section className={styles.InnerContainer}>
           <article>
             <H1>Streamlit documentation</H1>
             <p>

--- a/pages/index.js
+++ b/pages/index.js
@@ -64,8 +64,8 @@ export default function Home({ window, menu, gdpr_data }) {
           content={`https://${process.env.NEXT_PUBLIC_HOSTNAME}/sharing-image-twitter.jpg`}
         />
       </Head>
+      <GDPRBanner {...gdpr_data} />
       <section className={styles.Container}>
-        <GDPRBanner {...gdpr_data} />
         <SideBar menu={menu} slug={[]} />
         <section className={styles.InnerContainer}>
           <article>


### PR DESCRIPTION
This PR fixes an issue brought by Thiago where the Streamlit logo won't align horizontally with the nav bar on desktop resolutions.

**Before:**
<img width="317" alt="Screen Shot 2022-02-14 at 1 25 15 PM" src="https://user-images.githubusercontent.com/34423371/153955574-ea88b336-2ff9-4c32-92fa-9f7f57678f62.png">

**After:**
![Screen Shot 2022-02-14 at 19 16 14](https://user-images.githubusercontent.com/34423371/153955660-458ec5e9-07dc-4ce5-81be-aaf62c104fae.png)