### PR TITLE
Add a section on embedding public Streamlit Cloud apps

### DIFF
--- a/content/streamlit-cloud/get-started/deploy-an-app/index.md
+++ b/content/streamlit-cloud/get-started/deploy-an-app/index.md
@@ -61,7 +61,17 @@ For example:
 https://streamlit-demo-self-driving-streamlit-app-8jya0g.streamlitapp.com
 ```
 
-Streamlit Community Cloud supports embedding **public** apps using the subdomain scheme. To embed a public app, add the query parameter `/?embedded=true` to the end of the subdomain URL. For example [https://streamlit-demo-self-driving-streamlit-app-8jya0g.streamlitapp.com/?embedded=true](https://streamlit-demo-self-driving-streamlit-app-8jya0g.streamlitapp.com/?embedded=true). There will be no official support for embedding private apps.
+### Embed apps
+
+Streamlit Community Cloud supports embedding **public** apps using the subdomain scheme. To embed a public app, add the query parameter `/?embedded=true` to the end of the `*streamlitapp.com` subdomain URL.
+
+For example, say you want to embed the Streamlit Docs' PyDeck app: [https://doc-pydeck-chart.streamlitapp.com/](https://doc-pydeck-chart.streamlitapp.com/). The URL to include in your iframe is: [https://doc-pydeck-chart.streamlitapp.com/?embedded=true](https://doc-pydeck-chart.streamlitapp.com/?embedded=true).
+
+<Important>
+
+There will be no official support for embedding private apps.
+
+</Important>
 
 ### Custom subdomains
 

--- a/content/streamlit-cloud/get-started/deploy-an-app/index.md
+++ b/content/streamlit-cloud/get-started/deploy-an-app/index.md
@@ -67,7 +67,8 @@ Streamlit Community Cloud supports embedding **public** apps using the subdomain
 
 For example, say you want to embed the Streamlit Docs' PyDeck app: [https://doc-pydeck-chart.streamlitapp.com/](https://doc-pydeck-chart.streamlitapp.com/). The URL to include in your iframe is: [https://doc-pydeck-chart.streamlitapp.com/?embedded=true](https://doc-pydeck-chart.streamlitapp.com/?embedded=true).
 
-If you want to hide the chrome and hamburger menu in your embedded app, you can add the `/?embed=true` query parameter instead to the end of the `*streamlitapp.com` subdomain URL. For example: [https://doc-pydeck-chart.streamlitapp.com/?embed=true](https://doc-pydeck-chart.streamlitapp.com/?embed=true).
+If you want to hide the chrome, scrollbars, and hamburger menu in your embedded apps, you can add the `/?embed=true` query parameter instead to the end of the `*streamlitapp.com` subdomain URL.
+For example: [https://doc-pydeck-chart.streamlitapp.com/?embed=true](https://doc-pydeck-chart.streamlitapp.com/?embed=true).
 
 <Important>
 

--- a/content/streamlit-cloud/get-started/deploy-an-app/index.md
+++ b/content/streamlit-cloud/get-started/deploy-an-app/index.md
@@ -67,6 +67,8 @@ Streamlit Community Cloud supports embedding **public** apps using the subdomain
 
 For example, say you want to embed the Streamlit Docs' PyDeck app: [https://doc-pydeck-chart.streamlitapp.com/](https://doc-pydeck-chart.streamlitapp.com/). The URL to include in your iframe is: [https://doc-pydeck-chart.streamlitapp.com/?embedded=true](https://doc-pydeck-chart.streamlitapp.com/?embedded=true).
 
+If you want to hide the chrome and hamburger menu in your embedded app, you can add the `/?embed=true` query parameter instead to the end of the `*streamlitapp.com` subdomain URL. For example: [https://doc-pydeck-chart.streamlitapp.com/?embed=true](https://doc-pydeck-chart.streamlitapp.com/?embed=true).
+
 <Important>
 
 There will be no official support for embedding private apps.


### PR DESCRIPTION
## 📚 Context

Public Streamlit Cloud apps can be embedded by iframing `*.streamlitapp.com/?embedded=true` URLs. While this is called out in the current docs, the info is not easy find. 

## 🧠 Description of Changes

- Adds an explicit section "Embed apps" to the `Deploy an app` page in Streamlit Cloud's `Get started` docs.

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/187870702-01b0d2b2-8788-4d43-91ec-024a7e2bcaf3.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/187863568-1c62d76b-d5fb-426e-9dd7-bce9d6f12655.png)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Document-how-to-embed-iframe-an-app-9e555d024fa44b0a98c6ea0328376d76)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
