### PR TITLE
Add docs for 1.17.0 release

### DIFF
--- a/content/library/advanced-features/configuration.md
+++ b/content/library/advanced-features/configuration.md
@@ -67,7 +67,7 @@ streamlit config show
 The command above will print something like this:
 
 ```toml
-# Streamlit version: 1.16.0
+# Streamlit version: 1.17.0
 
 [global]
 

--- a/content/library/api-cheat-sheet.md
+++ b/content/library/api-cheat-sheet.md
@@ -5,7 +5,7 @@ slug: /library/cheatsheet
 
 # Cheat Sheet
 
-This is a summary of the docs, as of [Streamlit v1.16.0](https://pypi.org/project/streamlit/1.15.0/).
+This is a summary of the docs, as of [Streamlit v1.17.0](https://pypi.org/project/streamlit/1.15.0/).
 
 <Masonry>
 

--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -17,6 +17,22 @@ pip install --upgrade streamlit
 
 </Tip>
 
+## **Version 1.17.0**
+
+_Release date: January 12, 2023_
+
+**Notable Changes**
+
+- 🪄 [`@st.experimental_singleton`](/library/api-reference/performance/st.experimental_singleton#validating-the-cache) supports an optional `validate` parameter that accepts a validation function for cached data and is called each time the cached value is accessed.
+- 💾  [`@st.experimental_memo`](https://docs.streamlit.io/library/api-reference/performance/st.experimental_memo)’s `persist` parameter can also accept booleans.
+
+**Other Changes**
+
+- 📟 Multipage apps exclude `__init__.py` from the page selector ([#5890](https://github.com/streamlit/streamlit/pull/5890)).
+- 📐 The iframes of embedded apps have the ability to dynamically resize their height ([#5894](https://github.com/streamlit/streamlit/pull/5894)).
+- 🐞 Bug fix: thumb values of range sliders respect the container width ([#5913](https://github.com/streamlit/streamlit/pull/5913)).
+- 🪲 Bug fix: all examples in docstrings of Streamlit commands contain relevant imports to make them reproducible ([#5877](https://github.com/streamlit/streamlit/pull/5877)).
+
 ## **Version 1.16.0**
 
 _Release date: December 14, 2022_

--- a/pages/index.js
+++ b/pages/index.js
@@ -149,15 +149,17 @@ export default function Home({ window, menu, gdpr_data }) {
             <H2 className="no-b-m">What's new</H2>
 
             <TileContainer>
-              <RefCard size="third" href="/library/api-reference/charts">
-                <i className="material-icons-sharp">palette</i>
-                <h4>Streamlit theme for Plotly & Altair</h4>
+              <RefCard
+                size="third"
+                href="/library/api-reference/performance/st.experimental_singleton#validating-the-cache"
+              >
+                <i className="material-icons-sharp">verified</i>
+                <h4>Singleton cache validation</h4>
                 <p>
-                  1.16.0 includes a new default theme for Altair and Plotly
-                  charts in Streamlit apps through the{" "}
-                  <code>theme="streamlit"</code>
-                  keyword argument in st.altair_chart, st.vega_lite_chart, and
-                  st.plotly_chart.
+                  <code>@st.experimental_singleton</code> supports an optional
+                  <code>validate</code> parameter that accepts a validation
+                  function for cached data and is called each time the cached
+                  value is accessed.
                 </p>
               </RefCard>
               <RefCard
@@ -184,16 +186,15 @@ export default function Home({ window, menu, gdpr_data }) {
                   also support Snowpark and PySpark DataFrames.
                 </p>
               </RefCard>
-              <RefCard
-                size="third"
-                href="/library/api-reference/media/st.audio"
-              >
-                <i className="material-icons-sharp">music_note</i>
-                <h4>NumPy support for st.audio</h4>
+              <RefCard size="third" href="/library/api-reference/charts">
+                <i className="material-icons-sharp">palette</i>
+                <h4>Streamlit theme for Plotly & Altair</h4>
                 <p>
-                  <code>st.audio</code> can now properly play audio data from
-                  NumPy arrays with the <code>sample_rate</code> parameter.
-                  Click to see a demo. 🎶
+                  1.16.0 includes a new default theme for Altair and Plotly
+                  charts in Streamlit apps through the{" "}
+                  <code>theme="streamlit"</code>
+                  keyword argument in st.altair_chart, st.vega_lite_chart, and
+                  st.plotly_chart.
                 </p>
               </RefCard>
               <RefCard

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -2,8 +2,7 @@ FROM python:3.9-slim
 
 COPY sources.list /etc/apt/sources.list
 
-RUN apt-get update && apt-get install build-essential -y
-
+RUN apt-get update
 RUN pip install docstring_parser
 RUN pip install docutils
 RUN pip install lxml


### PR DESCRIPTION
## 📚 Context

This PR adds docs for all the relevant changes from `streamlit==1.17.0`

## 🧠 Description of Changes

- Remove unnecessary `build-essential` install from docstring container that was causing `make docstrings` to error out
- Bumps docstring version from 1.16.0 to 1.17.0 by running `make docstrings`
- Adds the release notes for 1.17.0 to changelog
- Bumps version to 1.17.0 in cheat sheet and configuration
- Updates the what's new tiles on the homepage for 1.17.0
- Adds docs for singleton cache validation (`@st.experimental_singleton`'s optional `validate` param)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
