### PR TITLE
Reorder menu to make installation appear before main concepts

### DIFF
--- a/content/library/get-started/index.md
+++ b/content/library/get-started/index.md
@@ -9,11 +9,11 @@ This Get Started guide explains how Streamlit works, how to install Streamlit on
 operating system, and how to create your first Streamlit app!
 
 <InlineCalloutContainer>
-  <InlineCallout color="violet-70" icon="description" bold="Main concepts" href="/library/get-started/main-concepts">
-    introduces you to Streamlit's data model and development flow. You'll learn what makes Streamlit the most powerful way to build data apps, including the ability to display and style data, draw charts and maps, add interactive widgets, customize app layouts, cache computation, and define themes.
-  </InlineCallout>
   <InlineCallout color="violet-70" icon="downloading" bold="Installation" href="/library/get-started/installation">
     helps you set up your virtual environment and walks you through installing Streamlit on Windows, macOS, and Linux. Regardless of which package management tool and OS you're using, we recommend running the commands on this page in a virtual environment.
+  </InlineCallout>
+  <InlineCallout color="violet-70" icon="description" bold="Main concepts" href="/library/get-started/main-concepts">
+    introduces you to Streamlit's data model and development flow. You'll learn what makes Streamlit the most powerful way to build data apps, including the ability to display and style data, draw charts and maps, add interactive widgets, customize app layouts, cache computation, and define themes.
   </InlineCallout>
   <InlineCallout color="violet-70" icon="auto_awesome" bold="Create an app" href="/library/get-started/create-an-app">
     using Streamlit's core features to fetch and cache data, draw charts, plot information on a map, and use interactive widgets, like a slider, to filter results.

--- a/content/library/get-started/installation.md
+++ b/content/library/get-started/installation.md
@@ -19,9 +19,6 @@ Before you get started, you're going to need a few things:
 - [Python 3.7 - Python 3.10](https://www.python.org/downloads/)
 - [PIP](https://pip.pypa.io/en/stable/installing/)
 
-If you haven't already, take a few minutes to read through [Main
-concepts](/library/get-started/main-concepts) to understand Streamlit's data flow model.
-
 ## Set up your virtual environment
 
 Regardless of which package management tool you're using, we recommend running
@@ -159,3 +156,5 @@ Streamlit's officially-supported environment manager for macOS and Linux is [Pip
    To stop the Streamlit server, press `ctrl-C`.
 
 3. When you're done using this environment, just type `exit` or press `ctrl-D` to return to your normal shell.
+
+Now that you've installed Streamlit, take a few minutes to read through [Main concepts](/library/get-started/main-concepts) to understand Streamlit's data flow model.

--- a/content/menu.md
+++ b/content/menu.md
@@ -6,10 +6,10 @@ site_menu:
     icon: description
   - category: Streamlit library / Get started
     url: /library/get-started
-  - category: Streamlit library / Get started / Main concepts
-    url: /library/get-started/main-concepts
   - category: Streamlit library / Get started / Installation
     url: /library/get-started/installation
+  - category: Streamlit library / Get started / Main concepts
+    url: /library/get-started/main-concepts
   - category: Streamlit library / Get started / Create an app
     url: /library/get-started/create-an-app
   - category: Streamlit library / Get started / Multipage apps


### PR DESCRIPTION
## 📚 Context

We should encourage users to install Streamlit first and then explain Streamlit's data flow model. Our docs currently make users read through the main concepts before telling them how to install Streamlit.

## 🧠 Description of Changes

- Switched the ordering of Installation and Main concepts in the menu and Get started page.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/Multipage-apps-docs-1cdc74d1970a40d58fb678671093806f?d=3c15f32b57664350ad49a92a60ee6e40)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
