### PR TITLE
Replace st.cache with memo+singleton in database tutorials

### DIFF
--- a/content/kb/tutorials/databases/aws-s3.md
+++ b/content/kb/tutorials/databases/aws-s3.md
@@ -100,8 +100,8 @@ import os
 fs = s3fs.S3FileSystem(anon=False)
 
 # Retrieve file contents.
-# Uses st.cache to only rerun when the query changes or after 10 min.
-@st.cache(ttl=600)
+# Uses st.experimental_memo to only rerun when the query changes or after 10 min.
+@st.experimental_memo(ttl=600)
 def read_file(filename):
     with fs.open(filename) as f:
         return f.read().decode("utf-8")
@@ -114,7 +114,7 @@ for line in content.strip().split("\n"):
     st.write(f"{name} has a :{pet}:")
 ```
 
-See `st.cache` above? Without it, Streamlit would run the query every time the app reruns (e.g. on a widget interaction). With `st.cache`, it only runs when the query changes or after 10 minutes (that's what `ttl` is for). Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Read more about caching [here](/library/advanced-features/caching).
+See `st.experimental_memo` above? Without it, Streamlit would run the query every time the app reruns (e.g. on a widget interaction). With `st.experimental_memo`, it only runs when the query changes or after 10 minutes (that's what `ttl` is for). Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Read more about caching [here](/library/advanced-features/experimental-cache-primitives).
 
 If everything worked out (and you used the example file given above), your app should look like this:
 

--- a/content/kb/tutorials/databases/bigquery.md
+++ b/content/kb/tutorials/databases/bigquery.md
@@ -118,12 +118,12 @@ credentials = service_account.Credentials.from_service_account_info(
 client = bigquery.Client(credentials=credentials)
 
 # Perform query.
-# Uses st.cache to only rerun when the query changes or after 10 min.
-@st.cache(ttl=600)
+# Uses st.experimental_memo to only rerun when the query changes or after 10 min.
+@st.experimental_memo(ttl=600)
 def run_query(query):
     query_job = client.query(query)
     rows_raw = query_job.result()
-    # Convert to list of dicts. Required for st.cache to hash the return value.
+    # Convert to list of dicts. Required for st.experimental_memo to hash the return value.
     rows = [dict(row) for row in rows_raw]
     return rows
 
@@ -135,7 +135,7 @@ for row in rows:
     st.write("✍️ " + row['word'])
 ```
 
