### PR TITLE
Replace share.streamlit.io app URLs with unique subdomains

### DIFF
--- a/content/kb/using-streamlit/create-anchor-link.md
+++ b/content/kb/using-streamlit/create-anchor-link.md
@@ -27,5 +27,5 @@ st.markdown("[Section 1](#section-1)", unsafe_allow_html=True)
 
 ## Examples
 
-- Demo app: [https://share.streamlit.io/dataprofessor/streamlit/main/anchor_app.py](https://share.streamlit.io/dataprofessor/streamlit/main/anchor_app.py)
+- Demo app: [https://dataprofessor-streamlit-anchor-app-80kk8w.streamlitapp.com/](https://dataprofessor-streamlit-anchor-app-80kk8w.streamlitapp.com/)
 - GitHub repo: [https://github.com/dataprofessor/streamlit/blob/main/anchor_app.py](https://github.com/dataprofessor/streamlit/blob/main/anchor_app.py)

--- a/content/kb/using-streamlit/how-download-file-streamlit.md
+++ b/content/kb/using-streamlit/how-download-file-streamlit.md
@@ -5,7 +5,7 @@ slug: /knowledge-base/using-streamlit/how-download-file-streamlit
 
 # How to download a file in Streamlit?
 
-Use the [`st.download_button`](/library/api-reference/widgets/st.download_button) widget that is natively built into Streamlit. Check out a [sample app](https://share.streamlit.io/streamlit/release-demos/0.88/0.88/streamlit_app.py) demonstrating how you can use `st.download_button` to download common file formats.
+Use the [`st.download_button`](/library/api-reference/widgets/st.download_button) widget that is natively built into Streamlit. Check out a [sample app](https://streamlit-release-demos-0-88streamlit-app-0-88-v8ram3.streamlitapp.com/) demonstrating how you can use `st.download_button` to download common file formats.
 
 ## Example usage
 
@@ -49,6 +49,6 @@ if st.download_button(...):
 
 Additional resources:
 
-- https://blog.streamlit.io/0-88-0-release-notes/
-- https://share.streamlit.io/streamlit/release-demos/0.88/0.88/streamlit_app.py
-- https://docs.streamlit.io/library/api-reference/widgets/st.download_button
+- <https://blog.streamlit.io/0-88-0-release-notes/>
+- <https://streamlit-release-demos-0-88streamlit-app-0-88-v8ram3.streamlitapp.com/>
+- <https://docs.streamlit.io/library/api-reference/widgets/st.download_button>

--- a/content/kb/using-streamlit/how-download-pandas-dataframe-csv.md
+++ b/content/kb/using-streamlit/how-download-pandas-dataframe-csv.md
@@ -5,7 +5,7 @@ slug: /knowledge-base/using-streamlit/how-download-pandas-dataframe-csv
 
 # How to download a Pandas DataFrame as a CSV?
 
-Use the [`st.download_button`](/library/api-reference/widgets/st.download_button) widget that is natively built into Streamlit. Check out a [sample app](https://share.streamlit.io/streamlit/release-demos/0.88/0.88/streamlit_app.py) demonstrating how you can use `st.download_button` to download common file formats.
+Use the [`st.download_button`](/library/api-reference/widgets/st.download_button) widget that is natively built into Streamlit. Check out a [sample app](https://streamlit-release-demos-0-88streamlit-app-0-88-v8ram3.streamlitapp.com/) demonstrating how you can use `st.download_button` to download common file formats.
 
 ## Example usage
 
@@ -33,6 +33,6 @@ st.download_button(
 
 Additional resources:
 
-- https://blog.streamlit.io/0-88-0-release-notes/
-- https://share.streamlit.io/streamlit/release-demos/0.88/0.88/streamlit_app.py
-- https://docs.streamlit.io/library/api-reference/widgets/st.download_button
+- <https://blog.streamlit.io/0-88-0-release-notes/>
+- <https://streamlit-release-demos-0-88streamlit-app-0-88-v8ram3.streamlitapp.com/>
+- <https://docs.streamlit.io/library/api-reference/widgets/st.download_button>

--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -252,7 +252,7 @@ _Release date: Aug 19, 2021_
 
 **Highlights**
 
-- 🔢 Introducing `st.metric`, an API for displaying KPIs. Check out the [demo app](https://share.streamlit.io/streamlit/release-demos/0.87/0.87) showcasing the functionality.
+- 🔢 Introducing `st.metric`, an API for displaying KPIs. Check out the [demo app](https://streamlit-release-demos-0-87streamlit-app-0-87-rfzphf.streamlitapp.com/) showcasing the functionality.
 
 **Other Changes**
 

--- a/content/library/get-started/multipage-apps/create-a-multi-page-app.md
+++ b/content/library/get-started/multipage-apps/create-a-multi-page-app.md
@@ -254,7 +254,7 @@ page_names_to_funcs[demo_name]()
 
 </details>
 
-<Cloud src="https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/hello/hello.py" height="700" />
+<Cloud src="https://doc-hello.streamlitapp.com/?embedded=true" height="700" />
 
 Notice how large the file is! Each app “page” is written as a function, and the selectbox is used to pick which page to display. As our app grows, maintaining the code requires a lot of additional overhead. Moreover, we’re limited by the `st.selectbox` UI to choose which “page” to run, we cannot customize individual page titles with `st.set_page_config`, and we’re unable to navigate between pages using URLs.
 
@@ -551,7 +551,7 @@ streamlit run Hello.py
 
 That’s it! The `Hello.py` script now corresponds to the main page of your app, and other scripts that Streamlit finds in the pages folder will also be present in the new page selector that appears in the sidebar.
 
-<Cloud src="https://share.streamlit.io/streamlit/docs/main/python/api-examples-source/mpa-hello/Hello.py" height="700" />
+<Cloud src="https://doc-mpa-hello.streamlitapp.com/?embedded=true" height="700" />
 
 ## Next steps
 

--- a/content/menu.md
+++ b/content/menu.md
@@ -355,7 +355,7 @@ site_menu:
   - category: Streamlit Cloud / Trust and Security
     url: /streamlit-cloud/trust-and-security
   - category: Streamlit Cloud / Release notes
-    url: https://share.streamlit.io/streamlit/cloud_release_notes_app/main/main.py
+    url: https://streamlit-cloud-release-notes-app-main-jfmm83.streamlitapp.com/
   - category: Streamlit Cloud / Troubleshooting
     url: /streamlit-cloud/troubleshooting
 

--- a/content/streamlit-cloud/get-started/deploy-an-app/index.md
+++ b/content/streamlit-cloud/get-started/deploy-an-app/index.md
@@ -5,7 +5,7 @@ slug: /streamlit-cloud/get-started/deploy-an-app
 
 # Deploy an app
 
-Streamlit Cloud lets you deploy your apps in just one click, and most apps will deploy in only a few minutes. If you don't have an app ready to deploy, [fork or clone one of our example apps](https://share.streamlit.io/streamlit/cloud-example-apps/main?hsCtaTracking=28f10086-a3a5-4ea8-9403-f3d52bf26184%7C22470002-acb1-4d93-8286-00ee4f8a46fb) — you can find apps for machine learning, data visualization, data exploration, A/B testing and more.
+Streamlit Cloud lets you deploy your apps in just one click, and most apps will deploy in only a few minutes. If you don't have an app ready to deploy, [fork or clone one of our example apps](https://streamlit-cloud-example-apps-streamlit-app-sw3u0r.streamlitapp.com/?hsCtaTracking=28f10086-a3a5-4ea8-9403-f3d52bf26184|22470002-acb1-4d93-8286-00ee4f8a46fb) — you can find apps for machine learning, data visualization, data exploration, A/B testing and more.
 
 ## Add your app to GitHub
 

--- a/content/streamlit-cloud/get-started/index.md
+++ b/content/streamlit-cloud/get-started/index.md
@@ -5,7 +5,7 @@ slug: /streamlit-cloud/get-started
 
 # Get started
 
-Welcome to Streamlit Cloud! First things first, before you get started with Streamlit Cloud, you need to have a Streamlit app to deploy. If you haven't built one yet, read our [Get started](/library/get-started) docs or start with an [Example app](https://share.streamlit.io/streamlit/cloud-example-apps/main). Either way, it only takes a few minutes to create your first app.
+Welcome to Streamlit Cloud! First things first, before you get started with Streamlit Cloud, you need to have a Streamlit app to deploy. If you haven't built one yet, read our [Get started](/library/get-started) docs or start with an [Example app](https://streamlit-cloud-example-apps-streamlit-app-sw3u0r.streamlitapp.com/). Either way, it only takes a few minutes to create your first app.
 
 ## How Streamlit Cloud works
 
@@ -130,7 +130,7 @@ Once a user is added to a repository on GitHub, it will take at most 15 minutes 
 
 ## Explore your Streamlit Cloud workspace
 
-Congrats! You are now logged in and ready to go. If you are joining someone else's workspace you may already see apps populated in your workspace. If not, then you need to deploy an app! Check out our next section on how to [deploy an app](/streamlit-cloud/get-started/deploy-an-app). And if you need an app to deploy check out our [example apps](https://share.streamlit.io/streamlit/cloud-example-apps/main) that include apps for machine learning, data science, and business use cases.
+Congrats! You are now logged in and ready to go. If you are joining someone else's workspace you may already see apps populated in your workspace. If not, then you need to deploy an app! Check out our next section on how to [deploy an app](/streamlit-cloud/get-started/deploy-an-app). And if you need an app to deploy check out our [example apps](https://streamlit-cloud-example-apps-streamlit-app-sw3u0r.streamlitapp.com/) that include apps for machine learning, data science, and business use cases.
 
 <Image alt="Workspace 1" src="/images/streamlit-cloud/workspace-1.png" />
 

--- a/content/streamlit-cloud/get-started/share-your-app/index.md
+++ b/content/streamlit-cloud/get-started/share-your-app/index.md
@@ -136,7 +136,7 @@ From your deployed app you can click on the "☰" menu on the top right and sele
 To help others find and play with your Streamlit app, you can add Streamlit's GitHub badge to your repo. Below is an example of what the badge looks like. Clicking on the badge takes you to, in this case, Streamlit's Face-GAN Demo.
 
 <div style={{ marginBottom: '-2em', marginLeft: '30%' }}>
-    <a href="https://share.streamlit.io/streamlit/demo-face-gan" target="_blank" style={{ borderBottom: 0 }}>
+    <a href="https://streamlit-demo-face-gan-streamlit-app-u7dzij.streamlitapp.com/" target="_blank" style={{ borderBottom: 0 }}>
     <Image src="https://static.streamlit.io/badges/streamlit_badge_black_white.svg" />
     </a>
 </div>

--- a/content/streamlit-cloud/troubleshooting.md
+++ b/content/streamlit-cloud/troubleshooting.md
@@ -79,7 +79,7 @@ If you're still having issues, click [here](/streamlit-cloud/get-started/manage-
 
 ### Can I get a custom URL for my app?
 
-We are working on this in Q2 of 2022. Check our [public roadmap](https://share.streamlit.io/streamlit/roadmap/#unique-and-custom-subdomain-per-app-in-development) for more information!
+We are working on this in Q2 of 2022. Check our [public roadmap](https://roadmap.streamlitapp.com/#unique-and-custom-subdomain-per-app-done-launched) for more information!
 
 ## Sharing and accessing apps
 


### PR DESCRIPTION
## 📚 Context

There continue to exist mentions of share.streamlit.io app URLs in the form of hyperlinks or embeds. This PR replaces them with their unique/custom subdomain counterparts.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Not small <!-- Everything else -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
