### PR TITLE
Bump docstring version from 1.5.0 to 1.6.0

### DIFF
--- a/content/library/api-cheat-sheet.md
+++ b/content/library/api-cheat-sheet.md
@@ -5,7 +5,7 @@ slug: /library/cheatsheet
 
 # Cheat Sheet
 
-This is a summary of the docs, as of [Streamlit v1.5.0](https://pypi.org/project/streamlit/1.5.0/).
+This is a summary of the docs, as of [Streamlit v1.6.0](https://pypi.org/project/streamlit/1.6.0/).
 
 <Masonry>
 

--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -17,6 +17,15 @@ $ pip install --upgrade streamlit
 
 </Tip>
 
+## **Version 1.6.0**
+
+_Release date: Feb 24, 2022_
+
+**Other Changes**
+
+- 🗜 WebSocket compression is now disabled by default, which will improve CPU and latency performance for large dataframes. You can use the `server.enableWebsocketCompression` configuration option to re-enable it if you find the increased network traffic more impactful.
+- ☑️ 🔘 Radio and checkboxes improve focus on Keyboard navigation ([#4308](https://github.com/streamlit/streamlit/pull/4308)).
+
 ## **Version 1.5.0**
 
 _Release date: Jan 27, 2022_


### PR DESCRIPTION
- [x] Update Changelog with 1.6.0 release notes
- [x] Bump docstring version from 1.5.0 to 1.6.0
- [x] Wait for PyPI release between 10 - 11 AM PST