### PR TITLE
Support for Python 3.11

### DIFF
--- a/content/kb/using-streamlit/sanity-checks.md
+++ b/content/kb/using-streamlit/sanity-checks.md
@@ -15,7 +15,7 @@ guaranteeing compatibility with _at least_ the last three minor versions of Pyth
 As new versions of Python are released, we will try to be compatible with the new version as soon
 as possible, though frequently we are at the mercy of other Python packages to support these new versions as well.
 
-Streamlit currently supports versions 3.7, 3.8, 3.9, and 3.10 of Python.
+Streamlit currently supports versions 3.7, 3.8, 3.9, 3.10, and 3.11 of Python.
 
 ## Check #1: Is Streamlit running?
 

--- a/content/library/components/components-api.md
+++ b/content/library/components/components-api.md
@@ -95,7 +95,7 @@ To make the process of creating bi-directional Streamlit Components easier, we'v
 
 To build a Streamlit Component, you need the following installed in your development environment:
 
-- Python 3.7 - Python 3.10
+- Python 3.7 - Python 3.11
 - Streamlit 0.63+
 - [nodejs](https://nodejs.org/en/)
 - [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/)

--- a/content/library/get-started/installation.md
+++ b/content/library/get-started/installation.md
@@ -16,7 +16,7 @@ slug: /library/get-started/installation
 Before you get started, you're going to need a few things:
 
 - Your favorite IDE or text editor
-- [Python 3.7 - Python 3.10](https://www.python.org/downloads/)
+- [Python 3.7 - Python 3.11](https://www.python.org/downloads/)
 - [PIP](https://pip.pypa.io/en/stable/installation/)
 
 ## Set up your virtual environment

--- a/content/streamlit-cloud/get-started/deploy-an-app/index.md
+++ b/content/streamlit-cloud/get-started/deploy-an-app/index.md
@@ -33,7 +33,7 @@ You can connect to private data sources either by using [secrets management](/st
 
 <Tip>
 
-Streamlit Cloud supports Python 3.7 - Python 3.11, and defaults to version 3.9. You can select a version of your choice from the "Python version" dropdown in the "Advanced settings" modal.
+Streamlit Cloud supports Python 3.7 - Python 3.10, and defaults to version 3.9. You can select a version of your choice from the "Python version" dropdown in the "Advanced settings" modal.
 
 </Tip>
 

--- a/content/streamlit-cloud/get-started/deploy-an-app/index.md
+++ b/content/streamlit-cloud/get-started/deploy-an-app/index.md
@@ -33,7 +33,7 @@ You can connect to private data sources either by using [secrets management](/st
 
 <Tip>
 
-Streamlit Cloud supports Python 3.7 - Python 3.10, and defaults to version 3.9. You can select a version of your choice from the "Python version" dropdown in the "Advanced settings" modal.
+Streamlit Cloud supports Python 3.7 - Python 3.11, and defaults to version 3.9. You can select a version of your choice from the "Python version" dropdown in the "Advanced settings" modal.
 
 </Tip>
 


### PR DESCRIPTION
## 📚 Context

Streamlit 1.18.0 will officially support Python 3.11.

## 🧠 Description of Changes

- Bumps the supported max Python version from 3.10 to 3.11 in core and cloud docs.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Support-Python-3-11-95468f54810d47af89c6b249127f31e4)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
