### PR TITLE
Fix typo on line #197(`st.muliselect` -> `st.multiselect`)

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -194,7 +194,7 @@ export default function Home({ window, menu, gdpr_data }) {
                 <i className="material-icons-sharp">
                   production_quantity_limits
                 </i>
-                <h4>Limit st.muliselect options</h4>
+                <h4>Limit st.multiselect options</h4>
                 <p>
                   🤏 <code>st.multiselect</code> has a keyword-only{" "}
                   <code>max_selections</code> parameter to limit the number of


### PR DESCRIPTION
## 📚 Context

Community member reached out through support email about the typo on the docs homepage [here](https://docs.streamlit.io/library/api-reference/widgets/st.multiselect).

## 🧠 Description of Changes

Missing `t` in muliselect:
- Before: Limit st.muliselect options
- After: Limit st.multiselect options

**Revised:**

![Screen Shot 2022-11-28 at 10 40 26 AM](https://user-images.githubusercontent.com/117667118/204319341-d76a8eee-e825-4e33-90da-9b04c1f12f64.png)

**Current:**

![Screen Shot 2022-11-28 at 10 33 14 AM](https://user-images.githubusercontent.com/117667118/204317822-1c534453-eba3-4742-bf7e-d4f7dbc30da4.png)

![Screen Shot 2022-11-28 at 10 35 56 AM](https://user-images.githubusercontent.com/117667118/204319510-1d7e3570-78d4-41ff-adeb-540742fa1d73.png)


## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [ ] Small 

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- N/A

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
