### PR TITLE
Fix on versioned URLs starting on 1.10

### DIFF
--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -106,7 +106,6 @@ const Autofunction = ({
 
   if (streamlitFunction in streamlit) {
     functionObject = streamlit[streamlitFunction];
-    const sourceFile = useSourceFile(functionObject.source);
 
     if (
       functionObject.description !== undefined &&

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -106,7 +106,7 @@ const Autofunction = ({
 
   if (streamlitFunction in streamlit) {
     functionObject = streamlit[streamlitFunction];
-
+    const sourceFile = useSourceFile(functionObject.source);
     if (
       functionObject.description !== undefined &&
       functionObject.description

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -269,7 +269,7 @@ export async function getStaticProps(context) {
   const all_versions = Object.keys(streamlitFuncs);
   const versions = sortBy(all_versions, [
     (o) => {
-      return parseFloat(o);
+      return parseInt(o, 10);
     },
   ]);
   const current_version = versions[versions.length - 1];
@@ -357,7 +357,7 @@ export async function getStaticPaths() {
   const all_versions = Object.keys(streamlitFuncs);
   const versions = sortBy(all_versions, [
     (o) => {
-      return parseFloat(o);
+      return parseInt(o);
     },
   ]);
   const current_version = versions[versions.length - 1];

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -357,7 +357,7 @@ export async function getStaticPaths() {
   const all_versions = Object.keys(streamlitFuncs);
   const versions = sortBy(all_versions, [
     (o) => {
-      return parseInt(o);
+      return parseInt(o, 10);
     },
   ]);
   const current_version = versions[versions.length - 1];


### PR DESCRIPTION
This PR fixes [this issue](https://www.notion.so/streamlit/API-version-selector-not-showing-latest-version-by-default-ef6b19e9e21c46ca8064ac1fe06e22c4) reported by @snehankekre 