### PR TITLE
Add docs for cached media element+form replay

### DIFF
--- a/content/library/api/performance/experimental-memo.md
+++ b/content/library/api/performance/experimental-memo.md
@@ -68,6 +68,7 @@ Supported static `st` elements in cache-decorated functions include:
 - `st.alert`
 - `st.altair_chart`
 - `st.area_chart`
+- `st.audio`
 - `st.bar_chart`
 - `st.ballons`
 - `st.bokeh_chart`
@@ -84,8 +85,12 @@ Supported static `st` elements in cache-decorated functions include:
 - `st.expander`
 - `st.experimental_get_query_params`
 - `st.experimental_set_query_params`
+- `st.experimental_show`
+- `st.form`
+- `st.form_submit_button`
 - `st.graphviz_chart`
 - `st.help`
+- `st.image`
 - `st.info`
 - `st.json`
 - `st.latex`
@@ -101,32 +106,8 @@ Supported static `st` elements in cache-decorated functions include:
 - `st.table`
 - `st.text`
 - `st.vega_lite_chart`
+- `st.video`
 - `st.warning`
-
-Forms and media elements are not supported in cache-decorated functions. If you use them, the code will only be called when we detect a cache "miss", which can lead to unexpected results. Which is why Streamlit will throw a `CachedStFunctionWarning`, like the one below:
-
-```python
-import numpy as np
-import pandas as pd
-import streamlit as st
-
-@st.experimental_memo
-def load_data(rows):
-    chart_data = pd.DataFrame(
-        np.random.randn(rows, 10),
-        columns=["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"],
-    )
-    # Contains an unsupported st command
-    st.video("https://www.youtube.com/watch?v=wpDuY9I2fDg")
-    # Streamlit will throw a CachedStFunctionWarning
-
-    return chart_data
-
-df = load_data(20)
-st.dataframe(df)
-```
-
-<Image src="/images/cached-st-function-warning.png" clean />
 
 ### Replay input widgets in cache-decorated functions
 

--- a/content/library/api/performance/experimental-singleton.md
+++ b/content/library/api/performance/experimental-singleton.md
@@ -45,6 +45,7 @@ Supported static `st` elements in cache-decorated functions include:
 - `st.alert`
 - `st.altair_chart`
 - `st.area_chart`
+- `st.audio`
 - `st.bar_chart`
 - `st.ballons`
 - `st.bokeh_chart`
@@ -61,8 +62,12 @@ Supported static `st` elements in cache-decorated functions include:
 - `st.expander`
 - `st.experimental_get_query_params`
 - `st.experimental_set_query_params`
+- `st.experimental_show`
+- `st.form`
+- `st.form_submit_button`
 - `st.graphviz_chart`
 - `st.help`
+- `st.image`
 - `st.info`
 - `st.json`
 - `st.latex`
@@ -78,30 +83,8 @@ Supported static `st` elements in cache-decorated functions include:
 - `st.table`
 - `st.text`
 - `st.vega_lite_chart`
+- `st.video`
 - `st.warning`
-
-Forms and media elements are not supported in cache-decorated functions. If you use them, the code will only be called when we detect a cache "miss", which can lead to unexpected results. Which is why Streamlit will throw a `CachedStFunctionWarning`, like the one below:
-
-```python
-import numpy as np
-import pandas as pd
-import streamlit as st
-from transformers import AutoModel
-
-@st.experimental_singleton
-def get_model(model_type):
-    # Contains an unsupported st command
-    st.video("https://www.youtube.com/watch?v=wpDuY9I2fDg")
-    # Streamlit will throw a CachedStFunctionWarning
-
-    # Create a model of the specified type
-    return AutoModel.from_pretrained(model_type)
-
-bert_model = get_model("distilbert-base-uncased")
-st.help(bert_model) # Display the model's docstring
-```
-
-<Image src="/images/cached-st-function-warning-singleton.png" clean />
 
 ### Replay input widgets in cache-decorated functions
 


### PR DESCRIPTION
## 📚 Context

With the upcoming Streamlit 1.16.0 release, the remaining elements now support cached replay. Those elements are `st.audio`, `st.form`, `st.form_submit_button`, `st.image`, and `st.video`.

## 🧠 Description of Changes

- Adds the above elements to the list of supported `st` commands for cached replay.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [s] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/Feature-Docs-for-replaying-st-image-in-cached-functions-ca5cbafff3c44a4ca422dd8e44b2529b)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
