### PR TITLE
Attempt to fix performance issue when browsing API reference page

### DIFF
--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -14,8 +14,6 @@ import "prismjs/plugins/toolbar/prism-toolbar";
 import "prismjs/plugins/copy-to-clipboard/prism-copy-to-clipboard";
 import "prismjs/plugins/normalize-whitespace/prism-normalize-whitespace";
 
-import useSourceFile from "../../lib/useSourceFile";
-
 import styles from "./autofunction.module.css";
 
 const cleanHref = (name) => {
@@ -126,7 +124,6 @@ const Autofunction = ({
 
   if (streamlitFunction in streamlit) {
     functionObject = streamlit[streamlitFunction];
-    const sourceFile = useSourceFile(functionObject.source);
     if (
       functionObject.description !== undefined &&
       functionObject.description
@@ -135,7 +132,7 @@ const Autofunction = ({
     }
   } else {
     return (
-      <div className={styles.Container} ref={blockRef}>
+      <div className={styles.Container} ref={blockRef} key={slug}>
         <div className="code-header">
           <H2>{streamlitFunction}</H2>
         </div>
@@ -273,7 +270,7 @@ const Autofunction = ({
   );
 
   return (
-    <section className={styles.Container} ref={blockRef}>
+    <section className={styles.Container} ref={blockRef} key={slug}>
       {header}
       {body}
     </section>

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -45,7 +45,6 @@ const Autofunction = ({
 
   // Code to destroy and regenerate iframes on each new autofunction render.
   const regenerateIframes = () => {
-    console.log("run");
     const iframes = Array.prototype.slice.call(
       blockRef.current.getElementsByTagName("iframe")
     );

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -41,10 +41,11 @@ const Autofunction = ({
   useEffect(() => {
     highlightWithPrism();
     regenerateIframes();
-  }, []);
+  }, [streamlitFunction]);
 
   // Code to destroy and regenerate iframes on each new autofunction render.
   const regenerateIframes = () => {
+    console.log("run");
     const iframes = Array.prototype.slice.call(
       blockRef.current.getElementsByTagName("iframe")
     );

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -40,7 +40,27 @@ const Autofunction = ({
 
   useEffect(() => {
     highlightWithPrism();
+    regenerateIframes();
   }, []);
+
+  // Code to destroy and regenerate iframes on each new autofunction render.
+  const regenerateIframes = () => {
+    const iframes = Array.prototype.slice.call(
+      blockRef.current.getElementsByTagName("iframe")
+    );
+    if (!iframes) return;
+
+    iframes.forEach((iframe) => {
+      const parent = iframe.parentElement;
+      const newFrame = iframe.cloneNode();
+
+      newFrame.src = "";
+      newFrame.classList.add("new");
+      newFrame.src = iframe.src;
+
+      parent.replaceChild(newFrame, iframe);
+    });
+  };
 
   const highlightWithPrism = () => {
     if (isHighlighted) {

--- a/components/blocks/cloud.js
+++ b/components/blocks/cloud.js
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import classNames from "classnames";
 
 import styles from "./cloud.module.css";
 
 const Cloud = ({ src, height }) => {
+  const iframeRef = useRef();
   let CloudBlock;
 
   if (height) {
@@ -15,6 +16,7 @@ const Cloud = ({ src, height }) => {
           height={height}
           className={styles.Iframe}
           allow="camera;"
+          key={src}
         />
         <a href={src} target="_blank" className={styles.Caption}>
           (view standalone Streamlit app)
@@ -29,6 +31,7 @@ const Cloud = ({ src, height }) => {
           src={`${src}`}
           className={classNames(styles.Iframe, styles.VideoAspectRatio)}
           allow="camera;"
+          key={src}
         />
         <a href={src} target="_blank" className={styles.Caption}>
           (view standalone Streamlit app)

--- a/components/utilities/floatingNav.js
+++ b/components/utilities/floatingNav.js
@@ -145,7 +145,12 @@ const Headings = ({ headings, activeId }) => {
   return (
     <>
       {sortedHeadings[0].map((heading, index) => (
-        <Heading heading={heading} index={index} activeId={activeId} />
+        <Heading
+          key={index}
+          heading={heading}
+          index={index}
+          activeId={activeId}
+        />
       ))}
     </>
   );

--- a/components/utilities/helpful.js
+++ b/components/utilities/helpful.js
@@ -83,7 +83,14 @@ const Helpful = ({ slug, sourcefile }) => {
     setIsHelpful(true);
   };
 
-  router.events.on("routeChangeComplete", handleRouteChange);
+  // Perform the route change cleanup function for the Helpful component inside a useEffect call,
+  // instead of using router.events.on("routeChangeComplete", handleRouteChange), because that
+  // adds new events progressively as you keep browsing the website, thus eventually leading to a memory leak.
+  useEffect(() => {
+    return () => {
+      handleRouteChange();
+    };
+  }, [sourcefile]);
 
   let joinedSlug = "/";
   if (slug) {

--- a/components/utilities/helpful.js
+++ b/components/utilities/helpful.js
@@ -83,9 +83,7 @@ const Helpful = ({ slug, sourcefile }) => {
     setIsHelpful(true);
   };
 
-  useEffect(() => {
-    router.events.on("routeChangeComplete", handleRouteChange);
-  });
+  router.events.on("routeChangeComplete", handleRouteChange);
 
   let joinedSlug = "/";
   if (slug) {


### PR DESCRIPTION
## 📚 Context

Some folks had been experiencing slow load times and unresponsiveness for our docs site after browsing multiple API reference pages. This seems to be caused by the fact API reference pages have apps embedded on them, and they're not properly destroyed when the user abandons the page. This PR aims to fix that!

## 🧠 Description of Changes

* Added a unique `key` to each `<iframe>` added to the `<Cloud>` components, so it can be regenerated by React whenever it changes;
* Added a function to destroy old `<iframe>` tags, clone them, change its `src` attribute, and insert them back when examples are added through the `<Autofunction>` component.

## 💥 Impact

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

## 🌐 References

- https://www.aleksandrhovhannisyan.com/blog/react-iframes-back-navigation-bug/#solution-remount-the-iframe-with-a-key
- https://www.notion.so/streamlit/Investigate-performance-issues-unresponsiveness-on-docs-site-3cbb0ba9d489483e9f41bc06b987ffe0
- https://github.com/streamlit/docs/issues/561

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
