### PR TITLE
Add callout to Snowflake tutorial to highlight all queries

### DIFF
--- a/content/kb/tutorials/databases/snowflake.md
+++ b/content/kb/tutorials/databases/snowflake.md
@@ -54,6 +54,12 @@ To execute the queries in the new web interface, highlight or select all the que
 
 <Image alt="AWS screenshot 1" src="/images/databases/snowflake-4.png" />
 
+<Important>
+
+Be sure to highlight or select **all** the queries (lines 1-10) before clicking the play button.
+
+</Important>
+
 Once you have executed the queries, you should see a preview of the table in the **Results** panel at the bottom of the page. Addionally, you should see your newly created database and schema by expanding the accordion on the left side of the page. Lastly, the warehouse name is displayed on the button to the left of the **Share** button.
 
 <Image alt="AWS screenshot 2" src="/images/databases/snowflake-5.png" />


### PR DESCRIPTION
This PR adds a callout in the Snowflake tutorial to highlight all queries in the New Web Interface before execution. 

Unlike the Classic UI, Snowflake's new UI doesn't include a checkbox or button to run all queries at once. It defaults to executing the line the user's mouse is focused on. If our users copy/paste the queries into the new UI and click play, only the final query `SELECT * FROM MYTABLE;` is executed. This leads to an error because the user is trying to select from a table and database that doesn't yet exist. Read more [here](https://www.notion.so/streamlit/Streamlit-Snowflake-docs-issue-bf233c8d76c64d7f9098d3c302cd42b9).