### PR TITLE
Fix streamlit run command in KB article

### DIFF
--- a/content/kb/using-streamlit/how-run-my-streamlit-script.md
+++ b/content/kb/using-streamlit/how-run-my-streamlit-script.md
@@ -15,7 +15,7 @@ Once you've created your script, say `your_script.py`, the easiest way to run it
 streamlit run your_script.py
 ```
 
-As soon as you run the script as shown above, a local Streamlit server will spin up and your app will open in a new tab your default web browser.
+As soon as you run the script as shown above, a local Streamlit server will spin up and your app will open in a new tab in your default web browser.
 
 ### Pass arguments to your script
 
@@ -39,7 +39,7 @@ Another way of running Streamlit is to run it as a Python module. This is useful
 
 ```bash
 # Running
-python -m streamlit your_script.py
+python -m streamlit run your_script.py
 ```
 
 ```bash


### PR DESCRIPTION
## 📚 Context

A KB [article](https://docs.streamlit.io/knowledge-base/using-streamlit/how-do-i-run-my-streamlit-script) omits `run` from `python -m streamlit your_script.py`.

## 🧠 Description of Changes

Adds the missing `run`.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->