### PR TITLE
Link to roadmap app in docs Streamlit library sidebar

### DIFF
--- a/content/menu.md
+++ b/content/menu.md
@@ -305,6 +305,8 @@ site_menu:
     url: /library/components/publish
   - category: Streamlit library / Components / Component gallery
     url: https://streamlit.io/components
+  - category: Streamlit library / Roadmap
+    url: https://roadmap.streamlit.app
   - category: Streamlit library / Changelog
     url: /library/changelog
   - category: Streamlit library / Cheat sheet


### PR DESCRIPTION
## 📚 Context

We'd love to give our r[oadmap app](https://roadmap.streamlitapp.com/) a bit more publicity, since today you basically have to know the URL to find it.

## 🧠 Description of Changes

- Links to roadmap app in sidebar, under the Streamlit library section.

**Revised:**

<img width="213" alt="image" src="https://user-images.githubusercontent.com/20672874/201682158-1ee8c26b-55c3-4ecc-aece-dda0d7210493.png">

**Current:**

<img width="197" alt="image" src="https://user-images.githubusercontent.com/20672874/201682228-cfb4e13d-7c03-453b-8718-5b7c681a81b7.png">

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Link-to-roadmap-app-in-docs-Streamlit-library-sidebar-5e94f1dbe5e14a5eb5bf6e921a16f09b)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