-See `st.cache` above? Without it, Streamlit would run the query every time the app reruns (e.g. on a widget interaction). With `st.cache`, it only runs when the query changes or after 10 minutes (that's what `ttl` is for). Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Read more about caching [here](/library/advanced-features/caching).
+See `st.experimental_memo` above? Without it, Streamlit would run the query every time the app reruns (e.g. on a widget interaction). With `st.experimental_memo`, it only runs when the query changes or after 10 minutes (that's what `ttl` is for). Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Read more about caching [here](/library/advanced-features/experimental-cache-primitives).
 
 Alternatively, you can use pandas to read from BigQuery right into a dataframe! Follow all the above steps, install the [pandas-gbq](https://pandas-gbq.readthedocs.io/en/latest/index.html) library (don't forget to add it to `requirements.txt`!), and call `pandas.read_gbq(query, credentials=credentials)`. More info [in the pandas docs](https://pandas.pydata.org/docs/reference/api/pandas.read_gbq.html).
 

--- a/content/kb/tutorials/databases/mongodb.md
+++ b/content/kb/tutorials/databases/mongodb.md
@@ -71,15 +71,20 @@ import streamlit as st
 import pymongo
 
 # Initialize connection.
-client = pymongo.MongoClient(**st.secrets["mongo"])
+# Uses st.experimental_singleton to only run once.
+@st.experimental_singleton
+def init_connection():
+    return pymongo.MongoClient(**st.secrets["mongo"])
+
+client = init_connection()
 
 # Pull data from the collection.
-# Uses st.cache to only rerun when the query changes or after 10 min.
-@st.cache(ttl=600)
+# Uses st.experimental_memo to only rerun when the query changes or after 10 min.
+@st.experimental_memo(ttl=600)
 def get_data():
     db = client.mydb
     items = db.mycollection.find()
-    items = list(items)  # make hashable for st.cache
+    items = list(items)  # make hashable for st.experimental_memo
     return items
 
 items = get_data()
@@ -89,7 +94,7 @@ for item in items:
     st.write(f"{item['name']} has a :{item['pet']}:")
 ```
 
-See `st.cache` above? Without it, Streamlit would run the query every time the app reruns (e.g. on a widget interaction). With `st.cache`, it only runs when the query changes or after 10 minutes (that's what `ttl` is for). Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Read more about caching [here](/library/advanced-features/caching).
+See `st.experimental_memo` above? Without it, Streamlit would run the query every time the app reruns (e.g. on a widget interaction). With `st.experimental_memo`, it only runs when the query changes or after 10 minutes (that's what `ttl` is for). Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Read more about caching [here](/library/advanced-features/experimental-cache-primitives).
 
 If everything worked out (and you used the example data we created above), your app should look like this:
 

--- a/content/kb/tutorials/databases/mysql.md
+++ b/content/kb/tutorials/databases/mysql.md
@@ -80,16 +80,16 @@ import streamlit as st
 import mysql.connector
 
 # Initialize connection.
-# Uses st.cache to only run once.
-@st.cache(allow_output_mutation=True, hash_funcs={"_thread.RLock": lambda _: None})
+# Uses st.experimental_singleton to only run once.
+@st.experimental_singleton
 def init_connection():
     return mysql.connector.connect(**st.secrets["mysql"])
 
 conn = init_connection()
 
 # Perform query.
-# Uses st.cache to only rerun when the query changes or after 10 min.
-@st.cache(ttl=600)
+# Uses st.experimental_memo to only rerun when the query changes or after 10 min.
+@st.experimental_memo(ttl=600)
 def run_query(query):
     with conn.cursor() as cur:
         cur.execute(query)
@@ -102,7 +102,7 @@ for row in rows:
     st.write(f"{row[0]} has a :{row[1]}:")
 ```
 
-See `st.cache` above? Without it, Streamlit would run the query every time the app reruns (e.g. on a widget interaction). With `st.cache`, it only runs when the query changes or after 10 minutes (that's what `ttl` is for). Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Read more about caching [here](/library/advanced-features/caching).
+See `st.experimental_memo` above? Without it, Streamlit would run the query every time the app reruns (e.g. on a widget interaction). With `st.experimental_memo`, it only runs when the query changes or after 10 minutes (that's what `ttl` is for). Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Read more about caching [here](/library/advanced-features/experimental-cache-primitives).
 
 If everything worked out (and you used the example table we created above), your app should look like this:
 

--- a/content/kb/tutorials/databases/postgresql.md
+++ b/content/kb/tutorials/databases/postgresql.md
@@ -76,16 +76,16 @@ import streamlit as st
 import psycopg2
 
 # Initialize connection.
-# Uses st.cache to only run once.
-@st.cache(allow_output_mutation=True, hash_funcs={"_thread.RLock": lambda _: None})
+# Uses st.experimental_singleton to only run once.
+@st.experimental_singleton
 def init_connection():
-    return psycopg2.connect(**st.secrets.postgres)
+    return psycopg2.connect(**st.secrets["postgres"])
 
 conn = init_connection()
 
 # Perform query.
-# Uses st.cache to only rerun when the query changes or after 10 min.
-@st.cache(ttl=600)
+# Uses st.experimental_memo to only rerun when the query changes or after 10 min.
+@st.experimental_memo(ttl=600)
 def run_query(query):
     with conn.cursor() as cur:
         cur.execute(query)
@@ -98,7 +98,7 @@ for row in rows:
     st.write(f"{row[0]} has a :{row[1]}:")
 ```
 
-See `st.cache` above? Without it, Streamlit would run the query every time the app reruns (e.g. on a widget interaction). With `st.cache`, it only runs when the query changes or after 10 minutes (that's what `ttl` is for). Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Read more about caching [here](/library/advanced-features/caching).
+See `st.experimental_memo` above? Without it, Streamlit would run the query every time the app reruns (e.g. on a widget interaction). With `st.experimental_memo`, it only runs when the query changes or after 10 minutes (that's what `ttl` is for). Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Read more about caching [here](/library/advanced-features/experimental-cache-primitives).
 
 If everything worked out (and you used the example table we created above), your app should look like this:
 

--- a/content/kb/tutorials/databases/private-gsheet.md
+++ b/content/kb/tutorials/databases/private-gsheet.md
@@ -133,6 +133,7 @@ conn = connect(credentials=credentials)
 @st.cache(ttl=600)
 def run_query(query):
     rows = conn.execute(query, headers=1)
+    rows = rows.fetchall()
     return rows
 
 sheet_url = st.secrets["private_gsheets_url"]

--- a/content/kb/tutorials/databases/public-gsheet.md
+++ b/content/kb/tutorials/databases/public-gsheet.md
@@ -74,6 +74,7 @@ conn = connect()
 @st.cache(ttl=600)
 def run_query(query):
     rows = conn.execute(query, headers=1)
+    rows = rows.fetchall()
     return rows
 
 sheet_url = st.secrets["public_gsheets_url"]

--- a/content/kb/tutorials/databases/tableau.md
+++ b/content/kb/tutorials/databases/tableau.md
@@ -96,8 +96,8 @@ server = TSC.Server(st.secrets["tableau"]["server_url"], use_server_version=True
 
 # Get various data.
 # Explore the tableauserverclient library for more options.
-# Uses st.cache to only rerun when the query changes or after 10 min.
-@st.cache(ttl=600)
+# Uses st.experimental_memo to only rerun when the query changes or after 10 min.
+@st.experimental_memo(ttl=600)
 def run_query():
     with server.auth.sign_in(tableau_auth):
 
@@ -142,7 +142,7 @@ st.write(f"And here's the data for view *{view_name}*:")
 st.write(pd.read_csv(StringIO(view_csv)))
 ```
 
-See `st.cache` above? Without it, Streamlit would run the query every time the app reruns (e.g. on a widget interaction). With `st.cache`, it only runs when the query changes or after 10 minutes (that's what `ttl` is for). Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Read more about caching [here](/library/advanced-features/caching).
+See `st.experimental_memo` above? Without it, Streamlit would run the query every time the app reruns (e.g. on a widget interaction). With `st.experimental_memo`, it only runs when the query changes or after 10 minutes (that's what `ttl` is for). Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Read more about caching [here](/library/advanced-features/experimental-cache-primitives).
 
 If everything worked out, your app should look like this (can differ based on your workbooks):
 

--- a/content/kb/tutorials/databases/tigergraph.md
+++ b/content/kb/tutorials/databases/tigergraph.md
@@ -71,8 +71,8 @@ conn = tg.TigerGraphConnection(**st.secrets["tigergraph"])
 conn.apiToken = conn.getToken(conn.createSecret())
 
 # Pull data from the graph by running the "mostDirectInfections" query.
-# Uses st.cache to only rerun when the query changes or after 10 min.
-@st.cache(ttl=600)
+# Uses st.experimental_memo to only rerun when the query changes or after 10 min.
+@st.experimental_memo(ttl=600)
 def get_data():
     most_infections = conn.runInstalledQuery("mostDirectInfections")[0]["Answer"][0]
     return most_infections["v_id"], most_infections["attributes"]
@@ -85,7 +85,7 @@ for key, val in items[1].items():
     st.write(f"Patient {items[0]}'s {key} is {val}.")
 ```
 
-See `st.cache` above? Without it, Streamlit would run the query every time the app reruns (e.g. on a widget interaction). With `st.cache`, it only runs when the query changes or after 10 minutes (that's what `ttl` is for). Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Read more about caching [here](/library/advanced-features/caching).
+See `st.experimental_memo` above? Without it, Streamlit would run the query every time the app reruns (e.g. on a widget interaction). With `st.experimental_memo`, it only runs when the query changes or after 10 minutes (that's what `ttl` is for). Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Read more about caching [here](/library/advanced-features/experimental-cache-primitives).
 
 If everything worked out (and you used the example data we created above), your app should look like this:
 


### PR DESCRIPTION
## :books: Context
With the latest Streamlit versions, most apps used in our tutorials throw `st.cache` related `UnhashableType` errors. Almost all of them go away when replaced either `st.experimental_singleton` or `st.experimental_memo`, depending on the return value of the cached function. Where possible, it is advantageous to replace st.cache with memo+singleton to avoid cryptic `st.cache` errors and improve performance.

## :brain: Description of Changes
- Replaced most instances of `st.cache` in our tutorials with the new cache primitives
- Verified the updated code works locally and on Streamlit Cloud