### PR TITLE
Fix on z-index for GDPR banner

### DIFF
--- a/components/utilities/gdpr.module.css
+++ b/components/utilities/gdpr.module.css
@@ -1,5 +1,5 @@
 .Container {
-  @apply fixed bottom-6 w-full z-20;
+  @apply fixed bottom-6 w-full z-30;
 }
 
 .BannerBackground {


### PR DESCRIPTION
This PR fixes an issue reported by Anna Kostenko, where the sidebar would cover the GDPR banner, not allow the user to decline it.

**Before:**
![Selection_248](https://user-images.githubusercontent.com/34423371/156608151-58e1e2d5-2863-4302-bf30-85b76dfa7213.png)
![Selection_249](https://user-images.githubusercontent.com/34423371/156608162-4937af8f-1406-42de-9404-08c2f7cfb325.png)

**After:**
![Screen Shot 2022-03-03 at 13 28 55](https://user-images.githubusercontent.com/34423371/156608213-1b929c2c-2969-4447-acb6-addc2eff2790.png)