### PR TITLE
Fix color on dark mode for table content

### DIFF
--- a/components/blocks/table.module.css
+++ b/components/blocks/table.module.css
@@ -18,6 +18,10 @@
   @apply bg-darkBlue-100/60 text-white;
 }
 
+:global(.dark) .Row td {
+  @apply text-white;
+}
+
 .Cell {
   @apply p-4 border-t border-t-gray-40 w-full border-collapse;
 }


### PR DESCRIPTION
This PR fixes the issue mentioned [here](https://github.com/streamlit/docs/issues/363) about text legibility on dark mode within tables