### PR TITLE
Remove `unsafe_allow_html` in anchor link KB article

### DIFF
--- a/content/kb/using-streamlit/create-anchor-link.md
+++ b/content/kb/using-streamlit/create-anchor-link.md
@@ -13,7 +13,7 @@ Have you wanted to create anchors so that users of your app can directly navigat
 
 Anchors are automatically added to header text.
 
-For example, if you define a header text via the [st.header()](/library/api-reference/text/st.header) function as follows:
+For example, if you define a header text via the [st.header()](/library/api-reference/text/st.header) command as follows:
 
 ```python
 st.header("Section 1")
@@ -22,7 +22,7 @@ st.header("Section 1")
 Then you can create a link to this header using:
 
 ```python
-st.markdown("[Section 1](#section-1)", unsafe_allow_html=True)
+st.markdown("[Section 1](#section-1)")
 ```
 
 ## Examples


### PR DESCRIPTION
## 📚 Context

This KB article incorrectly includes `unsafe_allow_html` in the code example. This PR removes it and replaces "st.header() function" with "st.header() command".

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->

## 🌐 References

- [x] [Slack](https://snowflake.slack.com/archives/C039XQ62PB7/p1661873706623829)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
