### PR TITLE
Add note: early access signup for custom subdomains is closed

### DIFF
--- a/content/streamlit-cloud/get-started/deploy-an-app/index.md
+++ b/content/streamlit-cloud/get-started/deploy-an-app/index.md
@@ -84,7 +84,7 @@ Subdomains will also soon be customizable! With this step you'll be able modify 
 <your-custom-subdomain>.streamlitapp.com
 ```
 
-Sign up for early access to try out customizable URLs in the beta [here](https://forms.streamlit.io/customizable-url-beta). To customize your app subdomain from the dashboard:
+Early access signup for custom subdomains is now closed. The feature will soon be publicly available. Once you have access, to customize your app subdomain from the dashboard:
 
 1. Click the "︙" overflow menu to the right of the app and select "**Settings**"
 


### PR DESCRIPTION
## 📚 Context

The early access signup form for custom subdomains is broken https://forms.streamlit.io/customizable-url-beta. It was intentional, we had individuals sign up for the beta which is about all we can support with current team size. We updated the public link though on the forum a bit ago, but not the docs.


## 🧠 Description of Changes

- Adds a note to the custom subdomain Cloud docs to say early access signup for custom subdomains is now closed. The feature will soon be publicly available.


## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

- [x] [Slack](https://snowflake.slack.com/archives/C039XQ62PB7/p1662362369278449)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
