### PR TITLE
typo: fix the capitalization of GitHub

### DIFF
--- a/content/kb/deployments/authentication-without-sso.md
+++ b/content/kb/deployments/authentication-without-sso.md
@@ -37,7 +37,7 @@ Be sure to add this file to your `.gitignore` so you don't commit your secrets!
 
 ### Step 2: Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+As the `secrets.toml` file above is not committed to GitHub, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 
@@ -114,7 +114,7 @@ Alternatively, you could set up and manage usernames & passwords via a spreadshe
 
 ### Step 2: Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+As the `secrets.toml` file above is not committed to GitHub, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [secrets management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/aws-s3.md
+++ b/content/kb/tutorials/databases/aws-s3.md
@@ -68,13 +68,13 @@ AWS_DEFAULT_REGION = "xxx"
 
 <Important>
 
-Be sure to replace `xxx` above with the values you noted down earlier, and add this file to `.gitignore` so you don't commit it to your Github repo!
+Be sure to replace `xxx` above with the values you noted down earlier, and add this file to `.gitignore` so you don't commit it to your GitHub repo!
 
 </Important>
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+As the `secrets.toml` file above is not committed to GitHub, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/bigquery.md
+++ b/content/kb/tutorials/databases/bigquery.md
@@ -81,13 +81,13 @@ client_x509_cert_url = "xxx"
 
 <Important>
 
-Add this file to `.gitignore` and don't commit it to your Github repo!
+Add this file to `.gitignore` and don't commit it to your GitHub repo!
 
 </Important>
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+As the `secrets.toml` file above is not committed to GitHub, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/detabase.md
+++ b/content/kb/tutorials/databases/detabase.md
@@ -38,13 +38,13 @@ Replace `xxx` above ☝️ with your **Project Key** from the previous step.
 
 <Important>
 
-Add this file to `.gitignore` and don't commit it to your Github repo!
+Add this file to `.gitignore` and don't commit it to your GitHub repo!
 
 </Important>
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+As the `secrets.toml` file above is not committed to GitHub, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/gcs.md
+++ b/content/kb/tutorials/databases/gcs.md
@@ -95,13 +95,13 @@ client_x509_cert_url = "xxx"
 
 <Important>
 
-Add this file to `.gitignore` and don't commit it to your Github repo!
+Add this file to `.gitignore` and don't commit it to your GitHub repo!
 
 </Important>
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+As the `secrets.toml` file above is not committed to GitHub, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/mongodb.md
+++ b/content/kb/tutorials/databases/mongodb.md
@@ -43,13 +43,13 @@ password = "xxx"
 
 When copying your app secrets to Streamlit Cloud, be sure to replace the values of **host**, **port**, **username**, and **password** with those of your _remote_ MongoDB database!
 
-Add this file to `.gitignore` and don't commit it to your Github repo!
+Add this file to `.gitignore` and don't commit it to your GitHub repo!
 
 </Important>
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+As the `secrets.toml` file above is not committed to GitHub, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/mssql.md
+++ b/content/kb/tutorials/databases/mssql.md
@@ -114,13 +114,13 @@ password = "xxx"
 
 When copying your app secrets to Streamlit Cloud, be sure to replace the values of **server**, **database**, **username**, and **password** with those of your _remote_ SQL Server!
 
-And add this file to `.gitignore` and don't commit it to your Github repo.
+And add this file to `.gitignore` and don't commit it to your GitHub repo.
 
 </Important>
 
 ## Copy your app secrets to Streamlit Cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+As the `secrets.toml` file above is not committed to GitHub, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/mysql.md
+++ b/content/kb/tutorials/databases/mysql.md
@@ -52,13 +52,13 @@ password = "xxx"
 
 When copying your app secrets to Streamlit Cloud, be sure to replace the values of **host**, **port**, **database**, **user**, and **password** with those of your _remote_ MySQL database!
 
