### PR TITLE
Update install-package-pypi-github.md

### DIFF
--- a/content/kb/dependencies/install-package-pypi-github.md
+++ b/content/kb/dependencies/install-package-pypi-github.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/dependencies/install-package-not-pypi-conda-available-gith
 
 ## Overview
 
-Are you trying to deploy your app to [Streamlit Cloud](/streamlit-cloud), but don't know how to specify a [Python dependency](/streamlit-cloud/get-started/deploy-an-app/app-dependencies#add-python-dependencies) in your requirements file that is available on GitHub but not any package index like PyPI or Conda? If so, continue reading to find out how!
+Are you trying to deploy your app to [Streamlit Cloud](/streamlit-cloud), but don't know how to specify a [Python dependency](/streamlit-cloud/get-started/deploy-an-app/app-dependencies#add-python-dependencies) in your requirements file that is available on a public GitHub repo but not any package index like PyPI or Conda? If so, continue reading to find out how!
 
 Let's suppose you want to install `SomePackage` and its Python dependencies from GitHub, a hosting service for the popular version control system (VCS) Git. And suppose `SomePackage` is found at the the following URL: `https://github.com/SomePackage.git`.
 
@@ -46,5 +46,13 @@ Install `SomePackage` by specifying a tag in `requirements.txt`:
 ```bash
 git+https://github.com/SomePackage.git@v1.1.0#egg=SomePackage
 ```
-## Known limitations
-* It is currently ot possible to install a private package from github that requires the use of a token in the url in `requirements.txt` that is stored as an environment variable using the [app settings for secrets](https://docs.readthedocs.io/en/stable/guides/private-python-packages.html), as [documented here](https://docs.readthedocs.io/en/stable/guides/private-python-packages.html).
+
+## Limitations
+
+It is currently **not possible** to install private packages from private GitHub repos using the URI form:
+
+```bash
+git+https://{token}@github.com/user/project.git@{version}
+```
+
+where `version` is a tag, a branch, or a commit. And `token` is a personal access token with read only permissions. Streamlit Cloud only supports installing public packages from public GitHub repos.

--- a/content/kb/dependencies/install-package-pypi-github.md
+++ b/content/kb/dependencies/install-package-pypi-github.md
@@ -46,3 +46,5 @@ Install `SomePackage` by specifying a tag in `requirements.txt`:
 ```bash
 git+https://github.com/SomePackage.git@v1.1.0#egg=SomePackage
 ```
+## Known limitations
+* It is currently ot possible to install a private package from github that requires the use of a token in the url in `requirements.txt` that is stored as an environment variable using the [app settings for secrets](https://docs.readthedocs.io/en/stable/guides/private-python-packages.html), as [documented here](https://docs.readthedocs.io/en/stable/guides/private-python-packages.html).


### PR DESCRIPTION
Proposing an update to this documentation in response to this forum thread: 
https://discuss.streamlit.io/t/can-you-use-secrets-as-environment-variable-for-use-in-requirements-txt/28881

## 📚 Context

Helpful information from forum representative here:
https://discuss.streamlit.io/t/can-you-use-secrets-as-environment-variable-for-use-in-requirements-txt/28881

## 🧠 Description of Changes

Proposed a known limitations section for documentation of the use packages not listed in PyPy of conda.

**Revised:**

Added "Known Limitations" section to this document with example Secrets manager not creating environment variables that can be used by pip installer.

**Current:**

Section did not exist.

## 💥 Impact

Narrow applicability, but useful to users referencing private git repositories in the requirements.txt file

Size:

- [X] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
