### PR TITLE
Replace h2 with h3 headings in API ref featured videos

### DIFF
--- a/content/library/api/widgets/button.md
+++ b/content/library/api/widgets/button.md
@@ -7,7 +7,7 @@ keywords: button
 
 <Autofunction function="streamlit.button" />
 
-## Featured videos
+### Featured videos
 
 Check out our video on how to use one of Streamlit's core functions, the button!
 

--- a/content/library/api/widgets/checkbox.md
+++ b/content/library/api/widgets/checkbox.md
@@ -6,7 +6,7 @@ description: st.checkbox displays a checkbox widget.
 
 <Autofunction function="streamlit.checkbox" />
 
-## Featured videos
+### Featured videos
 
 Check out our video on how to use one of Streamlit's core functions, the checkbox! ☑
 

--- a/content/library/api/widgets/radio.md
+++ b/content/library/api/widgets/radio.md
@@ -6,7 +6,7 @@ description: st.radio displays a radio button widget.
 
 <Autofunction function="streamlit.radio" />
 
-## Featured videos
+### Featured videos
 
 Check out our video on how to use one of Streamlit's core functions, the radio button! 🔘
 

--- a/content/library/api/widgets/select_slider.md
+++ b/content/library/api/widgets/select_slider.md
@@ -6,7 +6,7 @@ description: st.select_slider displays a slider widget to select items from a li
 
 <Autofunction function="streamlit.select_slider" />
 
-## Featured videos
+### Featured videos
 
 Check out our video on how to use one of Streamlit's core functions, the select slider! 🎈
 <YouTube videoId="MTaL_1UCb2g" />

--- a/content/library/api/widgets/slider.md
+++ b/content/library/api/widgets/slider.md
@@ -6,7 +6,7 @@ description: st.slider displays a slider widget.
 
 <Autofunction function="streamlit.slider" />
 
-## Featured videos
+### Featured videos
 
 Check out our video on how to use one of Streamlit's core functions, the slider!
 <YouTube videoId="tzAdd-MuWPw" />

--- a/content/library/api/write-magic/magic.md
+++ b/content/library/api/write-magic/magic.md
@@ -56,7 +56,7 @@ magicEnabled = false
     <p>Right now, Magic only works in the main Python app file, not in imported files. See GitHub issue #288 for a discussion of the issues.</p>
 </Important>
 
-## Featured video
+### Featured video
 
 Learn what the [`st.write`](/library/api-reference/write-magic/st.write) and [magic](/library/api-reference/write-magic/magic) commands are and how to use them.
 

--- a/content/library/api/write-magic/write.md
+++ b/content/library/api/write-magic/write.md
@@ -6,7 +6,7 @@ description: st.write writes arguments to the app.
 
 <Autofunction function="streamlit.write" />
 
-## Featured video
+### Featured video
 
 Learn what the [`st.write`](/library/api-reference/write-magic/st.write) and [magic](/library/api-reference/write-magic/magic) commands are and how to use them.
 


### PR DESCRIPTION
## 📚 Context

Uses `h3` headings in place of `h2` for the `Featured videos`section on API reference pages.