### PR TITLE
Allow camera access to iframe in Cloud component

### DIFF
--- a/components/blocks/cloud.js
+++ b/components/blocks/cloud.js
@@ -14,6 +14,7 @@ const Cloud = ({ src, height }) => {
           src={`${src}`}
           height={height}
           className={styles.Iframe}
+          allow="camera;"
         />
         <a href={src} target="_blank" className={styles.Caption}>
           (view standalone Streamlit app)
@@ -27,6 +28,7 @@ const Cloud = ({ src, height }) => {
           loading="lazy"
           src={`${src}`}
           className={classNames(styles.Iframe, styles.VideoAspectRatio)}
+          allow="camera;"
         />
         <a href={src} target="_blank" className={styles.Caption}>
           (view standalone Streamlit app)


### PR DESCRIPTION
## 📚 Context

One of the embedded apps in our docs uses the webcam. Specifically, the [MPA webcam demo](https://docs.streamlit.io/library/get-started/multipage-apps/create-a-multipage-app#run-the-multipage-app). The demo doesn't work because the iframe does not have camera access.

## 🧠 Description of Changes

- Allows camera access to iframe in Cloud component

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->