### PR TITLE
Add emphasis on connecting to **remote** DB in tutorials

### DIFF
--- a/content/kb/tutorials/databases/mongodb.md
+++ b/content/kb/tutorials/databases/mongodb.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/mongodb
 
 ## Introduction
 
-This guide explains how to securely access a MongoDB database from Streamlit Cloud. It uses the [PyMongo](https://github.com/mongodb/mongo-python-driver) library and Streamlit's [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+This guide explains how to securely access a **_remote_** MongoDB database from Streamlit Cloud. It uses the [PyMongo](https://github.com/mongodb/mongo-python-driver) library and Streamlit's [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ## Create a MongoDB Database
 
@@ -40,6 +40,8 @@ password = "xxx"
 ```
 
 <Important>
+
+When copying your app secrets to Streamlit Cloud, be sure to replace the values of **host**, **port**, **username**, and **password** with those of your _remote_ MongoDB database!
 
 Add this file to `.gitignore` and don't commit it to your Github repo!
 

--- a/content/kb/tutorials/databases/mssql.md
+++ b/content/kb/tutorials/databases/mssql.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/mssql
 
 ## Introduction
 
-This guide explains how to securely access a remote Microsoft SQL Server database from Streamlit Cloud. It uses the [pyodbc](https://github.com/mkleehammer/pyodbc/wiki) library and Streamlit's [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+This guide explains how to securely access a **_remote_** Microsoft SQL Server database from Streamlit Cloud. It uses the [pyodbc](https://github.com/mkleehammer/pyodbc/wiki) library and Streamlit's [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ## Create an SQL Server database
 
@@ -112,7 +112,7 @@ password = "xxx"
 
 <Important>
 
-When copying your app secrets to Streamlit Cloud, be sure to replace the values of **server**, **database**, **username**, and **password** with those of your remote SQL Server!
+When copying your app secrets to Streamlit Cloud, be sure to replace the values of **server**, **database**, **username**, and **password** with those of your _remote_ SQL Server!
 
 And add this file to `.gitignore` and don't commit it to your Github repo.
 

--- a/content/kb/tutorials/databases/mysql.md
+++ b/content/kb/tutorials/databases/mysql.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/mysql
 
 ## Introduction
 
-This guide explains how to securely access a MySQL database from Streamlit Cloud. It uses the [mysql-connector-python](https://github.com/mysql/mysql-connector-python) library and Streamlit's [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+This guide explains how to securely access a **_remote_** MySQL database from Streamlit Cloud. It uses the [mysql-connector-python](https://github.com/mysql/mysql-connector-python) library and Streamlit's [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ## Create a MySQL database
 
@@ -49,6 +49,8 @@ password = "xxx"
 ```
 
 <Important>
+
+When copying your app secrets to Streamlit Cloud, be sure to replace the values of **host**, **port**, **database**, **user**, and **password** with those of your _remote_ MySQL database!
 
 Add this file to `.gitignore` and don't commit it to your Github repo!
 

--- a/content/kb/tutorials/databases/postgresql.md
+++ b/content/kb/tutorials/databases/postgresql.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/postgresql
 
 ## Introduction
 
-This guide explains how to securely access a PostgreSQL database from Streamlit Cloud. It uses the [psycopg2](https://www.psycopg.org/) library and Streamlit's [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+This guide explains how to securely access a **_remote_** PostgreSQL database from Streamlit Cloud. It uses the [psycopg2](https://www.psycopg.org/) library and Streamlit's [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ## Create a PostgreSQL database
 
@@ -45,6 +45,8 @@ password = "xxx"
 ```
 
 <Important>
+
+When copying your app secrets to Streamlit Cloud, be sure to replace the values of **host**, **port**, **dbname**, **user**, and **password** with those of your _remote_ PostgreSQL database!
 
 Add this file to `.gitignore` and don't commit it to your Github repo!
 


### PR DESCRIPTION
## 📚 Context

In our database connection tutorials, we want to emphasize that the guide explains how to connect to **remote** databases. Users are not able to host MongoDB, MSSQL, PostgreSQL, and MySQL databases on Streamlit Cloud

## 🧠 Description of Changes

- Added an `Important` callout to the above DB tutorials emphasizing that when copying your app secrets to Streamlit Cloud, be sure to replace the values of your DB auth creds with those of your remote database.

**Revised:**
![image](https://user-images.githubusercontent.com/20672874/189298173-9205134a-c3c6-45f7-9874-457a14e22580.png)
![image](https://user-images.githubusercontent.com/20672874/189298130-177e4a92-98ce-4f22-bec2-f66b1bb9d433.png)


**Current:**
![image](https://user-images.githubusercontent.com/20672874/189298244-9890d94f-cc17-45df-a2f0-6106fab67a61.png)
![image](https://user-images.githubusercontent.com/20672874/189298287-413881e6-f17e-47f0-afb0-08ab1f5b75ba.png)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
