### PR TITLE
Add docs for st.tabs

### DIFF
--- a/content/library/api/layout/layout.md
+++ b/content/library/api/layout/layout.md
@@ -38,6 +38,20 @@ col1.write("this is column 1")
 col2.write("this is column 2")
 ```
 
+<RefCard href="/library/api-reference/layout/st.empty">
+
+<Image pure alt="screenshot" src="/images/api/TBD.jpg" />
+
+#### Tabs
+
+Insert containers seperated into tabs.
+
+```python
+tab1, tab2 = st.tabs(["Tab 1", "Tab2"])
+tab1.write("this is tab 1")
+tab2.write("this is tab 2")
+```
+
 </RefCard>
 <RefCard href="/library/api-reference/layout/st.expander">
 

--- a/content/library/api/layout/tabs.md
+++ b/content/library/api/layout/tabs.md
@@ -1,0 +1,7 @@
+---
+title: st.tabs
+slug: /library/api-reference/layout/st.tabs
+description: st.tabs inserts containers seperated into tabs.
+---
+
+<Autofunction function="streamlit.tabs" />

--- a/content/menu.md
+++ b/content/menu.md
@@ -173,6 +173,9 @@ site_menu:
   - category: Streamlit library / API reference / Layouts and containers / st.columns
     url: /library/api-reference/layout/st.columns
     isVersioned: true
+  - category: Streamlit library / API reference / Layouts and containers / st.tabs
+    url: /library/api-reference/layout/st.tabs
+    isVersioned: true
   - category: Streamlit library / API reference / Layouts and containers / st.expander
     url: /library/api-reference/layout/st.expander
     isVersioned: true

--- a/python/api-examples-source/layout.tabs1.py
+++ b/python/api-examples-source/layout.tabs1.py
@@ -1,0 +1,14 @@
+import streamlit as st
+
+tab1, tab2, tab3 = st.tabs(["Cat", "Dog", "Owl"])
+with tab1:
+    st.header("A cat")
+    st.image("https://static.streamlit.io/examples/cat.jpg", width=200)
+
+with tab2:
+    st.header("A dog")
+    st.image("https://static.streamlit.io/examples/dog.jpg", width=200)
+
+with tab3:
+    st.header("An owl")
+    st.image("https://static.streamlit.io/examples/owl.jpg", width=200)

--- a/python/api-examples-source/layout.tabs2.py
+++ b/python/api-examples-source/layout.tabs2.py
@@ -1,0 +1,11 @@
+import streamlit as st
+import numpy as np
+
+tab1, tab2 = st.tabs(["📈 Chart", "🗃 Data"])
+data = np.random.randn(10, 1)
+
+tab1.subheader("A tab with a chart")
+tab1.line_chart(data)
+
+tab2.subheader("A tab with the data")
+tab2.write(data)


### PR DESCRIPTION
## 📚 Context

Add documentation for the new `st.tabs` component (feature PR for the `st.tabs` component: https://github.com/streamlit/streamlit/pull/4898).

## 🧠 Description of Changes

- Add docs page for `st.tabs`
- Link page in menu and in layout section.
- Add two example scripts as linked in the docstring.

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
