### PR TITLE
Fix incorrect link to MPA docs in Get started

### DIFF
--- a/content/library/get-started/index.md
+++ b/content/library/get-started/index.md
@@ -18,7 +18,7 @@ operating system, and how to create your first Streamlit app!
   <InlineCallout color="violet-70" icon="auto_awesome" bold="Create an app" href="/library/get-started/create-an-app">
     using Streamlit's core features to fetch and cache data, draw charts, plot information on a map, and use interactive widgets, like a slider, to filter results.
   </InlineCallout>
-  <InlineCallout color="violet-70" icon="auto_stories" bold="Multipage apps" href="/library/get-started/create-an-app">
+  <InlineCallout color="violet-70" icon="auto_stories" bold="Multipage apps" href="/library/get-started/multipage-apps">
     teaches you how to add pages to your app, including how to define pages, structure and run multipage apps, and navigate between pages. Once you understand the basics, create your first multipage app based on the familiar <code>streamlit hello</code> command!
   </InlineCallout>
   {/*<InlineCallout color="violet-70" icon="share" bold="Deploy an app" href="/library/get-started/deploy-an-app">


### PR DESCRIPTION
## 📚 Context

@dataprofessor noticed an incorrect link to our MPA docs in the Get started inline callout.

## 🧠 Description of Changes

- Replaces link with the correct one

**Revised:**

`/library/get-started/multipage-apps`

**Current:**

`/library/get-started/create-an-app`

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Slack](https://snowflake.slack.com/archives/C039W9H711C/p1654219395700769?thread_ts=1653998657.447289&cid=C039W9H711C)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
