### PR TITLE
Update KB article on libgl opencv-python error

### DIFF
--- a/content/kb/dependencies/libgl.md
+++ b/content/kb/dependencies/libgl.md
@@ -11,4 +11,12 @@ You receive the error `ImportError libGL.so.1 cannot open shared object file No 
 
 ## Solution
 
-Include `opencv-python-headless` in your requirements file on Streamlit Cloud in place of `opencv_contrib_python` and `opencv-python`.
+If you use OpenCV in your app, include `opencv-python-headless` in your requirements file on Streamlit Cloud in place of `opencv_contrib_python` and `opencv-python`.
+
+If `opencv-python` is a _required_ (non-optional) dependency of your app or a dependency of a library used in your app, the above solution is not applicable. Instead, you can use the following solution:
+
+Create a `packages.txt` file in your repo with the following line to install the [apt-get dependency](/streamlit-cloud/get-started/deploy-an-app/app-dependencies#apt-get-dependencies) `libgl`:
+
+```
+libgl1
+```


### PR DESCRIPTION
This PR updates the [ImportError libGL.so.1 cannot open shared object file No such file or directory](https://docs.streamlit.io/knowledge-base/dependencies/libgl) KB article with instructions on how to fix the error if `opencv-python` is a required dependency of a dependency. 

The dependency will ignore `opencv-python-headless` and try calling `opencv-python`, which throws an ImportError, as described in this [forum post](https://discuss.streamlit.io/t/importerror-libgl-so-1-while-trying-to-run-a-detecto-app/23920).

The solution is to include `libgl` in a packages.txt file.