### PR TITLE
Bump version numbers to 1.8.0, update announcements

### DIFF
--- a/content/library/advanced-features/configuration.md
+++ b/content/library/advanced-features/configuration.md
@@ -90,7 +90,7 @@ Shows all config options available for Streamlit, including their current
 values:
 
 ```toml
-# Streamlit version: 1.7.0
+# Streamlit version: 1.8.0
 
 [global]
 

--- a/content/library/api-cheat-sheet.md
+++ b/content/library/api-cheat-sheet.md
@@ -5,7 +5,7 @@ slug: /library/cheatsheet
 
 # Cheat Sheet
 
-This is a summary of the docs, as of [Streamlit v1.7.0](https://pypi.org/project/streamlit/1.7.0/).
+This is a summary of the docs, as of [Streamlit v1.8.0](https://pypi.org/project/streamlit/1.7.0/).
 
 <Masonry>
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -149,10 +149,10 @@ export default function Home({ window, menu, gdpr_data }) {
 
             <NewsContainer>
               <NewsEntry
-                date="2022-03-02T16:05:00.000Z"
-                title="Streamlit and Snowflake: Better Together"
-                text="Snowflake has entered into an agreement to acquire Streamlit! For more information, click-through to the forum announcement below."
-                link="https://discuss.streamlit.io/t/streamlit-snowflake-better-together/22687"
+                date="2022-03-08T16:08:45.000Z"
+                title="Sogeti creates an educational Streamlit app for data preprocessing"
+                text="Learn how to use Sogeti's Data Quality Wrapper."
+                link="https://blog.streamlit.io/sogeti-creates-an-educational-streamlit-app-for-data-preprocessing/"
               />
               <NewsEntry
                 date="2022-03-06T07:30:00.000Z"
@@ -161,10 +161,10 @@ export default function Home({ window, menu, gdpr_data }) {
                 link="https://discuss.streamlit.io/c/official-announcements/"
               />
               <NewsEntry
-                date="2022-02-17T16:08:45.000Z"
-                title="Calculating distances in cosmology with Streamlit"
-                text="Learn how three friends made the cosmology on-the-go app CosmΩracle."
-                link="https://blog.streamlit.io/calculating-distances-in-cosmology-with-streamlit/"
+                date="2022-03-02T16:05:00.000Z"
+                title="Streamlit and Snowflake: Better Together"
+                text="Snowflake has entered into an agreement to acquire Streamlit! For more information, click-through to the forum announcement below."
+                link="https://discuss.streamlit.io/t/streamlit-snowflake-better-together/22687"
               />
               <Button link="https://blog.streamlit.io/">
                 View all updates


### PR DESCRIPTION
- This PR updates the version numbers in the Cheat sheet and Configuration pages to 1.8.0
- Adds the Sogeti [blog post](https://blog.streamlit.io/sogeti-creates-an-educational-streamlit-app-for-data-preprocessing/) to Announcements