### PR TITLE
Replace face GAN demo URL

### DIFF
--- a/content/streamlit-cloud/get-started/share-your-app/index.md
+++ b/content/streamlit-cloud/get-started/share-your-app/index.md
@@ -136,7 +136,7 @@ From your deployed app you can click on the "☰" menu on the top right and sele
 To help others find and play with your Streamlit app, you can add Streamlit's GitHub badge to your repo. Below is an example of what the badge looks like. Clicking on the badge takes you to, in this case, Streamlit's Face-GAN Demo.
 
 <div style={{ marginBottom: '-2em', marginLeft: '30%' }}>
-    <a href="https://streamlit-demo-face-gan-streamlit-app-u7dzij.streamlitapp.com/" target="_blank" style={{ borderBottom: 0 }}>
+    <a href="https://streamlit-demo-face-gan-streamlit-app-v2nxgz.streamlitapp.com/" target="_blank" style={{ borderBottom: 0 }}>
     <Image src="https://static.streamlit.io/badges/streamlit_badge_black_white.svg" />
     </a>
 </div>


### PR DESCRIPTION
## 📚 Context

The face GAN [demo](https://github.com/streamlit/demo-face-gan) app URL changed because it was deleted and re-deployed.

## 🧠 Description of Changes

- Replaces the face GAN demo URL

**Revised:**

https://streamlit-demo-face-gan-streamlit-app-v2nxgz.streamlitapp.com/


**Current:**

https://streamlit-demo-face-gan-streamlit-app-u7dzij.streamlitapp.com/

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
