### PR TITLE
Fix docstring generation for memo+singleton with v1.12.0

### DIFF
--- a/python/generate.py
+++ b/python/generate.py
@@ -1,20 +1,21 @@
 #!/usr/bin/python
 
-import sys
-import types
-import json
 import inspect
-import docstring_parser
-import stoutput
+import json
 import logging
 import pathlib
-import utils
+import sys
+import types
+
+import docstring_parser
 import streamlit
 import streamlit.components.v1 as components
-
 from docutils.core import publish_parts
 from docutils.parsers.rst import directives
 from numpydoc.docscrape import NumpyDocString
+
+import stoutput
+import utils
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
@@ -165,8 +166,8 @@ def get_obj_docstring_dict(obj, key_prefix, signature_prefix):
     allowed_types = (
         types.FunctionType, 
         types.MethodType,
-        streamlit.caching.memo_decorator.MemoAPI,
-        streamlit.caching.singleton_decorator.SingletonAPI
+        streamlit.runtime.caching.memo_decorator.MemoAPI,
+        streamlit.runtime.caching.singleton_decorator.SingletonAPI
     )
 
     for membername in dir(obj):
@@ -183,7 +184,7 @@ def get_obj_docstring_dict(obj, key_prefix, signature_prefix):
         
         # memo and singleton are callable objects rather than functions
         # See: https://github.com/streamlit/streamlit/pull/4263
-        while member in streamlit.caching.__dict__.values():
+        while member in streamlit.runtime.caching.__dict__.values():
             member = member.__call__
 
         fullname = '{}.{}'.format(key_prefix, membername)
@@ -196,8 +197,8 @@ def get_obj_docstring_dict(obj, key_prefix, signature_prefix):
 
 def get_streamlit_docstring_dict():
     module_docstring_dict = get_obj_docstring_dict(streamlit, 'streamlit', 'st')
-    memo_clear_docstring_dict = get_obj_docstring_dict(streamlit.caching.memo, 'streamlit.experimental_memo', 'st.experimental_memo')
-    singleton_clear_docstring_dict = get_obj_docstring_dict(streamlit.caching.singleton, 'streamlit.experimental_singleton', 'st.experimental_singleton')
+    memo_clear_docstring_dict = get_obj_docstring_dict(streamlit.runtime.caching.memo, 'streamlit.experimental_memo', 'st.experimental_memo')
+    singleton_clear_docstring_dict = get_obj_docstring_dict(streamlit.runtime.caching.singleton, 'streamlit.experimental_singleton', 'st.experimental_singleton')
     components_docstring_dict = get_obj_docstring_dict(components, 'streamlit.components.v1', 'st.components.v1')
     delta_docstring_dict = get_obj_docstring_dict(streamlit._DeltaGenerator, 'DeltaGenerator', 'element')
 


### PR DESCRIPTION
## 📚 Context

Between Streamlit 1.11.0 and the upcoming 1.12.0, memo and singleton moved from `streamlit.caching` to the new `streamlit.runtime.caching` package ([#5072](https://github.com/streamlit/streamlit/pull/5072)). We need to account for this change in how we pull docstrings for memo+singleton and their respective `.clear()` commands.

## 🧠 Description of Changes

- Updates `python/generate.py` to replace instances of `streamlit.caching` with `streamlit.runtime.caching`.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Streamlit Issue #5072](https://github.com/streamlit/streamlit/pull/5072)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
