### PR TITLE
Update st.audio app with sample_rate example

### DIFF
--- a/python/api-examples-source/charts.audio.py
+++ b/python/api-examples-source/charts.audio.py
@@ -1,3 +1,4 @@
+import numpy as np
 import requests
 import streamlit as st
 
@@ -32,3 +33,34 @@ st.write(
 
 """
 )
+
+st.code(
+    """
+import streamlit as st
+import numpy as np
+
+sample_rate = 44100  # 44100 samples per second
+seconds = 2  # Note duration of 2 seconds
+
+frequency_la = 440  # Our played note will be 440 Hz
+
+# Generate array with seconds*sample_rate steps, ranging between 0 and seconds
+t = np.linspace(0, seconds, seconds * sample_rate, False)
+
+# Generate a 440 Hz sine wave
+note_la = np.sin(frequency_la * t * 2 * np.pi)
+st.audio(note_la, sample_rate=sample_rate)
+"""
+)
+
+sample_rate = 44100  # 44100 samples per second
+seconds = 2  # Note duration of 2 seconds
+
+frequency_la = 440  # Our played note will be 440 Hz
+
+# Generate array with seconds*sample_rate steps, ranging between 0 and seconds
+t = np.linspace(0, seconds, seconds * sample_rate, False)
+
+# Generate a 440 Hz sine wave
+note_la = np.sin(frequency_la * t * 2 * np.pi)
+st.audio(note_la, sample_rate=sample_rate)

--- a/python/api-examples-source/requirements.txt
+++ b/python/api-examples-source/requirements.txt
@@ -8,4 +8,4 @@ numpy==1.22.0
 scipy
 altair==4.2.0
 pydeck==0.7.1
-streamlit==1.14.0
+streamlit-nightly==1.14.1.dev20221108


### PR DESCRIPTION
## 📚 Context

`st.audio` in the next release contains a new `sample_rate` parameter.

## 🧠 Description of Changes

- Updates the `st.audio` embedded app to include an example using the `sample_rate` parameter.


## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Feature-Example-app-for-st-audio-sample_rate-parameter-780f58d8bd254d0ea6227d268ed74428)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
