### PR TITLE
Patch generate.py to parse cache_data, cache_resource docstrings

### DIFF
--- a/python/generate.py
+++ b/python/generate.py
@@ -8,14 +8,13 @@ import sys
 import types
 
 import docstring_parser
+import stoutput
 import streamlit
 import streamlit.components.v1 as components
+import utils
 from docutils.core import publish_parts
 from docutils.parsers.rst import directives
 from numpydoc.docscrape import NumpyDocString
-
-import stoutput
-import utils
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
@@ -66,9 +65,11 @@ def get_function_docstring_dict(func, funcname, signature_prefix):
             "signature"
         ] = f'{signature_prefix}.{description["name"]}({arguments})'
 
-    # Edge case for .clear() method on st.experimental_memo and st.experimental_singleton
-    # Prepend "experimental_[memo | singleton]." to the name "clear"
-    if "experimental" in signature_prefix:
+    # Edge case for .clear() method on st.experimental_memo, st.experimental_singleton, st.cache_data, and st.cache_resource
+    # Prepend either "experimental_[memo | singleton]." or "cache_[data | resource]." to the name "clear"
+    if any(
+        x in signature_prefix for x in ["experimental", "cache_data", "cache_resource"]
+    ):
         description["name"] = f"{signature_prefix}.{funcname}".lstrip("st.")
 
     if docstring:
@@ -193,8 +194,8 @@ def get_obj_docstring_dict(obj, key_prefix, signature_prefix):
     allowed_types = (
         types.FunctionType,
         types.MethodType,
-        streamlit.runtime.caching.memo_decorator.MemoAPI,
-        streamlit.runtime.caching.singleton_decorator.SingletonAPI,
+        streamlit.runtime.caching.cache_data_api.CacheDataAPI,
+        streamlit.runtime.caching.cache_resource_api.CacheResourceAPI,
     )
 
     for membername in dir(obj):
@@ -212,7 +213,7 @@ def get_obj_docstring_dict(obj, key_prefix, signature_prefix):
         # memo and singleton are callable objects rather than functions
         # See: https://github.com/streamlit/streamlit/pull/4263
         while member in streamlit.runtime.caching.__dict__.values():
-            member = member.__call__
+            member = member._decorator
 
         fullname = "{}.{}".format(key_prefix, membername)
         member_docstring_dict = get_function_docstring_dict(
@@ -227,14 +228,24 @@ def get_obj_docstring_dict(obj, key_prefix, signature_prefix):
 def get_streamlit_docstring_dict():
     module_docstring_dict = get_obj_docstring_dict(streamlit, "streamlit", "st")
     memo_clear_docstring_dict = get_obj_docstring_dict(
-        streamlit.runtime.caching.memo,
+        streamlit.runtime.caching.experimental_memo,
         "streamlit.experimental_memo",
         "st.experimental_memo",
     )
+    cache_data_clear_docstring_dict = get_obj_docstring_dict(
+        streamlit.runtime.caching.cache_data_api.CacheDataAPI,
+        "streamlit.cache_data",
+        "st.cache_data",
+    )
     singleton_clear_docstring_dict = get_obj_docstring_dict(
-        streamlit.runtime.caching.singleton,
+        streamlit.runtime.caching.experimental_singleton,
         "streamlit.experimental_singleton",
         "st.experimental_singleton",
+    )
+    cache_resource_clear_docstring_dict = get_obj_docstring_dict(
+        streamlit.runtime.caching.cache_resource_api.CacheResourceAPI,
+        "streamlit.cache_resource",
+        "st.cache_resource",
     )
     components_docstring_dict = get_obj_docstring_dict(
         components, "streamlit.components.v1", "st.components.v1"
@@ -244,7 +255,9 @@ def get_streamlit_docstring_dict():
     )
 
     module_docstring_dict.update(memo_clear_docstring_dict)
+    module_docstring_dict.update(cache_data_clear_docstring_dict)
     module_docstring_dict.update(singleton_clear_docstring_dict)
+    module_docstring_dict.update(cache_resource_clear_docstring_dict)
     module_docstring_dict.update(components_docstring_dict)
     module_docstring_dict.update(delta_docstring_dict)
 


### PR DESCRIPTION
## 📚 Context

Streamlit 1.18.0 is deprecates `st.cache`, `st.experimental_memo`, `st.experimental_singleton`, and their respective `.clear()` methods. It also introduces `st.cache_data` and `st.cache_resource` and their `.clear()` methods in its place. Our docstring parser needs to updated.

## 🧠 Description of Changes

- Updates `python/generate.py` to parse these new cache primitives.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Release-Fix-python-generate-py-to-parse-new-cache-primitives-8b9be450de324c958924321dbcfdd90f)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
