### PR TITLE
Add link to custom subdomain page on cloud troubleshooting question

### DIFF
--- a/content/streamlit-cloud/troubleshooting.md
+++ b/content/streamlit-cloud/troubleshooting.md
@@ -79,7 +79,7 @@ If you're still having issues, click [here](/streamlit-cloud/get-started/manage-
 
 ### Can I get a custom URL for my app?
 
-We are working on this in Q2 of 2022. Check our [public roadmap](https://roadmap.streamlit.app/#unique-and-custom-subdomain-per-app-done-launched) for more information!
+Yes! You can find [instructions for setting a custom subdomain here](/knowledge-base/deploy/custom-subdomains).
 
 ## Sharing and accessing apps
 


### PR DESCRIPTION
## 📚 Context

There was an older question on the [Cloud Troubleshooting page](https://docs.streamlit.io/streamlit-cloud/troubleshooting#can-i-get-a-custom-url-for-my-app) about Custom URLs that had not been updated since we added custom subdomain support.

## 🧠 Description of Changes

* Added the link to the existing page for custom subdomains to answer the question

**Revised:**

![image](https://user-images.githubusercontent.com/116604821/210272664-b80294d7-5329-4d4b-8381-b2181bd3c431.png)

**Current:**

![image](https://user-images.githubusercontent.com/116604821/210272683-b41993f9-ac47-4200-9ff9-061350247d71.png)

## 💥 Impact

Better answer to the question

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
