### PR TITLE
Migrate `*.streamlitapp.com` URLs to `*.streamlit.app`

### DIFF
--- a/content/kb/using-streamlit/create-anchor-link.md
+++ b/content/kb/using-streamlit/create-anchor-link.md
@@ -27,5 +27,5 @@ st.markdown("[Section 1](#section-1)")
 
 ## Examples
 
-- Demo app: [https://dataprofessor-streamlit-anchor-app-80kk8w.streamlitapp.com/](https://dataprofessor-streamlit-anchor-app-80kk8w.streamlitapp.com/)
+- Demo app: [https://dataprofessor-streamlit-anchor-app-80kk8w.streamlit.app/](https://dataprofessor-streamlit-anchor-app-80kk8w.streamlit.app/)
 - GitHub repo: [https://github.com/dataprofessor/streamlit/blob/main/anchor_app.py](https://github.com/dataprofessor/streamlit/blob/main/anchor_app.py)

--- a/content/kb/using-streamlit/how-download-file-streamlit.md
+++ b/content/kb/using-streamlit/how-download-file-streamlit.md
@@ -5,7 +5,7 @@ slug: /knowledge-base/using-streamlit/how-download-file-streamlit
 
 # How to download a file in Streamlit?
 
-Use the [`st.download_button`](/library/api-reference/widgets/st.download_button) widget that is natively built into Streamlit. Check out a [sample app](https://streamlit-release-demos-0-88streamlit-app-0-88-v8ram3.streamlitapp.com/) demonstrating how you can use `st.download_button` to download common file formats.
+Use the [`st.download_button`](/library/api-reference/widgets/st.download_button) widget that is natively built into Streamlit. Check out a [sample app](https://streamlit-release-demos-0-88streamlit-app-0-88-v8ram3.streamlit.app/) demonstrating how you can use `st.download_button` to download common file formats.
 
 ## Example usage
 
@@ -50,5 +50,5 @@ if st.download_button(...):
 Additional resources:
 
 - <https://blog.streamlit.io/0-88-0-release-notes/>
-- <https://streamlit-release-demos-0-88streamlit-app-0-88-v8ram3.streamlitapp.com/>
+- <https://streamlit-release-demos-0-88streamlit-app-0-88-v8ram3.streamlit.app/>
 - <https://docs.streamlit.io/library/api-reference/widgets/st.download_button>

--- a/content/kb/using-streamlit/how-download-pandas-dataframe-csv.md
+++ b/content/kb/using-streamlit/how-download-pandas-dataframe-csv.md
@@ -5,7 +5,7 @@ slug: /knowledge-base/using-streamlit/how-download-pandas-dataframe-csv
 
 # How to download a Pandas DataFrame as a CSV?
 
-Use the [`st.download_button`](/library/api-reference/widgets/st.download_button) widget that is natively built into Streamlit. Check out a [sample app](https://streamlit-release-demos-0-88streamlit-app-0-88-v8ram3.streamlitapp.com/) demonstrating how you can use `st.download_button` to download common file formats.
+Use the [`st.download_button`](/library/api-reference/widgets/st.download_button) widget that is natively built into Streamlit. Check out a [sample app](https://streamlit-release-demos-0-88streamlit-app-0-88-v8ram3.streamlit.app/) demonstrating how you can use `st.download_button` to download common file formats.
 
 ## Example usage
 
@@ -34,5 +34,5 @@ st.download_button(
 Additional resources:
 
 - <https://blog.streamlit.io/0-88-0-release-notes/>
-- <https://streamlit-release-demos-0-88streamlit-app-0-88-v8ram3.streamlitapp.com/>
+- <https://streamlit-release-demos-0-88streamlit-app-0-88-v8ram3.streamlit.app/>
 - <https://docs.streamlit.io/library/api-reference/widgets/st.download_button>

--- a/content/library/api/charts/altair_chart.md
+++ b/content/library/api/charts/altair_chart.md
@@ -150,4 +150,4 @@ To use images instead of emojis, replace the line containing `.mark_text()` with
 
 Now that you've learned how to annotate charts, the sky's the limit! We've extended the above example to let you interactively paste your favorite emoji and set its position on the chart with Streamlit widgets. 👇
 
-<Cloud src="https://streamlit-example-app-time-series-annotati-streamlit-app-vmbrzi.streamlitapp.com/?embedded=true" height="700" />
+<Cloud src="https://streamlit-example-app-time-series-annotati-streamlit-app-vmbrzi.streamlit.app/?embedded=true" height="700" />

--- a/content/library/api/data/dataframe.md
+++ b/content/library/api/data/dataframe.md
@@ -34,7 +34,7 @@ df = load_data()
 st.dataframe(df, use_container_width=st.session_state.use_container_width)
 ```
 
-<Cloud src="https://doc-dataframe2.streamlitapp.com/?embedded=true" height="350" />
+<Cloud src="https://doc-dataframe2.streamlit.app/?embedded=true" height="350" />
 
 ### Interactivity
 

--- a/content/library/api/widgets/radio.md
+++ b/content/library/api/widgets/radio.md
@@ -36,7 +36,7 @@ with col2:
     )
 ```
 
-<Cloud src="https://doc-radio1.streamlitapp.com/?embedded=true" height="300" />
+<Cloud src="https://doc-radio1.streamlit.app/?embedded=true" height="300" />
 
 ### Featured videos
 

--- a/content/library/api/widgets/selectbox.md
+++ b/content/library/api/widgets/selectbox.md
@@ -37,4 +37,4 @@ with col2:
     )
 ```
 
-<Cloud src="https://doc-selectbox1.streamlitapp.com/?embedded=true" height="300" />
+<Cloud src="https://doc-selectbox1.streamlit.app/?embedded=true" height="300" />

--- a/content/library/api/widgets/text_input.md
+++ b/content/library/api/widgets/text_input.md
@@ -45,4 +45,4 @@ with col2:
         st.write("You entered: ", text_input)
 ```
 
-<Cloud src="https://doc-text-input1.streamlitapp.com/?embedded=true" height="400" />
+<Cloud src="https://doc-text-input1.streamlit.app/?embedded=true" height="400" />

--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -328,7 +328,7 @@ _Release date: Aug 19, 2021_
 
 **Highlights**
 
-- 🔢 Introducing `st.metric`, an API for displaying KPIs. Check out the [demo app](https://streamlit-release-demos-0-87streamlit-app-0-87-rfzphf.streamlitapp.com/) showcasing the functionality.
+- 🔢 Introducing `st.metric`, an API for displaying KPIs. Check out the [demo app](https://streamlit-release-demos-0-87streamlit-app-0-87-rfzphf.streamlit.app/) showcasing the functionality.
 
 **Other Changes**
 

--- a/content/library/get-started/index.md
+++ b/content/library/get-started/index.md
@@ -32,7 +32,7 @@ title="30 Days of Streamlit 🎈"
 copy="30 Days of Streamlit 🎈 is a free, self-paced 30 day challenge that teaches you how to build and deploy data apps with Streamlit. Complete the daily challenges, share your solutions with us on Twitter and LinkedIn, and stop by the forum with any questions!"
 button={{
     text: "Start the challenge",
-    link: "https://30days.streamlitapp.com/",
+    link: "https://30days.streamlit.app/",
     target: "_blank",
   }}
 image="/30days.png"

--- a/content/library/get-started/multipage-apps/create-a-multi-page-app.md
+++ b/content/library/get-started/multipage-apps/create-a-multi-page-app.md
@@ -254,7 +254,7 @@ page_names_to_funcs[demo_name]()
 
 </details>
 
-<Cloud src="https://doc-hello.streamlitapp.com/?embedded=true" height="700" />
+<Cloud src="https://doc-hello.streamlit.app/?embedded=true" height="700" />
 
 Notice how large the file is! Each app “page” is written as a function, and the selectbox is used to pick which page to display. As our app grows, maintaining the code requires a lot of additional overhead. Moreover, we’re limited by the `st.selectbox` UI to choose which “page” to run, we cannot customize individual page titles with `st.set_page_config`, and we’re unable to navigate between pages using URLs.
 
@@ -559,7 +559,7 @@ streamlit run Hello.py
 
 That’s it! The `Hello.py` script now corresponds to the main page of your app, and other scripts that Streamlit finds in the pages folder will also be present in the new page selector that appears in the sidebar.
 
-<Cloud src="https://doc-mpa-hello.streamlitapp.com/?embedded=true" height="700" />
+<Cloud src="https://doc-mpa-hello.streamlit.app/?embedded=true" height="700" />
 
 ## Next steps
 

--- a/content/menu.md
+++ b/content/menu.md
@@ -355,7 +355,7 @@ site_menu:
   - category: Streamlit Cloud / Trust and Security
     url: /streamlit-cloud/trust-and-security
   - category: Streamlit Cloud / Release notes
-    url: https://streamlit-cloud-release-notes-app-main-jfmm83.streamlitapp.com/
+    url: https://streamlit-cloud-release-notes-app-main-jfmm83.streamlit.app/
   - category: Streamlit Cloud / Troubleshooting
     url: /streamlit-cloud/troubleshooting
 

--- a/content/streamlit-cloud/get-started/deploy-an-app/index.md
+++ b/content/streamlit-cloud/get-started/deploy-an-app/index.md
@@ -5,7 +5,7 @@ slug: /streamlit-cloud/get-started/deploy-an-app
 
 # Deploy an app
 
-Streamlit Cloud lets you deploy your apps in just one click, and most apps will deploy in only a few minutes. If you don't have an app ready to deploy, [fork or clone one of our example apps](https://streamlit-cloud-example-apps-streamlit-app-sw3u0r.streamlitapp.com/?hsCtaTracking=28f10086-a3a5-4ea8-9403-f3d52bf26184|22470002-acb1-4d93-8286-00ee4f8a46fb) — you can find apps for machine learning, data visualization, data exploration, A/B testing and more.
+Streamlit Cloud lets you deploy your apps in just one click, and most apps will deploy in only a few minutes. If you don't have an app ready to deploy, [fork or clone one of our example apps](https://streamlit-cloud-example-apps-streamlit-app-sw3u0r.streamlit.app/?hsCtaTracking=28f10086-a3a5-4ea8-9403-f3d52bf26184|22470002-acb1-4d93-8286-00ee4f8a46fb) — you can find apps for machine learning, data visualization, data exploration, A/B testing and more.
 
 ## Add your app to GitHub
 
@@ -52,24 +52,24 @@ That's it — you're done! Your app now has a unique subdomain URL that you can 
 App subdomain URLs follow a structure based on your GitHub repo:
 
 ```text
-https://[user name]-[repo name]-[branch name]-[app path]-[short hash].streamlitapp.com
+https://[user name]-[repo name]-[branch name]-[app path]-[short hash].streamlit.app
 ```
 
 For example:
 
 ```text
-https://streamlit-demo-self-driving-streamlit-app-8jya0g.streamlitapp.com
+https://streamlit-demo-self-driving-streamlit-app-8jya0g.streamlit.app
 ```
 
 ### Embed apps
 
-Streamlit Community Cloud supports embedding **public** apps using the subdomain scheme. To embed a public app, add the query parameter `/?embedded=true` to the end of the `*streamlitapp.com` subdomain URL.
+Streamlit Community Cloud supports embedding **public** apps using the subdomain scheme. To embed a public app, add the query parameter `/?embedded=true` to the end of the `*streamlit.app` subdomain URL.
 
-For example, say you want to embed the Streamlit Docs' PyDeck app: [https://doc-pydeck-chart.streamlitapp.com/](https://doc-pydeck-chart.streamlitapp.com/). The URL to include in your iframe is: [https://doc-pydeck-chart.streamlitapp.com/?embedded=true](https://doc-pydeck-chart.streamlitapp.com/?embedded=true).
+For example, say you want to embed the Streamlit Docs' PyDeck app: [https://doc-pydeck-chart.streamlit.app/](https://doc-pydeck-chart.streamlit.app/). The URL to include in your iframe is: [https://doc-pydeck-chart.streamlit.app/?embedded=true](https://doc-pydeck-chart.streamlit.app/?embedded=true).
 
-If you want to hide the chrome, scrollbars, and hamburger menu in your embedded apps, you can add the `/?embed=true` query parameter instead to the end of the `*streamlitapp.com` subdomain URL.
+If you want to hide the chrome, scrollbars, and hamburger menu in your embedded apps, you can add the `/?embed=true` query parameter instead to the end of the `*streamlit.app` subdomain URL.
 
-For example: [https://doc-pydeck-chart.streamlitapp.com/?embed=true](https://doc-pydeck-chart.streamlitapp.com/?embed=true).
+For example: [https://doc-pydeck-chart.streamlit.app/?embed=true](https://doc-pydeck-chart.streamlit.app/?embed=true).
 
 <Important>
 
@@ -82,7 +82,7 @@ There will be no official support for embedding private apps.
 Subdomains are customizable! With this step you'll be able modify your app URLs to reflect your app content, personal branding, or whatever you’d like. The URL will appear as:
 
 ```text
-<your-custom-subdomain>.streamlitapp.com
+<your-custom-subdomain>.streamlit.app
 ```
 
 To customize your app subdomain from the dashboard:

--- a/content/streamlit-cloud/get-started/index.md
+++ b/content/streamlit-cloud/get-started/index.md
@@ -5,7 +5,7 @@ slug: /streamlit-cloud/get-started
 
 # Get started
 
-Welcome to Streamlit Cloud! First things first, before you get started with Streamlit Cloud, you need to have a Streamlit app to deploy. If you haven't built one yet, read our [Get started](/library/get-started) docs or start with an [Example app](https://streamlit-cloud-example-apps-streamlit-app-sw3u0r.streamlitapp.com/). Either way, it only takes a few minutes to create your first app.
+Welcome to Streamlit Cloud! First things first, before you get started with Streamlit Cloud, you need to have a Streamlit app to deploy. If you haven't built one yet, read our [Get started](/library/get-started) docs or start with an [Example app](https://streamlit-cloud-example-apps-streamlit-app-sw3u0r.streamlit.app/). Either way, it only takes a few minutes to create your first app.
 
 ## How Streamlit Cloud works
 
@@ -130,7 +130,7 @@ Once a user is added to a repository on GitHub, it will take at most 15 minutes 
 
 ## Explore your Streamlit Cloud workspace
 
-Congrats! You are now logged in and ready to go. If you are joining someone else's workspace you may already see apps populated in your workspace. If not, then you need to deploy an app! Check out our next section on how to [deploy an app](/streamlit-cloud/get-started/deploy-an-app). And if you need an app to deploy check out our [example apps](https://streamlit-cloud-example-apps-streamlit-app-sw3u0r.streamlitapp.com/) that include apps for machine learning, data science, and business use cases.
+Congrats! You are now logged in and ready to go. If you are joining someone else's workspace you may already see apps populated in your workspace. If not, then you need to deploy an app! Check out our next section on how to [deploy an app](/streamlit-cloud/get-started/deploy-an-app). And if you need an app to deploy check out our [example apps](https://streamlit-cloud-example-apps-streamlit-app-sw3u0r.streamlit.app/) that include apps for machine learning, data science, and business use cases.
 
 <Image alt="Workspace 1" src="/images/streamlit-cloud/workspace-1.png" />
 

--- a/content/streamlit-cloud/get-started/share-your-app/index.md
+++ b/content/streamlit-cloud/get-started/share-your-app/index.md
@@ -138,7 +138,7 @@ From your deployed app you can click on the "☰" menu on the top right and sele
 To help others find and play with your Streamlit app, you can add Streamlit's GitHub badge to your repo. Below is an example of what the badge looks like. Clicking on the badge takes you to, in this case, Streamlit's Face-GAN Demo.
 
 <div style={{ marginBottom: '-2em', marginLeft: '30%' }}>
-    <a href="https://streamlit-demo-face-gan-streamlit-app-v2nxgz.streamlitapp.com/" target="_blank" style={{ borderBottom: 0 }}>
+    <a href="https://streamlit-demo-face-gan-streamlit-app-v2nxgz.streamlit.app/" target="_blank" style={{ borderBottom: 0 }}>
     <Image src="https://static.streamlit.io/badges/streamlit_badge_black_white.svg" />
     </a>
 </div>
@@ -146,12 +146,12 @@ To help others find and play with your Streamlit app, you can add Streamlit's Gi
 Once you deploy your app, you can embed this badge right into your GitHub README.md by adding the following Markdown:
 
 ```markdown
-[![Streamlit App](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://<your-custom-subdomain>.streamlitapp.com)
+[![Streamlit App](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://<your-custom-subdomain>.streamlit.app)
 ```
 
 <Note>
 
-Be sure to replace `https://<your-custom-subdomain>.streamlitapp.com` with the URL of your deployed app!
+Be sure to replace `https://<your-custom-subdomain>.streamlit.app` with the URL of your deployed app!
 
 </Note>
 

--- a/content/streamlit-cloud/troubleshooting.md
+++ b/content/streamlit-cloud/troubleshooting.md
@@ -79,7 +79,7 @@ If you're still having issues, click [here](/streamlit-cloud/get-started/manage-
 
 ### Can I get a custom URL for my app?
 
-We are working on this in Q2 of 2022. Check our [public roadmap](https://roadmap.streamlitapp.com/#unique-and-custom-subdomain-per-app-done-launched) for more information!
+We are working on this in Q2 of 2022. Check our [public roadmap](https://roadmap.streamlit.app/#unique-and-custom-subdomain-per-app-done-launched) for more information!
 
 ## Sharing and accessing apps
 


### PR DESCRIPTION
## 📚 Context

The migration of Streamlit apps from `*.streamlitapp.com` to `*.streamlit.app` is GA as of today. 

## 🧠 Description of Changes

- Replaces all mentions of `streamlitapp.com` with `streamlit.app` in both the content and embedded docs apps.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] **[Notion](https://www.notion.so/streamlit/Feature-Update-Cloud-docs-to-reflect-new-app-url-streamlit-app-fecf4e12597d46c9a1498c632f942391)**

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
