### PR TITLE
Update dataframe docs with notes on interactivity

### DIFF
--- a/content/library/api/data/dataframe.md
+++ b/content/library/api/data/dataframe.md
@@ -5,3 +5,21 @@ description: st.dataframe displays a dataframe as an interactive table.
 ---
 
 <Autofunction function="streamlit.dataframe" />
+
+### Interactivity
+
+Dataframes displayed as interactive tables with `st.dataframe` have the following interactive features:
+
+- **Column sorting**: sort columns by clicking on their headers.
+- **Column resizing**: resize columns by dragging and dropping column header borders.
+- **Table (height, width) resizing**: resize tables by dragging and dropping the bottom right corner of tables.
+- **Search**: search through data by clicking a table, using hotkeys (`⌘ Cmd + F` or `Ctrl + F`) to bring up the search bar, and using the search bar to filter data.
+- **Copy to clipboard**: select one or multiple cells, copy them to clipboard, and paste them into your favorite spreadsheet software.
+
+<Image src="/images/dataframe-ui.gif" />
+
+<Note>
+
+Copy to clipboard does not currently work on Streamlit Cloud.
+
+</Note>


### PR DESCRIPTION
## 📚 Context

The upcoming Streamlit release includes updates to the `st.dataframe` UI. The updates include column resizing, table resizing, data search, and data copy-to-clipboard. 

## 🧠 Description of Changes

- Adds a new "Interactivity" section to the `st.dataframe` API reference page, detailing the interactive features in addition to an illustrative GIF.

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/171601181-6d000eae-f03e-47a5-8c14-aeaa50002012.png)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Improve-UX-of-st-dataframes-a2a4aaf142894926bc3f19100a1d4b26)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
