### PR TITLE
Use break-words to add line breaks mid-word to code

### DIFF
--- a/styles/text.scss
+++ b/styles/text.scss
@@ -86,7 +86,7 @@ li p:only-child {
 }
 
 .code {
-  @apply font-mono font-normal;
+  @apply font-mono font-normal break-words;
 }
 
 .bold {


### PR DESCRIPTION
## 📚 Context

@CharlyWargnier [noticed](https://snowflake.slack.com/archives/C039XQ62PB7/p1654421522473299) that code in the `Returns` section of the [st.slider API page](https://docs.streamlit.io/library/api-reference/widgets/st.slider) table overflows into the adjacent column. This occurs because there is no line break in the string.

## 🧠 Description of Changes

- Adds the `break-words` tailwind utility for code in `styles/text.scss`

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/172138303-88f3a9d7-fff9-4237-aee6-0a0b4ff4b144.png)


**Current:**

![image](https://user-images.githubusercontent.com/20672874/172138364-b153ad8b-a89f-42f2-8afe-f33366afa9d5.png)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://snowflake.slack.com/archives/C039XQ62PB7/p1654421522473299)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
