### PR TITLE
Add refcards for memo+singleton clear commands to Performance

### DIFF
--- a/content/library/api/performance/performance.md
+++ b/content/library/api/performance/performance.md
@@ -50,4 +50,42 @@ def get_database_session(url):
 ```
 
 </RefCard>
+
+<RefCard href="/library/api-reference/performance/st.experimental_memo.clear">
+
+#### Clear memo
+
+Clear all in-memory and on-disk memo caches.
+
+```python
+@st.experimental_memo
+def fetch_and_clean_data(url):
+  # Fetch data from URL here, and then clean it up.
+  return data
+
+if st.checkbox("Clear All"):
+  # Clear values from *all* memoized functions
+  st.experimental_memo.clear()
+```
+
+</RefCard>
+
+<RefCard href="/library/api-reference/performance/st.experimental_singleton.clear">
+
+#### Clear singleton
+
+Clear all singleton caches.
+
+```python
+@st.experimental_singleton
+def get_database_session(url):
+  # Create a database session object that points to the URL.
+  return session
+
+if st.button("Clear All"):
+  # Clears all singleton caches:
+  st.experimental_singleton.clear()
+```
+
+</RefCard>
 </TileContainer>


### PR DESCRIPTION
## 📚 Context

The "Optimize performance" page in the API reference is missing cards for `st.singleton.clear` and `st.memo.clear`.

## 🧠 Description of Changes

- Add refcards for memo+singleton clear commands to "Optimize performance" page

**Revised:**

<details><summary>View revised</summary>

![image](https://user-images.githubusercontent.com/20672874/174056514-481777b1-971f-43d2-a083-90406f2cb574.png)

</details>

**Current:**

<details open><summary>View current</summary>

![image](https://user-images.githubusercontent.com/20672874/174056410-3c6b6cf7-ef40-4dca-8303-96a48aa8056c.png)

</details>

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->