### PR TITLE
Fix typo: been giving -> been given in 'Share your app'

### DIFF
--- a/content/streamlit-cloud/get-started/share-your-app/index.md
+++ b/content/streamlit-cloud/get-started/share-your-app/index.md
@@ -35,7 +35,7 @@ Google OAuth is enabled by default, so if you use Google, you're good to go.
 
 <!-- Once you have added someone's email address to your app's viewer list, that person will be able to sign in via Google Single Sign-On or your organization-specific Single Sign-On and view your app. They will also receive an email inviting them to view your app. If they are already logged in with that account in their browser (the usual case for most people) then they will automatically be able to view the app. If they are not logged in, or they have not been giving access, then they will see a page asking them to first log in. -->
 
-Once you have added someone's email address to your app's viewer list, that person will be able to sign in via Google Single Sign-On and view your app. They will also receive an email inviting them to view your app. If they are already logged in with that account in their browser (the usual case for most people) then they will automatically be able to view the app. If they are not logged in, or they have not been giving access, then they will see a page asking them to first log in.
+Once you have added someone's email address to your app's viewer list, that person will be able to sign in via Google Single Sign-On and view your app. They will also receive an email inviting them to view your app. If they are already logged in with that account in their browser (the usual case for most people) then they will automatically be able to view the app. If they are not logged in, or they have not been given access, then they will see a page asking them to first log in.
 
 <Tip>
 


### PR DESCRIPTION
## 🧠 Description of Changes

- Fixes a typo in the Cloud "Share your app" page: `been giving access -> been given access`

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/213124936-3189db2b-b57b-4201-9462-9ef31b2cf617.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/213125003-1b929733-0a89-4511-a946-8a756199c478.png)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Bug-Fix-typo-on-Share-apps-page-63084cfd8c314c08a96d07d3da2b3d48)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
