### PR TITLE
Fix typo in MPA blog post link

### DIFF
--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -23,7 +23,7 @@ _Release date: June 2, 2022_
 
 **Highlights**
 
-- 📖 Introducing native support for multipage apps! Check out our [blog post](https://blog.streamlt.io/introducing-multipage-apps) and try out our new `streamlit hello`.
+- 📖 Introducing native support for multipage apps! Check out our [blog post](https://blog.streamlit.io/introducing-multipage-apps) and try out our new `streamlit hello`.
 
 **Notable Changes**
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -152,7 +152,7 @@ export default function Home({ window, menu, gdpr_data }) {
                 date="2022-06-02T16:05:00.000Z"
                 title="Introducing multipage apps! 📄"
                 text="Quickly and easily add more pages to your Streamlit apps."
-                link="https://blog.streamlt.io/introducing-multipage-apps"
+                link="https://blog.streamlit.io/introducing-multipage-apps"
               />
               <NewsEntry
                 date="2022-05-26T16:05:00.000Z"


### PR DESCRIPTION
## 📚 Context

There's a missing `i` in the URL of the MPA blog post. This PR fixes the link.