### PR TITLE
Fix variable name typo in Components API code example

### DIFF
--- a/content/library/components/components-api.md
+++ b/content/library/components/components-api.md
@@ -168,8 +168,8 @@ result = my_component(greeting="Hello", name="Streamlit")
 
 ```javascript
 // Receive arguments in frontend:
-let greeting = this.props.args["greeting"]; // name = "Hello"
-let name = this.props.args["name"]; // greeting = "Streamlit"
+let greeting = this.props.args["greeting"]; // greeting = "Hello"
+let name = this.props.args["name"]; // name = "Streamlit"
 ```
 
 - Use `Streamlit.setComponentValue()` to return data from the component to the Python script:


### PR DESCRIPTION
## 📚 Context

Typo in code example on Components API page

## 🧠 Description of Changes

The variable names were swapped in the output, which could be confusing.

**Revised:**

![image](https://user-images.githubusercontent.com/116604821/210272013-05a92ca9-3190-4506-8b0a-1214845d2fd9.png)

**Current:**

![image](https://user-images.githubusercontent.com/116604821/210271990-b6361a6e-00da-4171-9a11-be543817fd03.png)

## 💥 Impact

Docs are easier to understand!

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
