### PR TITLE
Add release notes for 1.9.0

### DIFF
--- a/content/library/advanced-features/configuration.md
+++ b/content/library/advanced-features/configuration.md
@@ -89,7 +89,7 @@ Shows all config options available for Streamlit, including their current
 values:
 
 ```toml
-# Streamlit version: 1.8.0
+# Streamlit version: 1.9.0
 
 [global]
 
@@ -103,9 +103,7 @@ disableWatchdogWarning = false
 showWarningOnDirectExecution = true
 
 # DataFrame serialization.
-# Acceptable values:
-#   - 'legacy': Serialize DataFrames using Streamlit's custom format. Slow but battle-tested.
-#   - 'arrow': Serialize DataFrames using Apache Arrow. Much faster and versatile.
+# Acceptable values: - 'legacy': Serialize DataFrames using Streamlit's custom format. Slow but battle-tested. - 'arrow': Serialize DataFrames using Apache Arrow. Much faster and versatile.
 # Default: "arrow"
 dataFrameSerialization = "arrow"
 
@@ -117,7 +115,7 @@ dataFrameSerialization = "arrow"
 level = "info"
 
 # String format for logging messages. If logger.datetimeFormat is set, logger messages will default to `%(asctime)s.%(msecs)03d %(message)s`. See [Python's documentation](https://docs.python.org/2.6/library/logging.html#formatter-objects) for available attributes.
-# Default: None
+# Default: "%(asctime)s %(message)s"
 messageFormat = "%(asctime)s %(message)s"
 
 
@@ -155,6 +153,10 @@ fixMatplotlib = true
 # Default: true
 postScriptGC = true
 
+# Handle script rerun requests immediately, rather than waiting for script execution to reach a yield point. Enabling this will make Streamlit much more responsive to user interaction, but it can lead to race conditions in apps that mutate session_state data outside of explicit session_state assignment statements.
+# Default: false
+fastReruns = false
+
 
 [server]
 
@@ -165,7 +167,7 @@ postScriptGC = true
 folderWatchBlacklist = []
 
 # Change the type of file watcher used by Streamlit, or turn it off completely.
-# Allowed values: * "auto" : Streamlit will attempt to use the watchdog module, and falls back to polling if watchdog is not available. * "watchdog" : Force Streamlit to use the watchdog module. * "poll": Force Streamlit to always use polling. * "none" : Streamlit will not watch files.
+# Allowed values: * "auto" : Streamlit will attempt to use the watchdog module, and falls back to polling if watchdog is not available. * "watchdog" : Force Streamlit to use the watchdog module. * "poll" : Force Streamlit to always use polling. * "none" : Streamlit will not watch files.
 # Default: "auto"
 fileWatcherType = "auto"
 
@@ -181,9 +183,9 @@ headless = false
 # Default: false
 runOnSave = false
 
-# The address where the server will listen for client and browser connections. Use this if you want to bind the server to a specific address. If set, the server will only be accessible from this address,and not from any aliases (like localhost).
+# The address where the server will listen for client and browser connections. Use this if you want to bind the server to a specific address. If set, the server will only be accessible from this address, and not from any aliases (like localhost).
 # Default: (unset)
-#address =
+# address =
 
 # The port where the server will listen for browser connections.
 # Default: 8501
@@ -212,8 +214,8 @@ maxUploadSize = 200
 maxMessageSize = 200
 
 # Enables support for websocket compression.
-# Default: true
-enableWebsocketCompression = true
+# Default: false
+enableWebsocketCompression = false
 
 
 [browser]
@@ -231,14 +233,6 @@ gatherUsageStats = true
 # This is used to: - Set the correct URL for CORS and XSRF protection purposes. - Show the URL on the terminal - Open the browser
 # Default: whatever value is set in server.port.
 serverPort = 8501
-
-
-[ui]
-
-# Flag to hide most of the UI elements found at the top of a Streamlit app.
-# NOTE: This does *not* hide the hamburger menu in the top-right of an app.
-# Default: false
-hideTopBar = false
 
 
 [mapbox]
@@ -262,20 +256,20 @@ showPyplotGlobalUse = true
 [theme]
 
 # The preset Streamlit theme that your custom theme inherits from. One of "light" or "dark".
-#base =
+# base =
 
 # Primary accent color for interactive elements.
-#primaryColor =
+# primaryColor =
 
 # Background color for the main content area.
-#backgroundColor =
+# backgroundColor =
 
 # Background color used for the sidebar and most interactive widgets.
-#secondaryBackgroundColor =
+# secondaryBackgroundColor =
 
 # Color used for almost all text.
-#textColor =
+# textColor =
 
 # Font family for all text in the app, except code blocks. One of "sans serif", "serif", or "monospace".
-#font =
+# font =
 ```

