### PR TITLE
fix the username for uploading wheel to PyPi

### DIFF
--- a/content/library/components/publish-component.md
+++ b/content/library/components/publish-component.md
@@ -77,7 +77,7 @@ With your wheel created, the final step is to upload to PyPI. The instructions h
 
    - Visit [https://test.pypi.org/manage/account/#api-tokens](https://test.pypi.org/manage/account/#api-tokens) and create a new API token. Don’t limit the token scope to a particular project, since you are creating a new project. Copy your token before closing the page, as you won’t be able to retrieve it again.
 
-2. Upload your wheel to Test PyPI. `twine` will prompt you for a username and password. For the username, use **token**. For the password, use your token value from the previous step, including the `pypi-` prefix:
+2. Upload your wheel to Test PyPI. `twine` will prompt you for a username and password. For the username, use **\_\_token\_\_**. For the password, use your token value from the previous step, including the `pypi-` prefix:
 
    ```shell
    python3 -m twine upload --repository testpypi dist/*


### PR DESCRIPTION


## 📚 Context

<!-- Why do you want to make this change? What background should the reviewer know? -->

## 🧠 Description of Changes

when uploading a wheel to PyPi or Test PyPi, the user name should be `__token__` rather than `token`


## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References
https://pypi.org/help/#apitoken
<img width="498" alt="image" src="https://user-images.githubusercontent.com/19774198/178062241-4c81c1e2-fe19-4aa1-998b-649e7ee8bdce.png">


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
