### PR TITLE
Update installation instructions for macOS

### DIFF
--- a/content/library/get-started/installation.md
+++ b/content/library/get-started/installation.md
@@ -17,7 +17,7 @@ Before you get started, you're going to need a few things:
 
 - Your favorite IDE or text editor
 - [Python 3.7 - Python 3.10](https://www.python.org/downloads/)
-- [PIP](https://pip.pypa.io/en/stable/installing/)
+- [PIP](https://pip.pypa.io/en/stable/installation/)
 
 If you haven't already, take a few minutes to read through [Main
 concepts](/library/get-started/main-concepts) to understand Streamlit's data flow model.

--- a/content/library/get-started/installation.md
+++ b/content/library/get-started/installation.md
@@ -106,6 +106,14 @@ Streamlit's officially-supported environment manager for macOS and Linux is [Pip
    pip3 install pipenv
    ```
 
+### Install Xcode command line tools on macOS
+
+On macOS, you'll need to install Xcode command line tools. They are required to compile some of Streamlit's Python dependencies during installation. To install Xcode command line tools, run:
+
+```sh
+xcode-select --install
+```
+
 ### Create a new environment with Streamlit
 
 1. Navigate to your project folder:

--- a/content/library/get-started/installation.md
+++ b/content/library/get-started/installation.md
@@ -84,12 +84,12 @@ Streamlit's officially-supported environment manager for macOS and Linux is [Pip
 
 ### Install Pipenv
 
-1. Install `pip`.
+1. Install `pip`. More details about installing `pip` can be found in [pip's documentation](https://pip.pypa.io/en/stable/installation/#supported-methods).
 
    On a macOS:
 
    ```sh
-   sudo easy_install pip
+   python -m ensurepip --upgrade
    ```
 
    On Ubuntu with Python 3:


### PR DESCRIPTION
## 📚 Context
 
`easy_install` is no longer how you install `pip`. The [correct way](https://pip.pypa.io/en/stable/installation/#supported-methods) to do this is:

```sh
python -m ensurepip --upgrade
```

Additionally, Xcode command line tools are required on macOS to compile some Streamlit Python deps from C. We don't mention this in the docs. Both issues were originally [reported on Twitter](https://twitter.com/thor_lindberg/status/1534203971379904512).

## 🧠 Description of Changes

- Replaced `easy_install` with the `ensurepip` method for macOS
- Added a section on how to install Xcode command line tools on macOS
- Replaced link to pip's installation docs as they have moved

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Replace-easy_install-with-ensurepip-in-docs-ef08f33678fa4a7385c9d0ff1ed3baca)
- [x] [Notion](https://www.notion.so/streamlit/Mention-XCode-fix-in-installation-docs-50846ae60da04e95b18bf775f6314cbd)
- [x] [Twitter](https://twitter.com/thor_lindberg/status/1534203971379904512) 

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
