### PR TITLE
Replace time series app link with unique subdomain URL

### DIFF
--- a/content/library/api/charts/altair_chart.md
+++ b/content/library/api/charts/altair_chart.md
@@ -150,4 +150,4 @@ To use images instead of emojis, replace the line containing `.mark_text()` with
 
 Now that you've learned how to annotate charts, the sky's the limit! We've extended the above example to let you interactively paste your favorite emoji and set its position on the chart with Streamlit widgets. 👇
 
-<Cloud src="https://share.streamlit.io/streamlit/example-app-time-series-annotation/main" height="700" />
+<Cloud src="https://streamlit-example-app-time-series-annotati-streamlit-app-vmbrzi.streamlitapp.com/?embedded=true" height="700" />


### PR DESCRIPTION
## 🧠 Description of Changes

- Replaced the share.streamlit.io link for the time series app embedded in the `st.altair_chart` docs with the unique subdomain URL

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
