### PR TITLE
Add release notes and docstrings for 1.15.0

### DIFF
--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -17,6 +17,23 @@ pip install --upgrade streamlit
 
 </Tip>
 
+## **Version 1.15.0**
+
+_Release date: November 17, 2022_
+
+**Notable Changes**
+
+- 💅 Widget labels can contain inline Markdown. See our [docs](https://docs.streamlit.io/library/api-reference/widgets) and demo [app](https://markdown-labels.streamlit.app/) for more info.
+- 🎵 [`st.audio`](/library/api-reference/media/st.audio) now supports playing audio data passed in as NumPy arrays with the keyword-only `sample_rate` parameter.
+- 🔁 Functions cached with `st.experimental_memo` or `st.experimental_singleton` can contain Streamlit widgets using the `experimental_allow_widgets` parameter. This allows caching checkbox, sliders, radio buttons, and more!
+
+**Other Changes**
+
+- 👩‍🎨 Design tweak to prevent jittering in sliders ([#5612](https://github.com/streamlit/streamlit/pull/5612)).
+- 🐛 Bug fix: links in headers are red, not blue ([#5609](https://github.com/streamlit/streamlit/pull/5609)).
+- 🐞 Bug fix: properly resize Plotly charts when exiting fullscreen ([#5645](https://github.com/streamlit/streamlit/pull/5645)).
+- 🐝: Bug fix: don’t accidentally trigger `st.balloons` and `st.snow` ([#5401](https://github.com/streamlit/streamlit/pull/5401)).
+
 ## **Version 1.14.0**
 
 _Release date: October 27, 2022_


### PR DESCRIPTION
## 🧠 Description of Changes

- Adds the 1.15.0 release notes to Changelog
- Bumps docstrings from version 1.14.0 to 1.15.0

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Core-1-15-0-Release-Cutoff-5d2e4fd6bbdf444e8aaf428d55c2dbf6)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
