### PR TITLE
Remove note on secondary background color for ploty

### DIFF
--- a/content/library/advanced-features/theming.md
+++ b/content/library/advanced-features/theming.md
@@ -55,9 +55,8 @@ Defines the background color used in the main content area of your app.
 ## secondaryBackgroundColor
 
 This color is used where a second background color is needed for added
-contrast. Most notably, it is the sidebar's background color. It is also used
-as the plot background color for `st.plotly_chart` and as the background color for most other interactive
-widgets.
+contrast. Most notably, it is the sidebar's background color. It is also used 
+as the background color for most interactive widgets.
 
 ![Secondary Background Color](/images/theme_config_options/secondaryBackgroundColor.png)
 


### PR DESCRIPTION
## 📚 Context

The docs state that we use the secondary background color as the background for Plotly charts. But we don't do this anymore with the new charting them. 

## 🧠 Description of Changes

<!-- What was specifically changed? Which files, algorithms, links, media? -->
<!-- Please add them here as a bulleted list -->
- Removing the sentence. 
- Might be good to also update the screenshot but I don't have the underlying app. 

**Revised:**

(Leaving this out since it's a one-liner).

**Current:**


## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
