### PR TITLE
Remove explanation of `_beta` features

### DIFF
--- a/content/library/advanced-features/index.md
+++ b/content/library/advanced-features/index.md
@@ -99,7 +99,7 @@ Session State is a way to share variables between reruns, for each user session.
 At Streamlit, we like to move quick while keeping things stable. In our latest effort to move even faster without sacrificing stability, we're offering our bold and fearless users two ways to try out Streamlit's bleeding-edge features.
 
 - [Nightly releases](/library/advanced-features/prerelease#nightly-releases)
-- [Beta and experimental features](/library/advanced-features/prerelease#beta-and-experimental-features)
+- [Experimental features](/library/advanced-features/prerelease#experimental-features)
 
 </RefCard>
 

--- a/content/library/advanced-features/prerelease-features.md
+++ b/content/library/advanced-features/prerelease-features.md
@@ -7,10 +7,41 @@ slug: /library/advanced-features/prerelease
 
 At Streamlit, we like to move quick while keeping things stable. In our latest effort to move even faster without sacrificing stability, we're offering our bold and fearless users two ways to try out Streamlit's bleeding-edge features:
 
-1. [Nightly releases](#nightly-releases)
-2. [Experimental features](#experimental-features)
+1. [Experimental features](#experimental-features)
+2. [Nightly releases](#nightly-releases)
+
+## Experimental Features
+
+Less stable Streamlit features have one naming convention: `st.experimental_`. This distinction is a prefix we attach to our command names to make sure their status is clear to everyone.
+
+Here's a quick rundown of what you get from each naming convention:
+
+- **st**: this is where our core features like `st.write` and `st.dataframe` live. If we ever make backward-incompatible changes to these, they will take place gradually and with months of announcements and warnings.
+- **experimental**: this is where we'll put all new features that may or may not ever make it into Streamlit core. This gives you a chance to try the next big thing we're cooking up weeks or months before we're ready to stabilize its API. We don't know whether these features have a future, but we want you to have access to everything we're trying, and work with us to figure them out.
+
+Features with the `experimental_` naming convention are things that we're still working on or trying
+to understand. If these features are successful, at some point they'll become part of Streamlit
+core. If unsuccessful, these features are removed without much notice. While in experimental, a feature's API and behaviors may not be stable, and it's possible they could change in ways that aren't backward-compatible.
+
+<Warning>
+
+Experimental features and their APIs may change or be removed at any time.
+
+</Warning>
+
+### The lifecycle of an experimental feature
+
+1. A feature is added with the `experimental_` prefix.
+2. The feature is potentially tweaked over time, with possible API/behavior breakages.
+3. If successful, we promote the feature to Streamlit core and remove it from `experimental_`:
+   - a\. The feature's API stabilizes and the feature is _cloned_ without the `experimental_` prefix, so it exists as both `st` and `experimental_`. At this point, users will see a warning when using the version of the feature with the `experimental_` prefix -- but the feature will still work.
+   - b\. At some point, the code of the `experimental_`-prefixed feature is _removed_, but there will still be a stub of the function prefixed with `experimental_` that shows an error with appropriate instructions.
+   - c\. Finally, at a later date the `experimental_` version is removed.
+4. If unsuccessful, the feature is removed without much notice and we leave a stub in `experimental_` that shows an error with instructions.
 
 ## Nightly releases
+
+In addition to experimental features, we offer another way to try out Streamlit's newest features: nightly releases.
 
 At the end of each day (at night 🌛), our bots run automated tests against the latest Streamlit code and, if everything looks good, it publishes them as the `streamlit-nightly` package. This means the nightly build includes all our latest features, bug fixes, and other enhancements on the same day they land on our codebase.
 
@@ -48,34 +79,3 @@ If you'd like to use a specific version, you can find the version number in our 
 **Can I compare changes between releases?**
 
 If you'd like to review the changes for a nightly release, you can use the [comparison tool on GitHub](https://github.com/streamlit/streamlit/compare/0.57.3...0.57.4.dev20200412).
-
-## Experimental Features
-
-In addition to nightly releases, we also have one naming convention for less stable Streamlit features: `st.experimental_`. This distinction is a prefix we attach to our command names to make sure their status is clear to everyone.
-
-Here's a quick rundown of what you get from each naming convention:
-
-- **st**: this is where our core features like `st.write` and `st.dataframe` live. If we ever make backward-incompatible changes to these, they will take place gradually and with months of announcements and warnings.
-- **experimental**: this is where we'll put all new features that may or may not ever make it into Streamlit core. This gives you a chance to try the next big thing we're cooking up weeks or months before we're ready to stabilize its API. We don't know whether these features have a future, but we want you to have access to everything we're trying, and work with us to figure them out.
-
-### Experimental
-
-Features with the `experimental_` naming convention are things that we're still working on or trying
-to understand. If these features are successful, at some point they'll become part of Streamlit
-core. If unsuccessful, these features are removed without much notice. While in experimental, a feature's API and behaviors may not be stable, and it's possible they could change in ways that aren't backward-compatible.
-
-<Warning>
-
-Experimental features and their APIs may change or be removed at any time.
-
-</Warning>
-
-**The lifecycle of an experimental feature**
-
-1. A feature is added with the `experimental_` prefix.
-2. The feature is potentially tweaked over time, with possible API/behavior breakages.
-3. If successful, we promote the feature to Streamlit core and remove it from `experimental_`:
-   - a\. The feature's API stabilizes and the feature is _cloned_ without the `experimental_` prefix, so it exists as both `st` and `experimental_`. At this point, users will see a warning when using the version of the feature with the `experimental_` prefix -- but the feature will still work.
-   - b\. At some point, the code of the `experimental_`-prefixed feature is _removed_, but there will still be a stub of the function prefixed with `experimental_` that shows an error with appropriate instructions.
-   - c\. Finally, at a later date the `experimental_` version is removed.
-4. If unsuccessful, the feature is removed without much notice and we leave a stub in `experimental_` that shows an error with instructions.

--- a/content/library/advanced-features/prerelease-features.md
+++ b/content/library/advanced-features/prerelease-features.md
@@ -8,7 +8,7 @@ slug: /library/advanced-features/prerelease
 At Streamlit, we like to move quick while keeping things stable. In our latest effort to move even faster without sacrificing stability, we're offering our bold and fearless users two ways to try out Streamlit's bleeding-edge features:
 
 1. [Nightly releases](#nightly-releases)
-2. [Beta and experimental features](#beta-and-experimental-features)
+2. [Experimental features](#experimental-features)
 
 ## Nightly releases
 
@@ -49,43 +49,20 @@ If you'd like to use a specific version, you can find the version number in our 
 
 If you'd like to review the changes for a nightly release, you can use the [comparison tool on GitHub](https://github.com/streamlit/streamlit/compare/0.57.3...0.57.4.dev20200412).
 
-## Beta and Experimental Features
+## Experimental Features
 
-In addition to nightly releases, we also have two naming conventions for less stable Streamlit features: `st.beta_` and `st.experimental_`. These distinctions are prefixes we attach to our function names to make sure their status is clear to everyone.
+In addition to nightly releases, we also have one naming convention for less stable Streamlit features: `st.experimental_`. This distinction is a prefix we attach to our command names to make sure their status is clear to everyone.
 
 Here's a quick rundown of what you get from each naming convention:
 
 - **st**: this is where our core features like `st.write` and `st.dataframe` live. If we ever make backward-incompatible changes to these, they will take place gradually and with months of announcements and warnings.
-- **beta**: this is where all new features land before they becoming part of Streamlit core. This gives you a chance to try the next big thing we're cooking up weeks or months before we're ready to stabilize its API.
-- **experimental**: this is where we'll put features that may or may not ever make it into Streamlit core. We don't know whether these features have a future, but we want you to have access to everything we're trying, and work with us to figure them out.
-
-The main difference between `beta_` and `experimental_` is that beta features are expected to make it into Streamlit core at some point soon, while experimental features may never make it.
-
-### Beta
-
-Features with the `beta_` naming convention are all scheduled to become part of Streamlit core.
-While in beta, a feature's API and behaviors may not be stable, and it's possible they could change
-in ways that aren't backward-compatible.
-
-**The lifecycle of a beta feature**
-
-1. A feature is added with the `beta_` prefix.
-
-2. The feature's API stabilizes and the feature is _cloned_ without the `beta_` prefix, so it exists
-   as both `st` and `beta_`. At this point, users will see a warning when using the version of the
-   feature with the `beta_` prefix -- but the feature will still work.
-
-3. At some point, the code of the `beta_`-prefixed feature is _removed_, but there will still be a
-   stub of the function prefixed with `beta_` that shows an error with appropriate instructions.
-
-4. Finally, at a later date the `beta_` version is removed.
+- **experimental**: this is where we'll put all new features that may or may not ever make it into Streamlit core. This gives you a chance to try the next big thing we're cooking up weeks or months before we're ready to stabilize its API. We don't know whether these features have a future, but we want you to have access to everything we're trying, and work with us to figure them out.
 
 ### Experimental
 
 Features with the `experimental_` naming convention are things that we're still working on or trying
 to understand. If these features are successful, at some point they'll become part of Streamlit
-core, by moving to the `beta_` naming convention and then to Streamlit core. If unsuccessful, these
-features are removed without much notice.
+core. If unsuccessful, these features are removed without much notice. While in experimental, a feature's API and behaviors may not be stable, and it's possible they could change in ways that aren't backward-compatible.
 
 <Warning>
 
@@ -97,4 +74,8 @@ Experimental features and their APIs may change or be removed at any time.
 
 1. A feature is added with the `experimental_` prefix.
 2. The feature is potentially tweaked over time, with possible API/behavior breakages.
-3. At some point, we either promote the feature to `beta_` or remove it from `experimental_`. Either way, we leave a stub in `experimental_` that shows an error with instructions.
+3. If successful, we promote the feature to Streamlit core and remove it from `experimental_`:
+   - a\. The feature's API stabilizes and the feature is _cloned_ without the `experimental_` prefix, so it exists as both `st` and `experimental_`. At this point, users will see a warning when using the version of the feature with the `experimental_` prefix -- but the feature will still work.
+   - b\. At some point, the code of the `experimental_`-prefixed feature is _removed_, but there will still be a stub of the function prefixed with `experimental_` that shows an error with appropriate instructions.
+   - c\. Finally, at a later date the `experimental_` version is removed.
+4. If unsuccessful, the feature is removed without much notice and we leave a stub in `experimental_` that shows an error with instructions.

--- a/content/library/api-cheat-sheet.md
+++ b/content/library/api-cheat-sheet.md
@@ -47,7 +47,7 @@ pip uninstall streamlit
 pip install streamlit-nightly --upgrade
 ```
 
-Learn more about [beta and experimental features](advanced-features/prerelease#beta-and-experimental-features)
+Learn more about [experimental features](advanced-features/prerelease#experimental-features)
 
 </CodeTile>
 

--- a/content/library/api/control-flow/experimental_rerun.md
+++ b/content/library/api/control-flow/experimental_rerun.md
@@ -6,7 +6,7 @@ description: st.experimental_rerun will rerun the script immediately.
 
 <Important>
 
-This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#beta-and-experimental-features).
+This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#experimental-features).
 
 </Important>
 

--- a/content/library/api/performance/experimental-memo-clear.md
+++ b/content/library/api/performance/experimental-memo-clear.md
@@ -6,7 +6,7 @@ description: st.experimental_memo.clear clears all in-memory and on-disk memo ca
 
 <Important>
 
-This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#beta-and-experimental-features).
+This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#experimental-features).
 
 </Important>
 

--- a/content/library/api/performance/experimental-memo.md
+++ b/content/library/api/performance/experimental-memo.md
@@ -6,7 +6,7 @@ description: st.experimental_memo is used to memoize function executions.
 
 <Important>
 
-This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#beta-and-experimental-features).
+This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#experimental-features).
 
 </Important>
 

--- a/content/library/api/performance/experimental-singleton-clear.md
+++ b/content/library/api/performance/experimental-singleton-clear.md
@@ -6,7 +6,7 @@ description: st.experimental_singleton.clear clears all singleton caches.
 
 <Important>
 
-This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#beta-and-experimental-features).
+This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#experimental-features).
 
 </Important>
 

--- a/content/library/api/performance/experimental-singleton.md
+++ b/content/library/api/performance/experimental-singleton.md
@@ -6,7 +6,7 @@ description: st.experimental_singleton is a function decorator used to store sin
 
 <Important>
 
-This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#beta-and-experimental-features).
+This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#experimental-features).
 
 </Important>
 

--- a/content/library/api/personalization/experimental-user.md
+++ b/content/library/api/personalization/experimental-user.md
@@ -8,7 +8,7 @@ description: st.experimental_user returns information about the logged-in user o
 
 <Important>
 
-This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#beta-and-experimental-features).
+This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#experimental-features).
 
 </Important>
 
@@ -167,4 +167,4 @@ if st.experimental_user.email:
 
 - `st.experimental_user` is **read-only**. You cannot update or modify its value. Doing so will throw a `StreamlitAPIException`.
 - A valid email is returned only if the user is logged in to Streamlit Cloud and the app is private. Else, `None` or test@localhost.com is returned.
-- This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#beta-and-experimental-features).
+- This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#experimental-features).

--- a/content/library/api/utilities/experimental_get_query_params.md
+++ b/content/library/api/utilities/experimental_get_query_params.md
@@ -6,7 +6,7 @@ description: st.experimental_get_query_params returns query parameters currently
 
 <Important>
 
-This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#beta-and-experimental-features).
+This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#experimental-features).
 
 </Important>
 

--- a/content/library/api/utilities/experimental_set_query_params.md
+++ b/content/library/api/utilities/experimental_set_query_params.md
@@ -6,7 +6,7 @@ description: st.experimental_set_query_params sets query parameters shown in the
 
 <Important>
 
-This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#beta-and-experimental-features).
+This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#experimental-features).
 
 </Important>
 

--- a/content/library/api/utilities/experimental_show.md
+++ b/content/library/api/utilities/experimental_show.md
@@ -6,7 +6,7 @@ description: st.experimental_show writes arguments and argument names to your ap
 
 <Important>
 
-This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#beta-and-experimental-features).
+This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#experimental-features).
 
 </Important>
 


### PR DESCRIPTION
## 📚 Context

`_beta` features are [no longer used](https://www.notion.so/streamlit/Remove-explanation-of-_beta-from-docs-cff9d6d9d6e042988db86a17ae068b71) in the API. Less stable features in the future will first go into `_experimental` before either becoming a part of Streamlit core (`st.`) or being removed entirely. As such, we should not talk about `_beta` features in the docs.

## 🧠 Description of Changes

- Removes mentions of `_beta` features and restructures section to talk only about the lifecycle of `_experimental` features
- Fixes URL anchors as a result of the change in heading from `Beta and experimental features` -> `Experimental features`
- Moves the experimental features section above nightly releases. We don’t need to advertise nightly and don’t want to push users to install it. See Notion doc below for context.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Remove-explanation-of-_beta-from-docs-cff9d6d9d6e042988db86a17ae068b71)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
