### PR TITLE
`media:print` stylesheet

### DIFF
--- a/styles/main.scss
+++ b/styles/main.scss
@@ -4,3 +4,5 @@
 @import "./tables.scss";
 @import "./scrollbars.scss";
 @import "./admonition.scss";
+
+@import "./print.scss";

--- a/styles/print.scss
+++ b/styles/print.scss
@@ -1,0 +1,16 @@
+@media print {
+  // Hide the elements we don't want to show on the PDF
+  // #content-container + section, #content-container + section ~ section, #content-container div section:last-child
+  header,
+  footer,
+  iframe,
+  #documentation .psa_Container___KGYF,
+  #documentation .arrowLink_Container__GdJWF,
+  #content-container .helpful_FormContainer__aXrIB {
+    display: none;
+  }
+
+  * {
+    -webkit-print-color-adjust: exact;
+  }
+}


### PR DESCRIPTION
## 📚 Context

This PR adds a `media:print` stylesheet to the codebase, so that PDFs get printed out nicely. It hides a handful of navigation and interactive elements.

## 🧠 Description of Changes

* Added a `print.scss` stylesheet;
* Linked it on `main.scss`;
* Added the necessary styles to hide `header`, `footer`, `iframe`, the `Was this page helpful?` and `Still have questions` section, as well as the navigation arrows.

**Revised:**

![Screen Shot 2022-06-03 at 10 04 31 AM](https://user-images.githubusercontent.com/34423371/171859609-43f228a1-dcc1-4dda-bfd5-d2f011079182.png)

![Screen Shot 2022-06-03 at 10 04 12 AM](https://user-images.githubusercontent.com/34423371/171859617-921bd165-ac25-441b-b313-449b2fae7c5e.png)

![Screen Shot 2022-06-03 at 10 03 59 AM](https://user-images.githubusercontent.com/34423371/171859621-d53bc7bd-d35c-45d7-adcb-21957b3d246f.png)

**Current:**

![Screen Shot 2022-06-03 at 10 07 26 AM](https://user-images.githubusercontent.com/34423371/171860120-9723dd0d-6bcc-4f8d-9da9-ab46a0f92ac9.png)

![Screen Shot 2022-06-03 at 10 07 38 AM](https://user-images.githubusercontent.com/34423371/171860136-e539c0e4-b8d2-4ea5-a0f6-a8cab97b3215.png)

![Screen Shot 2022-06-03 at 10 07 56 AM](https://user-images.githubusercontent.com/34423371/171860145-6825a21d-7fd9-4152-abdd-2f6561cd4718.png)

## 💥 Impact

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

This is a requirement for the [Docs PDF conversion](https://github.com/streamlit/docs/pull/396) PR we're working on.

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
