### PR TITLE
Make <summary> tag respect dark mode

### DIFF
--- a/styles/text.scss
+++ b/styles/text.scss
@@ -72,6 +72,10 @@ p {
   @apply mb-4 text-gray-90 dark:text-white;
 }
 
+summary {
+  @apply mb-4 text-gray-90 dark:text-white;
+}
+
 sup a {
   @apply underline hover:no-underline dark:text-white;
 }


### PR DESCRIPTION
## 📚 Context

@dataprofessor noticed that toggle widgets created with `<details><summary></summary></details>` does not respect dark mode. 

## 🧠 Description of Changes

- Adds a CSS property to turn dark text encapsulated with `<summary></summary>` to white when dark mode is enabled.

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/171800709-f3d7b5e6-2633-42bd-afd0-f4e525c8c3ae.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/171800791-c0bb8914-2561-463d-8c5b-d6347441d3dc.png)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Slack](https://snowflake.slack.com/archives/C039W9H711C/p1654220176640799?thread_ts=1653998657.447289&cid=C039W9H711C)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
