### PR TITLE
Pin `click` to fix errors related to it in 1.8.0

### DIFF
--- a/python/api-examples-source/requirements.txt
+++ b/python/api-examples-source/requirements.txt
@@ -1,7 +1,8 @@
 pandas==1.2.5
 plotly==5.1.0
 bokeh==2.4.1
-streamlit==1.4.0
+streamlit==1.8.0
+click==8
 graphviz==0.17
 requests==2.22.0
 matplotlib==3.4.1


### PR DESCRIPTION
Some docs apps see an error related to Streamlit's dependency `click`. See this issue for more details: https://github.com/streamlit/streamlit/issues/4555 

The proposed temporary [solution](https://github.com/streamlit/streamlit/issues/4555#issuecomment-1081632362) until Streamlit is patched is to pin `click==8`.