### PR TITLE
Add edge cases when private app viewers show up anonymously

### DIFF
--- a/content/streamlit-cloud/get-started/manage-your-app.md
+++ b/content/streamlit-cloud/get-started/manage-your-app.md
@@ -212,7 +212,11 @@ You're presented with a graph that you can hover over to see the number of users
 
 Solid lines indicate fully-complete months on the dashboard, while dotted lines indicate the current in-progress month.
 
-**Note:** Viewers data on your dashboard starts from April 2022 and onward. April 2022 data was our first month comprehensively tracking user analytics in Streamlit workspaces, and our tracking is even more refined starting in May 2022 and onward.
+<Note>
+
+Viewers data on your dashboard starts from April 2022 and onward. April 2022 data was our first month comprehensively tracking user analytics in Streamlit workspaces, and our tracking is even more refined starting in May 2022 and onward.
+
+</Note>
 
 ### App viewers
 
@@ -233,14 +237,6 @@ There are three ways to access the app viewers data:
    - The total (all time) number of unique viewers for the app.
    - A list of the most recent viewers' names and a relative timestamp of their last view, sorted by the time since the last view (newest first).
 
-<Note>
-
-For public apps, we anonymize all viewers outside your workspace for their privacy and display anonymous viewers as random pseudonyms. You’ll still be able to see the identities of fellow members in your workspace, though.
-
-Meanwhile, for private apps that are only accessible to your own workspace’s viewers, you will be able to see the specific users of your apps’ recent viewers.
-
-</Note>
-
 2. Click the "**Analytics**" option on the dashboard header and select the "**App viewers**" tab:
    ![Analytics option header](/images/streamlit-cloud/app-viewers-header.png)
 
@@ -258,3 +254,19 @@ Meanwhile, for private apps that are only accessible to your own workspace’s v
 <Image src="/images/streamlit-cloud/app-viewers-in-app.png" />
 <Image src="/images/streamlit-cloud/app-viewers-analytics-modal.png" />
 </Flex>
+
+#### **App viewers for public vs private apps**
+
+For public apps, we anonymize all viewers outside your workspace to protect their privacy and display anonymous viewers as random pseudonyms. You'll still be able to see the identities of fellow members in your workspace, though.
+
+Meanwhile, for private apps that are only accessible to your own workspace's viewers, you will be able to see the specific users who recently viewed your apps.
+
+Additionally, you may occasionally see anonymous users in private apps. Rest assured, these anonymous users _do_ have authorized view access granted by you or your workspace members.
+
+Common reasons why users show up anonymously are:
+
+1. The app was previously public
+2. Given viewer viewed app in April 2022, when the Streamlit team was honing user identification for this feature
+3. Given viewer disconnected their SSO and Github accounts previously
+
+See Streamlit's general Privacy Policy [here](https://streamlit.io/privacy-policy).


### PR DESCRIPTION
## 📚 Context

Based on a user report, the Champions Team has identified expected edge cases where viewers of private apps erroneously appear to be anonymous viewers. We should document these cases so that users know this is to be expected, and not a security incident.

## 🧠 Description of Changes

- Added the edge cases to a new subsection of "App viewers"
- Replaced the callout with the new subsection as the note was too large and the contents are a non-optional read

**Revised:**

<details>
<summary>New subsection</summary>

![image](https://user-images.githubusercontent.com/20672874/170437784-74f1825c-0686-4621-9755-65de99fb0a28.png)

</details>

**Current:**

<details>
<summary>Current callout</summary>

![image](https://user-images.githubusercontent.com/20672874/170438231-5514a384-70ef-4468-b44a-93d1b9bd2149.png)

</details>

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/Docs-App-viewers-Workspace-analytics-7a7e6769865744fca588b57e2a42685f?d=57340233b4654c5eb2e18e27f052793f#361aa4f51802421a8556ecd8be18e606)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
