### PR TITLE
Don't generate docstrings for pre-releases

### DIFF
--- a/python/build.py
+++ b/python/build.py
@@ -41,6 +41,10 @@ if 'info' in pypi_data:
         if version_obj.micro != 0:
             continue
 
+        # We don't care about pre-releases. e.g. 1.6.0rc3
+        if version_obj.is_prerelease:
+            continue
+
         if version_str not in current_data:
             logging.info(f"[{version_str}] Installing streamlit...")
 


### PR DESCRIPTION
This PR excludes pre-releases (e.g. `1.6.0rc3`) from the docstring generation process. The [issue](https://www.notion.so/streamlit/Issue-with-Release-Candidate-URLs-on-docs-page-7ce491a6382b40a582a4787f863c02ce) was noticed by @imjuangarcia:

> Release Candidate (RC) URLs don’t seem to work as expected on the autofunction component (See video of the bug [here](https://share.getcloudapp.com/E0uowQ6K)). These URLs seem to be generated differently than other versioned URLs, because [they add the number on the URL](https://share.getcloudapp.com/KouYg2yG), which also throws an error on the build because these numbered pages aren’t (and shouldn’t be) on `menu.md`.

> It seems like the RCs were generated erroneously while trying to create the 1.6.0 release. They shouldn't be included in the library selector dropdown. 

#328 offered a temporary fix by manually deleting the RCs from `streamlit.json` and running `python generate.py 1.6.0` instead of `make docstrings`. This PR is a permanent fix by excluding pre-releases from `build.py`.