-Add this file to `.gitignore` and don't commit it to your Github repo!
+Add this file to `.gitignore` and don't commit it to your GitHub repo!
 
 </Important>
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+As the `secrets.toml` file above is not committed to GitHub, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/postgresql.md
+++ b/content/kb/tutorials/databases/postgresql.md
@@ -48,13 +48,13 @@ password = "xxx"
 
 When copying your app secrets to Streamlit Cloud, be sure to replace the values of **host**, **port**, **dbname**, **user**, and **password** with those of your _remote_ PostgreSQL database!
 
-Add this file to `.gitignore` and don't commit it to your Github repo!
+Add this file to `.gitignore` and don't commit it to your GitHub repo!
 
 </Important>
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+As the `secrets.toml` file above is not committed to GitHub, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/private-gsheet.md
+++ b/content/kb/tutorials/databases/private-gsheet.md
@@ -89,13 +89,13 @@ client_x509_cert_url = "xxx"
 
 <Important>
 
-Add this file to `.gitignore` and don't commit it to your Github repo!
+Add this file to `.gitignore` and don't commit it to your GitHub repo!
 
 </Important>
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+As the `secrets.toml` file above is not committed to GitHub, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/public-gsheet.md
+++ b/content/kb/tutorials/databases/public-gsheet.md
@@ -37,13 +37,13 @@ public_gsheets_url = "https://docs.google.com/spreadsheets/d/xxxxxxx/edit#gid=0"
 
 <Important>
 
-Add this file to `.gitignore` and don't commit it to your Github repo!
+Add this file to `.gitignore` and don't commit it to your GitHub repo!
 
 </Important>
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+As the `secrets.toml` file above is not committed to GitHub, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/snowflake.md
+++ b/content/kb/tutorials/databases/snowflake.md
@@ -86,13 +86,13 @@ If you created the database from the previous step, the names of your database a
 
 <Important>
 
