### PR TITLE
Add Experimental Features link

### DIFF
--- a/content/library/api-cheat-sheet.md
+++ b/content/library/api-cheat-sheet.md
@@ -47,7 +47,7 @@ pip uninstall streamlit
 pip install streamlit-nightly --upgrade
 ```
 
-Learn more about [beta and experimental features](/)
+Learn more about [beta and experimental features](advanced-features/prerelease#beta-and-experimental-features)
 
 </CodeTile>
 


### PR DESCRIPTION
## Current behavior 

In the ["Cheat Sheet" page](https://docs.streamlit.io/library/cheatsheet), the link to learn more about beta and experimental features is currently leading back to the documentation home page (because the href is `/`) ![image](https://user-images.githubusercontent.com/7164864/159728930-1e0f0614-0271-4670-8e92-dbc41cefb1fc.png)

## Expected behavior

I think this should be leading to [that page](https://docs.streamlit.io/library/advanced-features/prerelease#beta-and-experimental-features) about _Beta and Experimental Features_

## Solution

- Modified `content/library/api-cheat-sheet.md` to add this in the Markdown link