### PR TITLE
Add KB article on custom subdomains

### DIFF
--- a/content/kb/deployments/custom-subdomains.md
+++ b/content/kb/deployments/custom-subdomains.md
@@ -1,0 +1,34 @@
+---
+title: Custom subdomains
+slug: /knowledge-base/deploy/custom-subdomains
+---
+
+# Custom subdomains
+
+Once you've [deployed your app](/streamlit-cloud/get-started/deploy-an-app) on Community Cloud, it's given an automatically generated subdomain that follows a structure based on your GitHub repo. This subdomain is unique to your app and can be used to share your app with others. However, the default subdomain is not always the most memorable or easy to share. E.g. the following is a bit of a mouthful!
+
+`https://streamlit-demo-self-driving-streamlit-app-8jya0g.streamlit.app`
+
+You can instead set up a custom subdomain to make your app easier to share. You can customize your subdomain to reflect your app content, personal branding, or whatever you’d like. The URL will appear as:
+
+```
+<your-custom-subdomain>.streamlit.app
+```
+
+To customize your app subdomain from the [dashboard](/streamlit-cloud/get-started/manage-your-app#manage-apps-from-your-app-dashboard):
+
+1. Click the "︙" overflow menu to the app's right and select "**Settings**".
+
+   ![Custom subdomain settings](/images/streamlit-cloud/custom-subdomain-settings.png)
+
+2. View the "**General**" tab in the App settings modal. Your app's unique subdomain will appear here.
+   ![Custom subdomain pick](/images/streamlit-cloud/custom-subdomain-pick.png)
+
+3. Pick a custom subdomain between 6 and 63 characters in length for your app's URL and hit "**Save**".
+   ![Custom subdomain save](/images/streamlit-cloud/custom-subdomain-save.png)
+
+It's that simple! You can then access your app by visiting your custom subdomain URL 🎉.
+
+If a custom subdomain is not available (e.g. because it's already taken), you'll see an error message like this:
+
+![Custom subdomain error](/images/streamlit-cloud/custom-subdomain-error.png)

--- a/content/kb/deployments/index.md
+++ b/content/kb/deployments/index.md
@@ -18,3 +18,4 @@ slug: /knowledge-base/deploy
 - [Upgrade the Streamlit version of your app on Streamlit Cloud](/knowledge-base/deploy/upgrade-streamlit-version-on-streamlit-cloud)
 - [Organizing your apps with workspaces on Streamlit Cloud](/knowledge-base/deploy/organizing-apps-workspaces-streamlit-cloud)
 - [How do I increase the upload limit of `st.file_uploader` on Streamlit Cloud?](/knowledge-base/deploy/increase-file-uploader-limit-streamlit-cloud)
+- [How do I customize my app's subdomain?](/knowledge-base/deploy/custom-subdomains)

--- a/content/menu.md
+++ b/content/menu.md
@@ -554,4 +554,7 @@ site_menu:
   - category: Knowledge base / Deployment issues / Upgrade the Streamlit version of your app on Streamlit Cloud
     url: /knowledge-base/deploy/upgrade-streamlit-version-on-streamlit-cloud
     visible: false
+  - category: Knowledge base / Deployment issues / Custom subdomains
+    url: /knowledge-base/deploy/custom-subdomains
+    visible: false
 ---

--- a/content/streamlit-cloud/get-started/deploy-an-app/index.md
+++ b/content/streamlit-cloud/get-started/deploy-an-app/index.md
@@ -67,6 +67,8 @@ For example:
 https://streamlit-demo-self-driving-streamlit-app-8jya0g.streamlit.app
 ```
 
+This subdomain is unique to your app and can be used to share your app with others. However, the default subdomain is not always the most memorable or easy to share. That's why you can also set a custom domain for your app.
+
 ### Embed apps
 
 Streamlit Community Cloud supports embedding **public** apps using the subdomain scheme. To embed a public app, add the query parameter `/?embedded=true` to the end of the `*streamlit.app` subdomain URL.
@@ -93,14 +95,14 @@ Subdomains are customizable! With this step you'll be able modify your app URLs 
 
 To customize your app subdomain from the dashboard:
 
-1. Click the "︙" overflow menu to the right of the app and select "**Settings**"
+1. Click the "︙" overflow menu to the app's right and select "**Settings**".
 
    ![Custom subdomain settings](/images/streamlit-cloud/custom-subdomain-settings.png)
 
-2. View the "**General**" tab in the App settings modal. Your app's unique subdomain will appear here
+2. View the "**General**" tab in the App settings modal. Your app's unique subdomain will appear here.
    ![Custom subdomain pick](/images/streamlit-cloud/custom-subdomain-pick.png)
 
-3. Pick a custom subdomain between 6 and 63 characters in length for your app's URL and hit "**Save**"
+3. Pick a custom subdomain between 6 and 63 characters in length for your app's URL and hit "**Save**".
    ![Custom subdomain save](/images/streamlit-cloud/custom-subdomain-save.png)
 
 It's that simple! You can then access your app by visiting your custom subdomain URL 🎉.


### PR DESCRIPTION
## 📚 Context

Docs on custom subdomains live under a heading in the "Deploy an app" page in the Community Cloud docs. As the content isn't on its own page, the custom subdomain docs neither appear in Google search results nor appear as the top 3 results in Algolia search. To bump the content in search results, the content should live on a dedicated page. 

The current URL for the custom subdomain docs is hardcoded in forum posts, blog posts, and the Community Cloud codebase. If we were to create another page in the Community Cloud section for this content, we'd have to direct the existing docs URL at the anchor tag level to the new page.

However, we have yet to figure out how to redirect pages at the heading/anchor level. In the interim, the solution is to create Knowledge Base entries. While the KB entries are duplicates of existing content, the KB entries ensure that relevant docs pages surface as top search results via Algolia and Google.

## 🧠 Description of Changes

- Adds a KB article on custom subdomains.
- Fixes grammar in existing custom subdomain docs.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Feature-Create-a-dedicated-page-for-custom-subdomain-docs-047eb5f1946d452f86b250f817f78d23)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
