### PR TITLE
Fix `visible` param in sidebar

### DIFF
--- a/components/navigation/navChild.js
+++ b/components/navigation/navChild.js
@@ -31,15 +31,17 @@ const NavChild = ({ slug, page, color, className }) => {
   if (page.children?.length > 0 && visibleItems.length > 0 && opened) {
     subNav = (
       <ul className={styles.List}>
-        {page.children.map((child) => (
-          <NavChild
-            slug={slug}
-            key={child.menu_key}
-            page={child}
-            color={color}
-            depth={child.depth + 1}
-          />
-        ))}
+        {page.children
+          .filter((child) => child.visible !== false)
+          .map((child) => (
+            <NavChild
+              slug={slug}
+              key={child.menu_key}
+              page={child}
+              color={color}
+              depth={child.depth + 1}
+            />
+          ))}
       </ul>
     );
   }


### PR DESCRIPTION
## 📚 Context

This PR fixes [this issue](https://www.notion.so/streamlit/Bug-with-setting-visible-boolean-in-docs-menu-md-1d481b1fe4fe4cbfb235372cf2bde925) reported by @snehankekre where the `visible` param in `menu.md` was behaving in a strange way depending on the children nesting level.

## 🧠 Description of Changes

* Added a `.filter` method on the `page.children` map in `<NavChild />`, checking whether the `visible` param is `!== false`;

**Revised:**

![Screenshot 2023-01-26 at 11 14 11 AM](https://user-images.githubusercontent.com/103376966/214858085-a38891dd-8d90-4b9e-a0da-7edc3174a245.png)

![Screenshot 2023-01-26 at 11 14 37 AM](https://user-images.githubusercontent.com/103376966/214858095-7fc8aca2-764a-4cc9-9f7e-ac4a714efe84.png)

**Current:**

![Screenshot 2023-01-26 at 11 15 35 AM](https://user-images.githubusercontent.com/103376966/214858411-5602280f-b5d8-43bf-9aaa-83a160b7a9c3.png)

![Screenshot 2023-01-26 at 11 15 52 AM](https://user-images.githubusercontent.com/103376966/214858415-9071c235-fb67-402b-b496-57e5da99ce57.png)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- https://www.notion.so/streamlit/Bug-with-setting-visible-boolean-in-docs-menu-md-1d481b1fe4fe4cbfb235372cf2bde925

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