--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -12,10 +12,24 @@ This page lists highlights, bug fixes, and known issues for official Streamlit r
 To upgrade to the latest version of Streamlit, run:
 
 ```bash
-$ pip install --upgrade streamlit
+pip install --upgrade streamlit
 ```
 
 </Tip>
+
+## **Version 1.9.0**
+
+_Release date: April 29, 2022_
+
+**Notable Changes**
+
+- 🪗 `st.json` now supports a keyword-only argument, `expanded` on whether the JSON should be expanded by default (defaults to `True`).
+- 🏃‍♀️ More performance improvements from reducing redundant work each script run.
+
+**Other Changes**
+
+- 🏇 Widgets when `disabled` is set/unset will maintain its value ([#4527](https://github.com/streamlit/streamlit/pull/4527)).
+- 🧪 Experimental feature to increase the speed of reruns using configuration `runner.fastReruns`. See [#4628](https://github.com/streamlit/streamlit/pull/4628) for the known issues in enabling this feature.
 
 ## **Version 1.8.0**
 
@@ -858,7 +872,7 @@ _Release date: September 19, 2019_
 **Highlights:**
 
 - ✨ Magic commands! Use `st.write` without typing `st.write`. See
-  https://docs.streamlit.io/en/latest/api.html#magic-commands
+  <https://docs.streamlit.io/en/latest/api.html#magic-commands>
 - 🎛️ New `st.multiselect` widget.
 - 🐍 Fixed numerous install issues so now you can use `pip install streamlit`
   even in Conda! We've therefore deactivated our Conda repo.
@@ -868,7 +882,7 @@ _Release date: September 19, 2019_
 
 - 🛡️ HTML tags are now blacklisted in `st.write`/`st.markdown` by default. More
   information and a temporary work-around at:
-  https://github.com/streamlit/streamlit/issues/152
+  <https://github.com/streamlit/streamlit/issues/152>
 
 ## Version 0.45.0
 
@@ -976,11 +990,11 @@ If you run `$ python your_script.py` the script will execute from top to bottom,
 If the new Streamlit isn't working, please let us know by Slack or email. You can downgrade at any time with these commands:
 
 ```bash
-$ pip install --upgrade streamlit==0.37
+pip install --upgrade streamlit==0.37
 ```
 
 ```bash
-$ conda install streamlit=0.37
+conda install streamlit=0.37
 ```
 
 **What's next?**

--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -19,7 +19,7 @@ pip install --upgrade streamlit
 
 ## **Version 1.9.0**
 
-_Release date: April 29, 2022_
+_Release date: May 4, 2022_
 
 **Notable Changes**
 

--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -30,6 +30,7 @@ _Release date: April 29, 2022_
 
 - 🏇 Widgets when `disabled` is set/unset will maintain its value ([#4527](https://github.com/streamlit/streamlit/pull/4527)).
 - 🧪 Experimental feature to increase the speed of reruns using configuration `runner.fastReruns`. See [#4628](https://github.com/streamlit/streamlit/pull/4628) for the known issues in enabling this feature.
+- 🗺️ DataFrame timestamps support UTC offset (in addition to time zone notation) ([#4669](https://github.com/streamlit/streamlit/pull/4669)).
 
 ## **Version 1.8.0**
 


### PR DESCRIPTION
###  :books: Context
Streamlit v1.9.0 will be released tomorrow. We need to update the changelog, docstrings, the configuration options page.

### 🧠  Description of changes
- [x] Add release notes to changelog
- [x] Update configuration options page with a new config option `runner.fastReruns` after the release
- [x] Bump docstrings from version 1.8.0 to 1.9.0
