### PR TITLE
Specify location for packages.txt

### DIFF
--- a/content/streamlit-cloud/get-started/deploy-an-app/app-dependencies.md
+++ b/content/streamlit-cloud/get-started/deploy-an-app/app-dependencies.md
@@ -47,7 +47,7 @@ however, if no requirements file is found, Streamlit will then look at the root 
 
 ### apt-get dependencies
 
-If `packages.txt` exists in the repository we automatically detect it, parse it, and install the listed packages as described below. You can read more about apt-get in their [docs](https://linux.die.net/man/8/apt-get).
+If `packages.txt` exists in the root directory of your repository we automatically detect it, parse it, and install the listed packages as described below. You can read more about apt-get in their [docs](https://linux.die.net/man/8/apt-get).
 
 Add **apt-get** dependencies to `packages.txt`, one package name per line. For example:
 


### PR DESCRIPTION
This edit specifies the location of `packages.txt`.

From the documentation it was not clear to me that `packages.txt` must be in the root directory of the repository. Especially because `requirements.txt` will be read from a subdirectory.

