### PR TITLE
Fix styling on `token.decorator.annotation.punctuation`

### DIFF
--- a/components/blocks/code.module.css
+++ b/components/blocks/code.module.css
@@ -46,6 +46,10 @@
   @apply text-yellow-80;
 }
 
+.Container pre code :global(.decorator.annotation.punctuation) {
+  @apply text-yellow-80;
+}
+
 .Container pre code :global(.string) {
   @apply text-darkBlue-30;
 }
@@ -82,6 +86,10 @@
 /* Dark mode adjustments */
 :global(.dark) .Container pre code :global(.operator),
 :global(.dark) .Container pre code :global(.decorator) {
+  @apply text-yellow-50;
+}
+
+:global(.dark) .Container pre code :global(.decorator.annotation.punctuation) {
   @apply text-yellow-50;
 }
 

--- a/components/blocks/code.module.css
+++ b/components/blocks/code.module.css
@@ -90,7 +90,7 @@
 }
 
 :global(.dark) .Container pre code :global(.decorator.annotation.punctuation) {
-  @apply text-yellow-50;
+  @apply text-yellow-80;
 }
 
 :global(.dark) .Container pre code :global(.keyword) {


### PR DESCRIPTION
## 📚 Context

Decorators (e.g. `@st.experimental_memo`) in Python code blocks are styled with gray text by default, making them visually similar to code comments. Those decorators are really special and should 'pop' as they have really high and unique value props.

## 🧠 Description of Changes

- Styles decorators (e.g. `@st.experimental_memo`) in Python code blocks with yellow.

e.g. https://deploy-preview-491--streamlit-docs.netlify.app/knowledge-base/tutorials/databases/snowflake#write-your-streamlit-app

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/190594339-ba101989-4c05-4a66-97f1-32a4c61f065a.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/190594505-a7f00300-81f9-4c1d-9c02-8788fa2e9c4b.png)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Slack](https://snowflake.slack.com/archives/C03A2G3T9N3/p1663246781951009?thread_ts=1663086338.931169&cid=C03A2G3T9N3)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
