### PR TITLE
Embed st.write and magic video tutorial to API reference

### DIFF
--- a/content/library/api/write-magic/magic.md
+++ b/content/library/api/write-magic/magic.md
@@ -55,3 +55,9 @@ magicEnabled = false
 <Important>
     <p>Right now, Magic only works in the main Python app file, not in imported files. See GitHub issue #288 for a discussion of the issues.</p>
 </Important>
+
+## Featured video
+
+Learn what the [`st.write`](/library/api-reference/write-magic/st.write) and [magic](/library/api-reference/write-magic/magic) commands are and how to use them.
+
+<YouTube videoId="wpDuY9I2fDg" />

--- a/content/library/api/write-magic/write.md
+++ b/content/library/api/write-magic/write.md
@@ -5,3 +5,9 @@ description: st.write writes arguments to the app.
 ---
 
 <Autofunction function="streamlit.write" />
+
+## Featured video
+
+Learn what the [`st.write`](/library/api-reference/write-magic/st.write) and [magic](/library/api-reference/write-magic/magic) commands are and how to use them.
+
+<YouTube videoId="wpDuY9I2fDg" />


### PR DESCRIPTION
## 🧠 Description of Changes\

- Embeds Chanin's [YouTube tutorial](https://www.youtube.com/watch?v=wpDuY9I2fDg) on `st.write` and magic commands to their API reference pages.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->