### PR TITLE
Fix "Unsupported browser" issue for embedded apps

### DIFF
--- a/python/stoutput.py
+++ b/python/stoutput.py
@@ -47,7 +47,7 @@ class StOutput(Directive):
             text="""
                 <iframe
                     loading="lazy"
-                    src="%(src)s&embed=true"
+                    src="%(src)s"
                     style="
                         width: 100%%;
                         border: none;


### PR DESCRIPTION
## 📚 Context

Embedded apps in our API reference pages show an "Unsupported browser" page instead of rendering the app content. While we're still unsure of what changes, if any, on Cloud led to this development, @raethlein observed that removing `&embed=true` param from app urls in iframes resolves the issue.

## 🧠 Description of Changes

- Removed the `&embed=true` param from the script that parses docstrings 
- Updated embedded urls in `streamlit.json`

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/170187035-77d689be-6b10-4584-afbd-1040515306f8.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/170187140-9f91f626-16b8-4b6a-8f52-09740e009e23.png)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Slack](https://snowflake.slack.com/archives/C03AFAHCG1J/p1653451986147779)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
