### PR TITLE
Mention more clearly when things are experimental

### DIFF
--- a/content/library/api/control-flow/experimental_rerun.md
+++ b/content/library/api/control-flow/experimental_rerun.md
@@ -4,4 +4,10 @@ slug: /library/api-reference/control-flow/st.experimental_rerun
 description: st.experimental_rerun will rerun the script immediately.
 ---
 
+<Important>
+
+This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#beta-and-experimental-features).
+
+</Important>
+
 <Autofunction function="streamlit.experimental_rerun" />

--- a/content/library/api/performance/experimental-memo-clear.md
+++ b/content/library/api/performance/experimental-memo-clear.md
@@ -4,6 +4,12 @@ slug: /library/api-reference/performance/st.experimental_memo.clear
 description: st.experimental_memo.clear clears all in-memory and on-disk memo caches.
 ---
 
+<Important>
+
+This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#beta-and-experimental-features).
+
+</Important>
+
 <Autofunction function="streamlit.experimental_memo.clear" />
 
 #### Example

--- a/content/library/api/performance/experimental-memo.md
+++ b/content/library/api/performance/experimental-memo.md
@@ -4,4 +4,10 @@ slug: /library/api-reference/performance/st.experimental_memo
 description: st.experimental_memo is used to memoize function executions.
 ---
 
+<Important>
+
+This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#beta-and-experimental-features).
+
+</Important>
+
 <Autofunction function="streamlit.experimental_memo" />

--- a/content/library/api/performance/experimental-singleton-clear.md
+++ b/content/library/api/performance/experimental-singleton-clear.md
@@ -4,6 +4,12 @@ slug: /library/api-reference/performance/st.experimental_singleton.clear
 description: st.experimental_singleton.clear clears all singleton caches.
 ---
 
+<Important>
+
+This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#beta-and-experimental-features).
+
+</Important>
+
 <Autofunction function="streamlit.experimental_singleton.clear" />
 
 #### Example

--- a/content/library/api/performance/experimental-singleton.md
+++ b/content/library/api/performance/experimental-singleton.md
@@ -4,4 +4,10 @@ slug: /library/api-reference/performance/st.experimental_singleton
 description: st.experimental_singleton is a function decorator used to store singleton objects.
 ---
 
+<Important>
+
+This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#beta-and-experimental-features).
+
+</Important>
+
 <Autofunction function="streamlit.experimental_singleton" />

--- a/content/library/api/utilities/experimental_get_query_params.md
+++ b/content/library/api/utilities/experimental_get_query_params.md
@@ -4,4 +4,10 @@ slug: /library/api-reference/utilities/st.experimental_get_query_params
 description: st.experimental_get_query_params returns query parameters currently showing in the browser's URL bar.
 ---
 
+<Important>
+
+This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#beta-and-experimental-features).
+
+</Important>
+
 <Autofunction function="streamlit.experimental_get_query_params" />

--- a/content/library/api/utilities/experimental_set_query_params.md
+++ b/content/library/api/utilities/experimental_set_query_params.md
@@ -4,4 +4,10 @@ slug: /library/api-reference/utilities/st.experimental_set_query_params
 description: st.experimental_set_query_params sets query parameters shown in the browser's URL bar.
 ---
 
+<Important>
+
+This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#beta-and-experimental-features).
+
+</Important>
+
 <Autofunction function="streamlit.experimental_set_query_params" />

--- a/content/library/api/utilities/experimental_show.md
+++ b/content/library/api/utilities/experimental_show.md
@@ -4,4 +4,10 @@ slug: /library/api-reference/utilities/st.experimental_show
 description: st.experimental_show writes arguments and argument names to your app for debugging purposes.
 ---
 
+<Important>
+
+This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#beta-and-experimental-features).
+
+</Important>
+
 <Autofunction function="streamlit.experimental_show" />


### PR DESCRIPTION
## 📚 Context

Docs should mention more clearly when things are experimental. We should say something like “This is an experimental feature. To find out more about experimental features, click here.”

## 🧠 Description of Changes

- Added callouts above all experimental API command pages that read, "_This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#beta-and-experimental-features)._"

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/168550754-4bc4b0f8-67e3-49cc-8554-d0f9c3dd8cc1.png)


**Current:**

![image](https://user-images.githubusercontent.com/20672874/168550825-91e91497-c512-4c67-8e08-e8b02448ef89.png)

## 💥 Impact

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Docs-should-mention-more-clearly-when-things-are-experimental-660d234f1bcd47da9f407c996fd8e5b3)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
