### PR TITLE
switch to dot notation to avoid error in caching with database example doc

### DIFF
--- a/content/kb/tutorials/databases/postgresql.md
+++ b/content/kb/tutorials/databases/postgresql.md
@@ -79,7 +79,7 @@ import psycopg2
 # Uses st.cache to only run once.
 @st.cache(allow_output_mutation=True, hash_funcs={"_thread.RLock": lambda _: None})
 def init_connection():
-    return psycopg2.connect(**st.secrets["postgres"])
+    return psycopg2.connect(**st.secrets.postgres)
 
 conn = init_connection()
 


### PR DESCRIPTION
['postgres'] notation resulted in an error that reads in part:

```
While caching the body of init_connection(), Streamlit encountered an object of type builtins.weakref, which it does not know how to hash.
```