### PR TITLE
Update st.dataframe and st.table CSS hack in KB

### DIFF
--- a/content/kb/using-streamlit/hide-row-indices-display-dataframe.md
+++ b/content/kb/using-streamlit/hide-row-indices-display-dataframe.md
@@ -65,6 +65,12 @@ st.table(df)
 
 ## Hide row indices with st.dataframe
 
+<Warning>
+
+The below workaround for [`st.dataframe`](/library/api-reference/data/st.dataframe) does not work for `streamlit>=1.10.0`.
+
+</Warning>
+
 ```python
 import streamlit as st
 import pandas as pd

--- a/content/kb/using-streamlit/hide-row-indices-display-dataframe.md
+++ b/content/kb/using-streamlit/hide-row-indices-display-dataframe.md
@@ -49,8 +49,8 @@ df = pd.DataFrame(
 # CSS to inject contained in a string
 hide_table_row_index = """
             <style>
+            thead tr th:first-child {display:none}
             tbody th {display:none}
-            .blank {display:none}
             </style>
             """
 


### PR DESCRIPTION
## 📚 Context

With the new dataframe backend (canvas) from Streamlit 1.10.0, a CSS hack to hide the dataframe index with `st.dataframe` no longer works.

## 🧠 Description of Changes

- Added a warning saying the hack does not work for `streamlit>=1.10.0`
- Replaced the stylesheet for the `st.table` hack with a more robust one by @naokimaejima in the below issue
- Closes #439 

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Update-KB-article-on-hiding-index-in-st-dataframe-0bff656618084ef6950c962866b5956b)
- [x] [Issue 439](#439)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
