### PR TITLE
Update code example to resolve NameError

### DIFF
--- a/content/kb/using-streamlit/remove-streamlit-app-title.md
+++ b/content/kb/using-streamlit/remove-streamlit-app-title.md
@@ -8,7 +8,7 @@ slug: /knowledge-base/using-streamlit/remove-streamlit-app-title
 Using [`st.set_page_config`](/library/api-reference/utilities/st.set_page_config) to assign the page title will not append "· Streamlit" to that title. E.g.:
 
 ```python
-import streamlit
+import streamlit as st
 
 st.set_page_config(
    page_title="Ex-stream-ly Cool App",


### PR DESCRIPTION
Previously this example would raise the following:
```
NameError: name 'st' is not defined
```