### PR TITLE
With notation containers

### DIFF
--- a/content/library/api/layout/expander.md
+++ b/content/library/api/layout/expander.md
@@ -5,3 +5,19 @@ description: st.expander inserts a multi-element container that can be expanded/
 ---
 
 <Autofunction function="streamlit.expander" />
+
+Or you can use object notation and just call methods directly in the returned objects:
+
+```python
+import streamlit as st
+
+st.bar_chart({"data": [1, 5, 2, 6, 2, 1]})
+
+expander = st.expander("See explanation")
+expander.write("""
+    The chart above shows some numbers I picked for you.
+    I rolled actual dice for these, so they're *guaranteed* to
+    be random.
+""")
+expander.image("https://static.streamlit.io/examples/dice.jpg")
+```

--- a/content/library/api/layout/layout.md
+++ b/content/library/api/layout/layout.md
@@ -7,7 +7,7 @@ slug: /library/api-reference/layout
 
 ## Complex layouts
 
-Streamlit provides several options for controlling different elements are laid out on the screen.
+Streamlit provides several options for controlling how different elements are laid out on the screen.
 
 <TileContainer>
 <RefCard href="/library/api-reference/layout/st.sidebar">

--- a/content/library/api/layout/sidebar.md
+++ b/content/library/api/layout/sidebar.md
@@ -8,15 +8,62 @@ description: st.sidebar displays items in a sidebar.
 
 ## Add widgets to sidebar
 
-Not only can you add interactivity to your report with widgets, you can organize them into a sidebar with `st.sidebar.[element_name]`. Each element that's passed to `st.sidebar` is pinned to the left, allowing users to focus on the content in your app. The only elements that aren't supported are `st.echo` and `st.spinner`.
+<!-- Below, describe with st.sidebar using object notation and "with" notation -->
 
-Here's an example of how you'd add a selectbox to your sidebar.
+<!-- Not only can you add interactivity to your report with widgets, you can organize them into a sidebar with `st.sidebar.[element_name]`. Each element that's passed to `st.sidebar` is pinned to the left, allowing users to focus on the content in your app. The only elements that aren't supported are `st.echo` and `st.spinner`. -->
+
+Not only can you add interactivity to your app with widgets, you can organize them into a sidebar. Elements can be passed to `st.sidebar` using object notation and `with` notation.
+
+The following two snippets are equivalent:
+
+```python
+# Object notation
+st.sidebar.[element_name]
+```
+
+```python
+# "with" notation
+with st.sidebar:
+    st.[element_name]
+```
+
+Each element that's passed to `st.sidebar` is pinned to the left, allowing users to focus on the content in your app.
+
+Here's an example of how you'd add a selectbox and a radio button to your sidebar:
 
 ```python
 import streamlit as st
 
+# Using object notation
 add_selectbox = st.sidebar.selectbox(
     "How would you like to be contacted?",
     ("Email", "Home phone", "Mobile phone")
 )
+
+# Using "with" notation
+with st.sidebar:
+    add_radio = st.radio(
+        "Choose a shipping method",
+        ("Standard (5-15 days)", "Express (2-5 days)")
+    )
+```
+
+<Important>
+
+The only elements that aren't supported using object notation are `st.echo` and `st.spinner`. To use these elements, you must use `with` notation.
+
+</Important>
+
+Here's an example of how you'd add [`st.echo`](/library/api-reference/utilities/st.echo) and [`st.spinner`](/library/api-reference/status/st.spinner) to your sidebar:
+
+```python
+import streamlit as st
+
+with st.sidebar:
+    with st.echo():
+        st.write("This code will be printed to the sidebar.")
+
+    with st.spinner("Loading..."):
+        time.sleep(5)
+    st.success("Done!")
 ```

--- a/content/library/api/layout/sidebar.md
+++ b/content/library/api/layout/sidebar.md
@@ -8,10 +8,6 @@ description: st.sidebar displays items in a sidebar.
 
 ## Add widgets to sidebar
 
-<!-- Below, describe with st.sidebar using object notation and "with" notation -->
-
-<!-- Not only can you add interactivity to your report with widgets, you can organize them into a sidebar with `st.sidebar.[element_name]`. Each element that's passed to `st.sidebar` is pinned to the left, allowing users to focus on the content in your app. The only elements that aren't supported are `st.echo` and `st.spinner`. -->
-
 Not only can you add interactivity to your app with widgets, you can organize them into a sidebar. Elements can be passed to `st.sidebar` using object notation and `with` notation.
 
 The following two snippets are equivalent:


### PR DESCRIPTION
### :books: Context

`st.sidebar` and other containers support passing elements via object (dot `.` ) notation and "`with`" notation. The documentation for few containers (`st.sidebar` and `st.expander`) use one or the other, not both. The documentation [should](https://www.notion.so/streamlit/Talk-about-with-notation-in-st-sidebar-docs-and-others-41e8953b9c6d41ad843e8233467c62ff) talk about _both_ methods of adding items to containers.

### :brain: Description of Changes
- Add object notation example to `st.expander` API docs
- Add "with" notation example to `st.sidebar` API docs