### PR TITLE
fix typos: paramters -> parameters

### DIFF
--- a/content/library/api/utilities/utilities.md
+++ b/content/library/api/utilities/utilities.md
@@ -68,7 +68,7 @@ st.experimental_show(df)
 
 <RefCard href="/library/api-reference/utilities/st.experimental_get_query_params">
 
-#### Get query paramters
+#### Get query parameters
 
 Return the query parameters that are currently showing in the browser's URL bar.
 
@@ -80,7 +80,7 @@ st.experimental_get_query_params()
 
 <RefCard href="/library/api-reference/utilities/st.experimental_set_query_params">
 
-#### Set query paramters
+#### Set query parameters
 
 Set the query parameters that are shown in the browser's URL bar.
 


### PR DESCRIPTION
## 📚 Context

There were a couple of typos on this page. Nothing functional was modified.

## 🧠 Description of Changes

Fixed two tiny misspellings of the word "parameters":

- paramters -> parameters

## 💥 Impact

Size:

- [x] Small
- [ ] Not small

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
