### PR TITLE
Revert changes to singleton cache validation docs

### DIFF
--- a/content/library/api/performance/experimental-singleton.md
+++ b/content/library/api/performance/experimental-singleton.md
@@ -18,7 +18,7 @@ The `@st.experimental_singleton` decorator is used to cache the output of a func
 
 However, in some cases, the cached output may become invalid over time, such as when a database connection times out. To handle this, the `@st.experimental_singleton` decorator supports an optional `validate` parameter, which accepts a validation function that is called each time the cached output is accessed. If the validation function returns False, the cached output is discarded and the decorated function is executed again.
 
-Let's learn how to use the `validate` parameter to ensure that cached output remains valid. Let's also look at specific examples and best practices to help you understand how to use this feature effectively.
+<!-- Let's learn how to use the `validate` parameter to ensure that cached output remains valid. Let's also look at specific examples and best practices to help you understand how to use this feature effectively.
 
 #### Example 1: Validating a database connection
 
@@ -231,7 +231,7 @@ try:
     st.write(data)
 except requests.exceptions.HTTPError as err:
     st.error(err)
-```
+``` -->
 
 #### Best Practices
 


### PR DESCRIPTION
## 🧠 Description of Changes

- Reverts changes to singleton cache validation docs until we can identify a use case where it’s actually correct to use `validate`. We will revisit the docs in the near future.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Feature-Docs-for-singleton-cache-validation-d0e9113ba1344a3dbd2a7d2e2e355490)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
