### PR TITLE
Style Note and Warning callouts in API reference

### DIFF
--- a/styles/admonition.scss
+++ b/styles/admonition.scss
@@ -1,0 +1,32 @@
+// Styles for notes, warnings, etc., inside API reference page
+div.admonition {
+  @apply p-4 rounded-md mt-8 mb-12;
+
+  // Title
+  p.first.admonition-title {
+    @apply text-lg font-bold;
+  }
+
+  // Text
+  p {
+    @apply mb-0;
+  }
+
+  // Note
+  &.note {
+    @apply bg-lightBlue-10 dark:bg-lightBlue-100/30;
+
+    p.first.admonition-title {
+      @apply text-lightBlue-80 dark:text-lightBlue-60;
+    }
+  }
+
+  // Warning
+  &.warning {
+    @apply bg-orange-10 dark:bg-orange-100/30;
+
+    p.first.admonition-title {
+      @apply text-orange-70 dark:text-orange-70;
+    }
+  }
+}

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -3,3 +3,4 @@
 @import "./lists.scss";
 @import "./tables.scss";
 @import "./scrollbars.scss";
+@import "./admonition.scss";

--- a/styles/text.scss
+++ b/styles/text.scss
@@ -72,6 +72,21 @@ p {
   @apply mb-4 text-gray-90 dark:text-white;
 }
 
+// Add custom color to div.admonition.note in dark mode below
+div.admonition.note {
+  @apply bg-lightBlue-10 p-4 md:p-8 rounded-md mt-8 mb-12 dark:bg-lightBlue-100/30;
+  p.first.admonition-title {
+    @apply text-lg text-lightBlue-80 font-bold dark:text-lightBlue-60;
+  }
+}
+
+div.admonition.warning {
+  @apply bg-orange-10 p-4 md:p-8 rounded-md mt-8 mb-12 dark:bg-orange-100/30;
+  p.first.admonition-title {
+    @apply text-lg text-orange-70 font-bold dark:text-orange-70;
+  }
+}
+
 sup a {
   @apply underline hover:no-underline dark:text-white;
 }

--- a/styles/text.scss
+++ b/styles/text.scss
@@ -72,20 +72,6 @@ p {
   @apply mb-4 text-gray-90 dark:text-white;
 }
 
-div.admonition.note {
-  @apply bg-lightBlue-10 p-4 md:p-8 rounded-md mt-8 mb-12 dark:bg-lightBlue-100/30;
-  p.first.admonition-title {
-    @apply text-lg text-lightBlue-80 font-bold dark:text-lightBlue-60;
-  }
-}
-
-div.admonition.warning {
-  @apply bg-orange-10 p-4 md:p-8 rounded-md mt-8 mb-12 dark:bg-orange-100/30;
-  p.first.admonition-title {
-    @apply text-lg text-orange-70 font-bold dark:text-orange-70;
-  }
-}
-
 sup a {
   @apply underline hover:no-underline dark:text-white;
 }

--- a/styles/text.scss
+++ b/styles/text.scss
@@ -72,7 +72,6 @@ p {
   @apply mb-4 text-gray-90 dark:text-white;
 }
 
-// Add custom color to div.admonition.note in dark mode below
 div.admonition.note {
   @apply bg-lightBlue-10 p-4 md:p-8 rounded-md mt-8 mb-12 dark:bg-lightBlue-100/30;
   p.first.admonition-title {


### PR DESCRIPTION
This PR fixes two issues ([1](https://www.notion.so/streamlit/st-set_page_config-note-box-not-rendered-correctly-8de759688e3b40aab3d98f156bb4f7fd), [2](https://www.notion.so/streamlit/st-columns-API-ref-38c5d360fa134702b1b98ffc3c932570)) whereby callouts such as `Note` and `Warning` in API reference docstrings are rendered as paragraph text without any CSS styling like their React component counterparts.

The issues arises because the content in the docstring is not pulled from markdown files (so Tailwind styling does not apply). It is instead pulled from `python/streamlit.json`, that in-turn is populated by `python/generate.py` which parses the `.. note:: ` and `.. warning::` admonitions from Python scripts in the Streamlit library repo. E.g. [st.set_page_config](https://github.com/streamlit/streamlit/blob/38256624c59a41123eebab98ddcfc176daf3cd3a/lib/streamlit/commands/page_config.py#L40-L42).

## Before
![image](https://user-images.githubusercontent.com/20672874/161734295-a4504494-6ed8-424c-ac59-51e4bc1e8a0e.png)
![image](https://user-images.githubusercontent.com/20672874/161734544-3f17c024-8ffc-4f35-89d3-66d12959178a.png)

## After
![image](https://user-images.githubusercontent.com/20672874/161734815-444885fa-190e-4d09-97bf-2071a0d9c0fb.png)
![image](https://user-images.githubusercontent.com/20672874/161735012-09008cdd-e8a5-487d-81bd-a61ffd32dac0.png)



