### PR TITLE
Add description to Optimize performance API reference page

### DIFF
--- a/content/library/api/performance/performance.md
+++ b/content/library/api/performance/performance.md
@@ -5,6 +5,10 @@ slug: /library/api-reference/performance
 
 # Optimize performance
 
+Streamlit provides powerful [cache primitives](/library/advanced-features/experimental-cache-primitives) for memoization and storing heavyweight singleton objects across sessions. They allow your app to stay performant even when loading data from the web, caching the results of expensive computations, and storing singleton objects (like TensorFlow/Torch/Keras sessions and/or database connections).
+
+The two new primitives: `st.experimental_memo` and `st.experimental_singleton` are conceptually simpler and much, much faster than [@st.cache](/library/advanced-features/caching), with the potentional to replace `@st.cache` at some point in 2022.
+
 <TileContainer>
 <RefCard href="/library/api-reference/performance/st.cache">
 


### PR DESCRIPTION
## 📚 Context

Each child page / category in the API reference should have a short description of what the commands belonging to that category do. The `Optimize performance` page in the API reference is missing such a description.  

## 🧠 Description of Changes

- Adds a short description to "Optimize performance" in the "API reference" of what the cache primitives do
- Links to the experimental primitives page and the general caching with st.cache page.

**Revised:**

<details><summary>Revised screenshot</summary>

![image](https://user-images.githubusercontent.com/20672874/182593957-3605b645-bb53-40bb-a7f8-82ea7a883453.png)
</details>

**Current:**

<details><summary>Current screenshot</summary>

![image](https://user-images.githubusercontent.com/20672874/182594012-43a634bc-ba9a-47f2-9d8d-20f8676d5bec.png)
</details>

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Add-short-description-in-the-Optimize-Performance-API-reference-page-ddbe421f56474ddca16beb8818593f42)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