-Add this file to `.gitignore` and don't commit it to your Github repo!
+Add this file to `.gitignore` and don't commit it to your GitHub repo!
 
 </Important>
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+As the `secrets.toml` file above is not committed to GitHub, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/supabase.md
+++ b/content/kb/tutorials/databases/supabase.md
@@ -81,13 +81,13 @@ Replace `xxxx` above with your Project URL and API key from [Step 1](/knowledge-
 
 <Important>
 
-Add this file to `.gitignore` and don't commit it to your Github repo!
+Add this file to `.gitignore` and don't commit it to your GitHub repo!
 
 </Important>
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+As the `secrets.toml` file above is not committed to GitHub, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/tableau.md
+++ b/content/kb/tutorials/databases/tableau.md
@@ -55,13 +55,13 @@ site_id = "streamlitexample"  # in your site's URL behind the server_url
 
 <Important>
 
-Add this file to `.gitignore` and don't commit it to your Github repo!
+Add this file to `.gitignore` and don't commit it to your GitHub repo!
 
 </Important>
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+As the `secrets.toml` file above is not committed to GitHub, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/tidb.md
+++ b/content/kb/tutorials/databases/tidb.md
@@ -81,13 +81,13 @@ ssl-ca = "<path_to_CA_store>"
 
 <Important>
 
-Add this file to `.gitignore` and don't commit it to your Github repo!
+Add this file to `.gitignore` and don't commit it to your GitHub repo!
 
 </Important>
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+As the `secrets.toml` file above is not committed to GitHub, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/tutorials/databases/tigergraph.md
+++ b/content/kb/tutorials/databases/tigergraph.md
@@ -37,13 +37,13 @@ graphname = "xxx"
 
 <Important>
 
-Add this file to `.gitignore` and don't commit it to your Github repo!
+Add this file to `.gitignore` and don't commit it to your GitHub repo!
 
 </Important>
 
 ## Copy your app secrets to the cloud
 
-As the `secrets.toml` file above is not committed to Github, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on Edit Secrets. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+As the `secrets.toml` file above is not committed to GitHub, you need to pass its content to your deployed app (on Streamlit Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on Edit Secrets. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 

--- a/content/kb/using-streamlit/how-run-my-streamlit-script.md
+++ b/content/kb/using-streamlit/how-run-my-streamlit-script.md
@@ -27,7 +27,7 @@ streamlit run your_script.py [-- script args]
 
 ### Pass a URL to streamlit run
 
-You can also pass a URL to `streamlit run`! This is great when your script is hosted remotely, such as a Github Gist. For example:
+You can also pass a URL to `streamlit run`! This is great when your script is hosted remotely, such as a GitHub Gist. For example:
 
 ```bash
 streamlit run https://raw.githubusercontent.com/streamlit/demo-uber-nyc-pickups/master/streamlit_app.py

--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -940,7 +940,7 @@ _Release date: November 10, 2019_
   [`st.write`](/library/api-reference/write-magic/st.write).
 - 🌄 You can now set config options using environment variables. For example,
   `export STREAMLIT_SERVER_PORT=9876`.
-- 🐱 Ability to call `streamlit run` directly with Github and Gist URLs. No
+- 🐱 Ability to call `streamlit run` directly with GitHub and Gist URLs. No
   need to grab the "raw" URL first!
 - 📃 Cleaner exception stack traces. We now remove all Streamlit-specific code
   from stack traces originating from the user's app.

--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -940,7 +940,7 @@ _Release date: November 10, 2019_
   [`st.write`](/library/api-reference/write-magic/st.write).
 - 🌄 You can now set config options using environment variables. For example,
   `export STREAMLIT_SERVER_PORT=9876`.
-- 🐱 Ability to call `streamlit run` directly with GitHub and Gist URLs. No
+- 🐱 Ability to call `streamlit run` directly with Github and Gist URLs. No
   need to grab the "raw" URL first!
 - 📃 Cleaner exception stack traces. We now remove all Streamlit-specific code
   from stack traces originating from the user's app.

--- a/content/library/get-started/create-an-app.md
+++ b/content/library/get-started/create-an-app.md
@@ -57,7 +57,7 @@ Streamlit is more than just a way to make data apps, it’s also a community of 
 
     <Tip>
 
-   Did you know you can also pass a URL to `streamlit run`? This is great when combined with Github Gists. For example:
+   Did you know you can also pass a URL to `streamlit run`? This is great when combined with GitHub Gists. For example:
 
    ```bash
    $ streamlit run https://raw.githubusercontent.com/streamlit/demo-uber-nyc-pickups/master/streamlit_app.py

--- a/content/library/get-started/main-concepts.md
+++ b/content/library/get-started/main-concepts.md
@@ -43,7 +43,7 @@ $ streamlit run your_script.py
 <Tip>
 
 You can also pass a URL to `streamlit run`! This is great when combined with
-Github Gists. For example:
+GitHub Gists. For example:
 
 ```bash
 streamlit run https://raw.githubusercontent.com/streamlit/demo-uber-nyc-pickups/master/streamlit_app.py

--- a/content/streamlit-cloud/get-started/manage-your-app.md
+++ b/content/streamlit-cloud/get-started/manage-your-app.md
@@ -272,6 +272,6 @@ Common reasons why users show up anonymously are:
 
 1. The app was previously public
 2. Given viewer viewed app in April 2022, when the Streamlit team was honing user identification for this feature
-3. Given viewer disconnected their SSO and Github accounts previously
+3. Given viewer disconnected their SSO and GitHub accounts previously
 
 See Streamlit's general Privacy Policy [here](https://streamlit.io/privacy-policy).

--- a/content/streamlit-cloud/get-started/share-your-app/index.md
+++ b/content/streamlit-cloud/get-started/share-your-app/index.md
@@ -169,4 +169,4 @@ If you want to try out something new while still keeping your original app runni
 
 ### Finding app code
 
-Every deployed app has its Github source code linked in the "☰" menu on the top right. So if you are looking to understand the code of another Streamlit app, you can navigate to the GitHub page from there and read or fork the app.
+Every deployed app has its GitHub source code linked in the "☰" menu on the top right. So if you are looking to understand the code of another Streamlit app, you can navigate to the GitHub page from there and read or fork the app.

--- a/content/streamlit-cloud/troubleshooting.md
+++ b/content/streamlit-cloud/troubleshooting.md
@@ -165,7 +165,7 @@ If you choose not to set up billing, you will be downgraded to the Starter plan 
 
 ### Why does Streamlit require additional OAuth scope?
 
-In order to deploy your app, Streamlit requires access to your app's source code in GitHub and also the ability to manage the public keys associated with the repositories. The default GitHub OAuth scopes are sufficient to work with apps in public Github repositories. However, in order to work with apps in private Github repositories, Streamlit requires the additional `repo` OAuth scope from Github. We recognize that this scope provides Streamlit with extra permissions that we do not really need, and which, as people who prize security, we'd rather not even be granted. Alas, we need to work with the APIs we are provided by Github.
+In order to deploy your app, Streamlit requires access to your app's source code in GitHub and also the ability to manage the public keys associated with the repositories. The default GitHub OAuth scopes are sufficient to work with apps in public GitHub repositories. However, in order to work with apps in private GitHub repositories, Streamlit requires the additional `repo` OAuth scope from GitHub. We recognize that this scope provides Streamlit with extra permissions that we do not really need, and which, as people who prize security, we'd rather not even be granted. Alas, we need to work with the APIs we are provided by GitHub.
 
 ### After deploying my private-repo app, I received an email from GitHub saying a new public key was added to my repo. Is this expected?
 

--- a/pages/style-guide.js
+++ b/pages/style-guide.js
@@ -193,7 +193,7 @@ ls -l myscript.sh`}
           >
             <p>
               Did you know you can also pass a URL to streamlit run? This is
-              great when combined with Github Gists. For example:
+              great when combined with GitHub Gists. For example:
             </p>
             <Code
               language="bash"
@@ -211,7 +211,7 @@ https://raw.githubusercontent.com/streamlit/demo-uber-nyc-pickups/master/streaml
             <p>
               If the email you originally signed-up with isn’t the primary email
               associated with your GitHub account, just reply to your invite
-              email telling us your primary Github email so we can grant access
+              email telling us your primary GitHub email so we can grant access
               to the correct account.
             </p>
           </Important>
@@ -295,7 +295,7 @@ https://raw.githubusercontent.com/streamlit/demo-uber-nyc-pickups/master/streaml
               },
               {
                 title: `<p><span class='bold'>body</span> <span class='italic code'>(str)</span></p>`,
-                body: `<p>The string to display as Github-flavored Markdown. Syntax information can be found at: <a href='https://github.github.com/gfm'>https://github.github.com/gfm</a>.</p><p>This also supports:</p><ul><li>Emoji shortcodes, such as :+1: and :sunglasses:. For a list of all supported codes, see <a href='https://raw.githubusercontent.com/omnidan/node-emoji/master/lib/emoji.json'>https://raw.githubusercontent.com/omnidan/node-emoji/master/lib/emoji.json</a>.<ul><li>Second level of bullets example</li><ul><li>Third level of bullets example</li></ul></ul></li><li>LaTeX expressions, by wrapping them in “$” or “$$” (the “$$” must be on their own lines). Supported LaTeX functions are listed at <a href='https://katex.org/docs/supported.html'>https://katex.org/docs/supported.html</a>.</li></ul>`,
+                body: `<p>The string to display as GitHub-flavored Markdown. Syntax information can be found at: <a href='https://github.github.com/gfm'>https://github.github.com/gfm</a>.</p><p>This also supports:</p><ul><li>Emoji shortcodes, such as :+1: and :sunglasses:. For a list of all supported codes, see <a href='https://raw.githubusercontent.com/omnidan/node-emoji/master/lib/emoji.json'>https://raw.githubusercontent.com/omnidan/node-emoji/master/lib/emoji.json</a>.<ul><li>Second level of bullets example</li><ul><li>Third level of bullets example</li></ul></ul></li><li>LaTeX expressions, by wrapping them in “$” or “$$” (the “$$” must be on their own lines). Supported LaTeX functions are listed at <a href='https://katex.org/docs/supported.html'>https://katex.org/docs/supported.html</a>.</li></ul>`,
               },
             ]}
           />


### PR DESCRIPTION
## 📚 Context

GitHub should always be stylized as GitHub with a capital 'H'. This commit fixes this problem across the entire documentation website.

## 🧠 Description of Changes

- many files in the knowledge base and the getting started sections.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->

## 🌐 References

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
