### PR TITLE
Update blog posts on homepage

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -241,26 +241,26 @@ export default function Home({ window, menu, gdpr_data }) {
 
             <NewsContainer>
               <NewsEntry
-                date="2022-12-19T16:05:00.000Z"
-                title="A new Streamlit theme for Altair and Plotly charts"
-                text="Our charts just got a new look!"
-                link="https://blog.streamlit.io/a-new-streamlit-theme-for-altair-and-plotly/"
+                date="2023-01-10T16:05:00.000Z"
+                title="Build an image background remover in Streamlit"
+                text="Skip the fees and do it for free! 🎈"
+                link="https://blog.streamlit.io/build-an-image-background-remover-in-streamlit/"
                 image="/blog-1.svg"
                 target="_blank"
               />
               <NewsEntry
-                date="2022-12-15T16:05:00.000Z"
-                title="How to quickly deploy and share your machine learning model for drug discovery"
-                text="Share your ML model in 3 simple steps"
-                link="https://blog.streamlit.io/how-to-quickly-deploy-and-share-your-machine-learning-model-for-drug-discovery/"
+                date="2023-01-05T16:05:00.000Z"
+                title="ScienceIO manages billions of rows of training data with Streamlit"
+                text="Learn how Gaurav Kaushik of ScienceIO created a dataset with over 2.3 billion labels"
+                link="https://blog.streamlit.io/scienceio-manages-billions-of-rows-of-training-data-with-streamlit/"
                 image="/blog-2.svg"
                 target="_blank"
               />
               <NewsEntry
-                date="2022-12-08T16:05:00.000Z"
-                title="Find the top songs from your high school years with a Streamlit app"
-                text="Use the Spotify API to generate 1,000+ playlists!"
-                link="https://blog.streamlit.io/find-the-top-songs-from-your-high-school-years-with-a-streamlit-app/"
+                date="2022-12-19T16:05:00.000Z"
+                title="A new Streamlit theme for Altair and Plotly charts"
+                text="Our charts just got a new look!"
+                link="https://blog.streamlit.io/a-new-streamlit-theme-for-altair-and-plotly/"
                 image="/blog-3.svg"
                 target="_blank"
               />


### PR DESCRIPTION
Adds the latest blog posts to the docs homepage.

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/212005697-6b18a1fa-7426-4c97-a08f-725f41d21626.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/212005783-ec055011-62a3-4fbc-b316-5e8cfdef00f7.png)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Update-blog-posts-on-homepage-ab1702ed8d4847af9ede700529e37b68)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
