### PR TITLE
Make one-line docstring descriptions respect dark mode

### DIFF
--- a/styles/text.scss
+++ b/styles/text.scss
@@ -115,3 +115,8 @@ li > code {
 p a code {
   @apply border-none p-0;
 }
+
+/* One-line code descriptions in docstrings */
+div.code-desc {
+  @apply mb-4 text-gray-90 dark:text-white;
+}


### PR DESCRIPTION
## 📚 Context

One-line descriptions in docstrings on API ref pages don't respect dark mode. For multiline descriptions, each line is wrapped in a `<p></p>` tag -- so it respects dark mode because CSS for that exists.

## 🧠 Description of Changes

- Styled one-line descriptions in docstrings identical to how `<p>` is styled.

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/172815268-b72e427a-c4ff-4440-aa29-e685b534391a.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/172815556-0759cab3-1b1a-40a3-bed5-5db045aea8c2.png)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
