### PR TITLE
Add line breaks mid-word to API ref param names

### DIFF
--- a/styles/text.scss
+++ b/styles/text.scss
@@ -69,7 +69,7 @@ a {
 }
 
 p {
-  @apply mb-4 text-gray-90 dark:text-white;
+  @apply mb-4 text-gray-90 break-words dark:text-white;
 }
 
 summary {


### PR DESCRIPTION
## 📚 Context

When parameter names in tables within the API reference are too long, they overflow into the adjacent column.

## 🧠 Description of Changes

- This PR adds the `break-words` tailwind utility for `<p>` inside Markdown in `styles/text.scss`.

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/207016769-cfa3cc24-724f-44bc-9c88-7a8eb594617f.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/207016849-570a25ff-e8f8-40ed-8ca6-3c1d58284c87.png)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [s] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/Bug-Long-parameter-names-in-API-ref-tables-should-wrap-not-overflow-2580fb39b91e4800b037c9dd1233191a)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
