### PR TITLE
Add hyperlink to account identifier docs

### DIFF
--- a/content/kb/tutorials/databases/snowflake.md
+++ b/content/kb/tutorials/databases/snowflake.md
@@ -17,7 +17,7 @@ If you already have a database that you want to use, feel free to [skip to the n
 
 </Note>
 
-First, [sign up for Snowflake](https://signup.snowflake.com/) and log into the [Snowflake web interface](https://docs.snowflake.com/en/user-guide/connecting.html#logging-in-using-the-web-interface) (note down your username, password, and account identifier!):
+First, [sign up for Snowflake](https://signup.snowflake.com/) and log into the [Snowflake web interface](https://docs.snowflake.com/en/user-guide/connecting.html#logging-in-using-the-web-interface) (note down your username, password, and [account identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html)!):
 
 ![](/images/databases/snowflake-1.png)
 
@@ -68,7 +68,7 @@ Make sure to note down the name of your warehouse, database, and schema. ☝️
 
 ## Add username and password to your local app secrets
 
-Your local Streamlit app will read secrets from a file `.streamlit/secrets.toml` in your app’s root directory. Create this file if it doesn’t exist yet and add your Snowflake username, password, account identifier, and the name of your warehouse, database, and schema as shown below:
+Your local Streamlit app will read secrets from a file `.streamlit/secrets.toml` in your app’s root directory. Create this file if it doesn’t exist yet and add your Snowflake username, password, [account identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html), and the name of your warehouse, database, and schema as shown below:
 
 ```python
 # .streamlit/secrets.toml


### PR DESCRIPTION
This PR adds hyperlinks to Snowflake's account identifier documentation.