### PR TITLE
Fix: typo in layout page

### DIFF
--- a/content/library/api-cheat-sheet.md
+++ b/content/library/api-cheat-sheet.md
@@ -156,7 +156,7 @@ st.video(data)
 #### Tabs
 
 ```python
-# Insert containers seperated into tabs:
+# Insert containers separated into tabs:
 >>> tab1, tab2 = st.tabs(["Tab 1", "Tab2"])
 >>> tab1.write("this is tab 1")
 >>> tab2.write("this is tab 2")

--- a/content/library/api/api-reference.md
+++ b/content/library/api/api-reference.md
@@ -648,7 +648,7 @@ col2.write("this is column 2")
 
 #### Tabs
 
-Insert containers seperated into tabs.
+Insert containers separated into tabs.
 
 ```python
 tab1, tab2 = st.tabs(["Tab 1", "Tab2"])

--- a/content/library/api/layout/layout.md
+++ b/content/library/api/layout/layout.md
@@ -45,7 +45,7 @@ col2.write("this is column 2")
 
 #### Tabs
 
-Insert containers seperated into tabs.
+Insert containers separated into tabs.
 
 ```python
 tab1, tab2 = st.tabs(["Tab 1", "Tab2"])

--- a/content/library/api/layout/tabs.md
+++ b/content/library/api/layout/tabs.md
@@ -1,7 +1,7 @@
 ---
 title: st.tabs
 slug: /library/api-reference/layout/st.tabs
-description: st.tabs inserts containers seperated into tabs.
+description: st.tabs inserts containers separated into tabs.
 ---
 
 <Autofunction function="streamlit.tabs" />

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -169,7 +169,7 @@ collections:
       - label: Page Catgeory
         name: category
         widget: string
-        hint: "Categories should be seperated by back slashes (Parent / Child / Child)"
+        hint: "Categories should be separated by back slashes (Parent / Child / Child)"
       - label: Body
         name: body
         widget: markdown


### PR DESCRIPTION
## 📚 Context

Same typo (seperated -> separated) was fixed in https://github.com/streamlit/docs/pull/433, but not on the parent page.

## 🧠 Description of Changes

Seperated -> separated

**Current:**

<img width="273" alt="image" src="https://user-images.githubusercontent.com/9258253/181470659-c51851f6-70be-48cd-b30e-633b002d8885.png">


## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
