### PR TITLE
Pass undefined to non-boolean attribute className in `globalTemplate.js`

### DIFF
--- a/components/layouts/globalTemplate.js
+++ b/components/layouts/globalTemplate.js
@@ -22,7 +22,9 @@ const Layout = ({ children }) => {
   return (
     <main id="root" className="dark:bg-gray-100">
       <Header isSticky={isSticky} />
-      <div className={isSticky && styles.stickyPageWrapper}>{children}</div>
+      <div className={isSticky ? styles.stickyPageWrapper : undefined}>
+        {children}
+      </div>
     </main>
   );
 };


### PR DESCRIPTION
## 📚 Context

As part of Sticky navigation fixes (#483), the `isSticky` value is passed as a prop  to both `<Header>`  and the main children container. When passing it to the main children container, it was conditionally omitted using `&&`, which threw the following warning to console:

```
Warning: Received `false` for a non-boolean attribute `className`.

If you want to write it to the DOM, pass a string instead: className="false" or className={value.toString()}.

If you used to conditionally omit it with className={condition && value}, pass className={condition ? value : undefined} instead.
    at div
    at main
    at Layout (webpack-internal:///./components/layouts/globalTemplate.js:16:19)
    at Home (webpack-internal:///./pages/index.js:62:17)
    at AppContextProvider (webpack-internal:///./context/AppContext.js:13:31)
    at StreamlitDocs (webpack-internal:///./pages/_app.js:70:26)
    at StyleRegistry (/Users/skekre/docs/node_modules/styled-jsx/dist/index/index.js:671:34)
    at AppContainer (/Users/skekre/docs/node_modules/next/dist/server/render.js:415:29)
    at AppContainerWithIsomorphicFiberStructure (/Users/skekre/docs/node_modules/next/dist/server/render.js:447:57)
    at div
    at Body (/Users/skekre/docs/node_modules/next/dist/server/render.js:715:21)
```

## 🧠 Description of Changes

- Used the ternary operator instead and pass `undefined` if the condition is falsy.

**Revised:**

```js
<div className={isSticky ? styles.stickyPageWrapper : undefined}>
    {children}
</div>
```

**Current:**

```js
<div className={isSticky && styles.stickyPageWrapper}>{children}</div>
```

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->