### PR TITLE
Add Docker & k8s tiles to KB deployment article

### DIFF
--- a/content/kb/deployments/deploy-streamlit-heroku-aws-google-cloud.md
+++ b/content/kb/deployments/deploy-streamlit-heroku-aws-google-cloud.md
@@ -11,7 +11,25 @@ You want to deploy your Streamlit app on a cloud service other than [Streamlit C
 
 ## Solution
 
-Here are some user-submitted tutorials for different cloud services:
+<DataSourcesContainer>
+<DataSourcesCard href="/knowledge-base/tutorials/deploy/docker">
+
+<Image pure alt="screenshot" src="/images/deploy/docker.png" />
+
+<h5 align="center">Docker</h5>
+
+</DataSourcesCard>
+
+<DataSourcesCard href="/knowledge-base/tutorials/deploy/kubernetes">
+
+<Image pure alt="screenshot" src="/images/deploy/kubernetes.png" />
+
+<h5 align="center">Kubernetes</h5>
+
+</DataSourcesCard>
+</DataSourcesContainer>
+
+While we work on official Streamlit deployment guides for other hosting providers, here are some user-submitted tutorials for different cloud services:
 
 - [How to deploy Streamlit apps to Google App Engine](https://dev.to/whitphx/how-to-deploy-streamlit-apps-to-google-app-engine-407o), by [Yuichiro Tachibana (Tsuchiya)](https://discuss.streamlit.io/u/whitphx/summary)
 - [How to Deploy Streamlit to a Free Amazon EC2 instance](https://towardsdatascience.com/how-to-deploy-a-streamlit-app-using-an-amazon-free-ec2-instance-416a41f69dc3), by Rahul Agarwal

--- a/content/streamlit-cloud/get-started/deploy-an-app/index.md
+++ b/content/streamlit-cloud/get-started/deploy-an-app/index.md
@@ -7,6 +7,12 @@ slug: /streamlit-cloud/get-started/deploy-an-app
 
 Streamlit Cloud lets you deploy your apps in just one click, and most apps will deploy in only a few minutes. If you don't have an app ready to deploy, [fork or clone one of our example apps](https://streamlit-cloud-example-apps-streamlit-app-sw3u0r.streamlit.app/?hsCtaTracking=28f10086-a3a5-4ea8-9403-f3d52bf26184|22470002-acb1-4d93-8286-00ee4f8a46fb) — you can find apps for machine learning, data visualization, data exploration, A/B testing and more.
 
+<Note>
+
+If you want to deploy your app on a different cloud service, check out the [Deploy Streamlit apps](/knowledge-base/tutorials/deploy) article in our Knowledge Base.
+
+</Note>
+
 ## Add your app to GitHub
 
 Streamlit Cloud launches apps directly from your GitHub repo, so your app code and dependencies need to be on GitHub before you try to deploy the app. See [App dependencies](/streamlit-cloud/get-started/deploy-an-app/app-dependencies) for more information.


### PR DESCRIPTION
## 📚 Context

There exist two pages on deployment in our Knowledge Base. [Deploy Streamlit apps](https://docs.streamlit.io/knowledge-base/tutorials/deploy) and [How do I deploy Streamlit on Heroku, AWS, Google Cloud, etc...?](https://docs.streamlit.io/knowledge-base/deploy/deploy-streamlit-heroku-aws-google-cloud) could be merged, but we want them both up for SEO reasons. What we can do is copy the Docker and Kubernetes `DataSourcesCard`s from the former into the latter.

## 🧠 Description of Changes

- Added the Docker and Kubernetes `DataSourcesCard`s from [Deploy Streamlit apps](https://docs.streamlit.io/knowledge-base/tutorials/deploy) to [How do I deploy Streamlit on Heroku, AWS, Google Cloud, etc...?](https://docs.streamlit.io/knowledge-base/deploy/deploy-streamlit-heroku-aws-google-cloud).
- Added a note callout to the Cloud [Deploy an app](https://docs.streamlit.io/streamlit-cloud/get-started/deploy-an-app) page linking to [Deploy Streamlit apps](https://docs.streamlit.io/knowledge-base/tutorials/deploy).

**Revised:**

<img width="731" alt="image" src="https://user-images.githubusercontent.com/20672874/201674233-7c881cf8-a58f-4e74-9d84-17846128c5fd.png">
<img width="739" alt="image" src="https://user-images.githubusercontent.com/20672874/201674323-add0fcbe-57eb-4b58-80e4-825634934132.png">


**Current:**

<img width="674" alt="image" src="https://user-images.githubusercontent.com/20672874/201674618-b283100b-e48b-40fd-bacf-3047dc04a720.png">
<img width="919" alt="image" src="https://user-images.githubusercontent.com/20672874/201674461-692ef4d1-c7c1-4a7a-9a3a-82e658bf251f.png">

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Two-pages-on-deployment-maybe-merge-7a635b53934d487f986dac4493dfa216)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
