### PR TITLE
Update docs to reflect Streamlit's support for Python 3.10

### DIFF
--- a/content/kb/using-streamlit/sanity-checks.md
+++ b/content/kb/using-streamlit/sanity-checks.md
@@ -15,7 +15,7 @@ guaranteeing compatibility with _at least_ the last three minor versions of Pyth
 As new versions of Python are released, we will try to be compatible with the new version as soon
 as possible, though frequently we are at the mercy of other Python packages to support these new versions as well.
 
-Streamlit currently supports versions 3.7, 3.8, and 3.9 of Python.
+Streamlit currently supports versions 3.7, 3.8, 3.9, and 3.10 of Python.
 
 ## Check #1: Is Streamlit running?
 

--- a/content/kb/using-streamlit/sanity-checks.md
+++ b/content/kb/using-streamlit/sanity-checks.md
@@ -17,12 +17,6 @@ as possible, though frequently we are at the mercy of other Python packages to s
 
 Streamlit currently supports versions 3.7, 3.8, 3.9, and 3.10 of Python.
 
-<Note>
-
-Streamlit Cloud does not currently support Python 3.10
-
-</Note>
-
 ## Check #1: Is Streamlit running?
 
 On a Mac or Linux machine, type this on the terminal:

--- a/content/kb/using-streamlit/sanity-checks.md
+++ b/content/kb/using-streamlit/sanity-checks.md
@@ -17,6 +17,12 @@ as possible, though frequently we are at the mercy of other Python packages to s
 
 Streamlit currently supports versions 3.7, 3.8, 3.9, and 3.10 of Python.
 
+<Note>
+
+Streamlit Cloud does not currently support Python 3.10
+
+</Note>
+
 ## Check #1: Is Streamlit running?
 
 On a Mac or Linux machine, type this on the terminal:

--- a/content/library/components/components-api.md
+++ b/content/library/components/components-api.md
@@ -95,7 +95,7 @@ To make the process of creating bi-directional Streamlit Components easier, we'v
 
 To build a Streamlit Component, you need the following installed in your development environment:
 
-- Python 3.7 - Python 3.9
+- Python 3.7 - Python 3.10
 - Streamlit 0.63+
 - [nodejs](https://nodejs.org/en/)
 - [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/)

--- a/content/library/get-started/installation.md
+++ b/content/library/get-started/installation.md
@@ -16,7 +16,7 @@ slug: /library/get-started/installation
 Before you get started, you're going to need a few things:
 
 - Your favorite IDE or text editor
-- [Python 3.7 - Python 3.9](https://www.python.org/downloads/)
+- [Python 3.7 - Python 3.10](https://www.python.org/downloads/)
 - [PIP](https://pip.pypa.io/en/stable/installing/)
 
 If you haven't already, take a few minutes to read through [Main


### PR DESCRIPTION
## 📚 Context

The Streamlit library added support for Python 3.10 in version 1.4.0, back in January. Our docs say we support Python 3.7 - 3.9.

## 🧠 Description of Changes

- Say Streamlit supports versions 3.7 through 3.10 of Python
- Streamlit Cloud will support 3.10 in the next release, so not adding a callout to say Cloud does not support it.

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/169016721-4853ae4c-b9bc-4205-a62c-9c0e8784ebe2.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/169016528-dbe53b0c-9bbf-42e4-9477-0c4d893d48fe.png)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Slack](https://snowflake.slack.com/archives/C039XQ62PB7/p1652803206998109)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
