### PR TITLE
Add templates for issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,55 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ""
+labels: bug, needs triage
+assignees: ""
+---
+
+### Summary
+
+Type here a clear and concise description of the bug. Aim for 2-3 sentences.
+
+### Steps to reproduce
+
+Code snippet:
+
+```
+
+```
+
+Screenshot(s):
+
+(Please provide a code snippet and/or screenshots! These will help expedite us finding and solving the problem.)
+
+If applicable, please provide the steps we should take to reproduce the bug:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+
+**Expected behavior:**
+
+Explain what you expect to happen when you go through the steps above, assuming there were no bugs.
+
+**Actual behavior:**
+
+Explain the buggy behavior you experience when you go through the steps above.
+If applicable, add screenshots to help explain your problem.
+
+### Is this a regression?
+
+That is, did this use to work the way you expected in the past?
+yes / no
+
+### Debug info
+
+- Docs page link: (do you have a link to the docs page containing the bug?)
+- npm version: (get it with `npm -v`)
+- node version: (get it with `node -v`)
+- OS version:
+- Browser version:
+
+### Additional information
+
+If needed, add any other context about the problem here. For example, did this bug come from <https://discuss.streamlit.io> or another site? Link the original source here!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Streamlit community support
+    url: https://discuss.streamlit.io/
+    about: Please ask and answer questions here.
+  - name: Streamlit documentation
+    url: https://docs.streamlit.io/
+    about: To learn more about how Streamlit works.
+  - name: Streamlit docs README
+    url: https://github.com/streamlit/docs/blob/main/README.md
+    about: To learn how Streamlit's documentation works.

--- a/.github/ISSUE_TEMPLATE/doc_improvement.md
+++ b/.github/ISSUE_TEMPLATE/doc_improvement.md
@@ -1,0 +1,13 @@
+---
+name: Documentation improvement request
+about: Let us know how our docs could be better
+title: ""
+labels: docs, needs triage
+assignees: ""
+---
+
+**Link to doc page in question (if any):**
+
+**Name of the Streamlit feature whose docs need improvement:**
+
+**What you think the docs should say:**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ""
+labels: enhancement, needs triage
+assignees: ""
+---
+
+_(Note, you don't have to fill out every section here. They're just here for guidance. That said, nicely detailed feature requests are more likely to get eng attention sooner)_
+
+### Problem
+
+Is your feature request related to a problem? Please describe the problem here. Ex. I'm always frustrated when [...]
+
+### Solution
+
+**MVP:** What's the smallest possible solution that would get 80% of the problem out of the way?
+
+**Possible additions:** What are other things that could be added to the MVP over time to make it better?
+
+**Preferred solution:** If you don't like the MVP above, tell us why, and what you'd like done instead.
+
+### Additional context
+
+Add any other context or screenshots about the feature request here. For example, did this FR come from <https://discuss.streamlit.io> or another site? Link the original source here!

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+## 📚 Context
+
+<!-- Why do you want to make this change? What background should the reviewer know? -->
+
+## 🧠 Description of Changes
+
+<!-- What was specifically changed? Which files, algorithms, links, media? -->
+<!-- Please add them here as a bulleted list -->
+
+**Revised:**
+
+_Insert screenshot of your updated UI/code here_
+
+**Current:**
+
+_Insert screenshot of existing UI/code here_
+
+## 💥 Impact
+
+<!-- what is the scale of this change -->
+
+Size:
+
+- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
+- [ ] Not small <!-- Everything else -->
+
+## 🌐 References
+
+<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
+<!-- For small isolated changes, you can skip this section -->
+
+- [ ] [Notion](...)
+
+<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->
+
+**Contribution License Agreement**
+
+By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.


### PR DESCRIPTION
## 📚 Context

We would like contributors to follow standard templates while submitting issues and creating PRs.

## 🧠 Description of Changes

- Adds templates for issues and PRs that work via GH actions.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Not small <!-- Everything else -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.