### PR TITLE
Make expanded state of `Collapse` component configurable via prop

### DIFF
--- a/components/blocks/collapse.js
+++ b/components/blocks/collapse.js
@@ -2,8 +2,8 @@ import React, { useState } from "react";
 import styles from "./collapse.module.css";
 import classNames from "classnames";
 
-const Collapse = ({ title, children }) => {
-  const [show, setShow] = useState(false);
+const Collapse = ({ title, children, expanded = false }) => {
+  const [show, setShow] = useState(expanded);
 
   return (
     <section className={styles.Container}>


### PR DESCRIPTION
## 📚 Context

The `Collapse` component is used to expand/collapse content. There isn't a way to set the default expanded state when using the component.

## 🧠 Description of Changes

The following changes were made to the `Collapse` component:

- An `expanded` boolean prop was introduced to allow users to specify whether the content should be expanded or collapsed by default.
- A default value of `false` was set for the expanded prop in case it is not provided.

**Revised:**

```js
const Collapse = ({ title, children, expanded = false }) => {
  const [show, setShow] = useState(expanded);
  // ...
};
```

**Current:**

```js
const Collapse = ({ title, children }) => {
  const [show, setShow] = useState(false);
  // ...
};
```

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->