### PR TITLE
Note: Streamlit apps cannot be run from OS' root dir

### DIFF
--- a/content/kb/tutorials/deploy/docker.md
+++ b/content/kb/tutorials/deploy/docker.md
@@ -100,6 +100,13 @@ Let’s walk through each line of the Dockerfile :
    WORKDIR /app
    ```
 
+   <Important>
+
+   As mentioned in [Development flow](/library/get-started/main-concepts#development-flow), for Streamlit version 1.10.0 and higher, Streamlit apps cannot be run from the root directory of Unix-like operating systems, including Linux and macOS. Your main script should live in a directory other than the root directory. If you try to run a Streamlit app from the root directory, Streamlit will throw a `FileNotFoundError: [Errno 2] No such file or directory` error. For more information, see GitHub issue [#5239](https://github.com/streamlit/streamlit/issues/5239).
+
+   If you are using Streamlit version 1.10.0 or higher, you must set the `WORKDIR` to a directory other than the root directory. For example, you can set the `WORKDIR` to `/app` as shown in the example `Dockerfile` above.
+   </Important>
+
 4. Install `git` so that we can clone the app code from a remote repo:
 
    ```dockerfile

--- a/content/kb/tutorials/deploy/kubernetes.md
+++ b/content/kb/tutorials/deploy/kubernetes.md
@@ -117,6 +117,13 @@ COPY run.sh /home/appuser
 ENTRYPOINT ["./run.sh"]
 ```
 
+<Important>
+
+As mentioned in [Development flow](/library/get-started/main-concepts#development-flow), for Streamlit version 1.10.0 and higher, Streamlit apps cannot be run from the root directory of Unix-like operating systems, including Linux and macOS. Your main script should live in a directory other than the root directory. If you try to run a Streamlit app from the root directory, Streamlit will throw a `FileNotFoundError: [Errno 2] No such file or directory` error. For more information, see GitHub issue [#5239](https://github.com/streamlit/streamlit/issues/5239).
+
+If you are using Streamlit version 1.10.0 or higher, you must set the `WORKDIR` to a directory other than the root directory. For example, you can set the `WORKDIR` to `/home/appuser` as shown in the example `Dockerfile` above.
+</Important>
+
 ### Build a Docker image
 
 Put the above files (`run.sh` and `Dockerfile`) in the same folder and build the docker image:

--- a/content/library/get-started/main-concepts.md
+++ b/content/library/get-started/main-concepts.md
@@ -71,6 +71,10 @@ time. Give it a try!
 
 </Tip>
 
+As of Streamlit version 1.10.0 and higher, Streamlit apps cannot be run from the root directory of Unix-like operating systems, including Linux and macOS. If you try to run a Streamlit app from the root directory, Streamlit will throw a `FileNotFoundError: [Errno 2] No such file or directory` error. For more information, see GitHub issue [#5239](https://github.com/streamlit/streamlit/issues/5239).
+
+If you are using Streamlit version 1.10.0 or higher, your main script should live in a directory other than the root directory. When using Docker, you can use the `WORKDIR` command to specify the directory where your main script lives. For an example of how to do this, read [Create a Dockerfile](/knowledge-base/tutorials/deploy/docker#create-a-dockerfile).
+
 ## Data flow
 
 Streamlit's architecture allows you to write apps the same way you write plain


### PR DESCRIPTION
## 📚 Context

With Streamlit version 1.10 and higher, Streamlit apps cannot be run from the root directory of Unix-like operating systems. i.e. the main script should live in a directory other than root. If run from the root dir, users will see a `FileNotFoundError: [Errno 2] No such file or directory` ([#5239](https://github.com/streamlit/streamlit/issues/5239), [#4842](https://github.com/streamlit/streamlit/issues/4842)).


## 🧠 Description of Changes

- Adds a paragraph to `Development flow` in `Main concepts` saying Streamlit apps cannot be run from the root dir.
- Adds an `Important` callout to Docker and Kubernetes tutorials restating the paragraph from Development flow, in addition to pointing out that users must set the `WORKDIR` to a directory other than the root directory when using Docker.

<details><summary><b>Revised:</b></summary>

![image](https://user-images.githubusercontent.com/20672874/189590450-6614a431-2b0f-4329-856e-647b43d9e298.png)
![image](https://user-images.githubusercontent.com/20672874/189590544-7204d503-4940-4631-925e-afa8efc2922b.png)
</details>

<details><summary><b>Current:</b></summary>

![image](https://user-images.githubusercontent.com/20672874/189590635-901a0d27-0e5e-453a-98c0-fbeb65784370.png)
![image](https://user-images.githubusercontent.com/20672874/189590706-58e11390-5a37-40a1-8cbb-a26784dfb596.png)

</details>

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

- [x] [Closes #5239](https://github.com/streamlit/streamlit/issues/5239)
