### PR TITLE
Fix on newsEntry background color

### DIFF
--- a/components/blocks/newsEntry.module.css
+++ b/components/blocks/newsEntry.module.css
@@ -21,3 +21,7 @@
   @apply text-sm tracking-tight leading-normal;
   @apply text-gray-90 !important;
 }
+
+:global(.dark) .Container {
+  @apply border-b-gray-90;
+}

--- a/components/blocks/tile.js
+++ b/components/blocks/tile.js
@@ -44,7 +44,7 @@ const Tile = ({
 
   let image;
   if (img) {
-    image = <img src={img} />;
+    image = <img src={img} className={styles.Icon} />;
   } else {
     image = (
       <i className={classNames("material-icons-sharp", styles.Icon)}>
@@ -58,6 +58,8 @@ const Tile = ({
       ? styles.OrangeBackground
       : background === "violet-70"
       ? styles.VioletBackground
+      : background === "unset"
+      ? styles.TransparentBackground
       : styles.BlueBackground;
 
   return (

--- a/components/blocks/tile.module.css
+++ b/components/blocks/tile.module.css
@@ -53,3 +53,15 @@
 .BlueBackground {
   @apply bg-lightBlue-70;
 }
+
+.TransparentBackground i,
+.TransparentBackground h4,
+.TransparentBackground p {
+  @apply text-gray-90 !important;
+}
+
+:global(.dark) .TransparentBackground i,
+:global(.dark) .TransparentBackground h4,
+:global(.dark) .TransparentBackground p {
+  @apply text-white !important;
+}


### PR DESCRIPTION
This PR fixes [this issue](https://www.notion.so/streamlit/Revert-NewsEntry-utlity-color-1fd0e32eb4574b978ecb7cbf97914a7d) mentioned by @snehankekre, where tiles with `unset` background color would default to the light blue color