### PR TITLE
Style inline code in callouts like inline code in paragraphs

### DIFF
--- a/components/blocks/callout.module.css
+++ b/components/blocks/callout.module.css
@@ -8,7 +8,7 @@
 }
 
 .Container p > code {
-  @apply border border-gray-30 text-red-70 rounded-md px-2 py-1 mx-1 break-words;
+  @apply border border-gray-40 text-red-70 rounded-md px-1 mx-1 break-words;
 }
 
 .Container p:only-child,


### PR DESCRIPTION
## 📚 Context

@arnaudmiribel flagged that inline code in callouts look weird. There's too much padding around code and the styling is not consistent with that of inline code in paragraph text.

## 🧠 Description of Changes

- Styled inline code in callouts the same as inline code in paragraph text is styled. i.e. removed the extra horizontal and vertical padding, and darkened the border by a shade.

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/191675624-e2ecefec-0dd1-4d0c-9124-003ec4ae6dd1.png)
![image](https://user-images.githubusercontent.com/20672874/191675679-31aead61-8690-4184-9e82-6461e1988955.png)


**Current:**

![image](https://user-images.githubusercontent.com/20672874/191676454-910cb197-4388-45c5-86f8-2c13da172390.png)
![image](https://user-images.githubusercontent.com/20672874/191676511-dd3100ac-b6eb-44cf-8d59-261f14cd1de4.png)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Code-font-looks-weird-in-callouts-a245837e85dd4c45a03b7ec4335329fd)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
