### PR TITLE
Create KB article on restrictions with nesting `st.columns`

### DIFF
--- a/content/kb/using-streamlit/index.md
+++ b/content/kb/using-streamlit/index.md
@@ -30,3 +30,4 @@ Here are some frequently asked questions about using Streamlit. If you feel some
 - [Widget updating for every second input when using session state](/knowledge-base/using-streamlit/widget-updating-session-state)
 - [How do I create an anchor link?](/knowledge-base/using-streamlit/create-anchor-link)
 - [How do I enable camera access?](/knowledge-base/using-streamlit/enable-camera)
+- [Why does Streamlit restrict nested `st.columns`?](/knowledge-base/using-streamlit/why-streamlit-restrict-nested-columns)

--- a/content/kb/using-streamlit/why-streamlit-restrict-nested-columns.md
+++ b/content/kb/using-streamlit/why-streamlit-restrict-nested-columns.md
@@ -1,0 +1,21 @@
+---
+title: Why does Streamlit restrict nested st.columns?
+slug: /knowledge-base/using-streamlit/why-streamlit-restrict-nested-columns
+---
+
+# Why does Streamlit restrict nested `st.columns`?
+
+Starting in version 1.18.0, Streamlit allows nesting [`st.columns`](/library/api-reference/widgets/st.columns) inside other 
+`st.columns` with the following restrictions:
+
+- In the main area of the app, columns can be nested up to one level of nesting. 
+- In the sidebar, columns cannot be nested. 
+
+These restrictions are in place to make Streamlit apps look good on all device sizes. Nesting columns multiple times often leads to a bad UI. 
+You might be able to make it look good on one screen size but as soon as a user on a different screen views the app, 
+they will have a bad experience. Some columns will be tiny, others will be way too long, and complex layouts will look out of place.
+Streamlit tries its best to automatically resize elements to look good across devices, without any help from the developer. 
+But for complex layouts with multiple levels of nesting, this is not possible. 
+
+We are always working on improving layout options though! So if you have a use case that requires a more complex layout, 
+please [open a GitHub issue](https://github.com/streamlit/streamlit/issues), ideally with a sketch of what you want to do. 

--- a/content/menu.md
+++ b/content/menu.md
@@ -484,6 +484,9 @@ site_menu:
   - category: Knowledge base / Using Streamlit / Widget updating for every second input when using session state
     url: /knowledge-base/using-streamlit/widget-updating-session-state
     visible: false
+  - category: Knowledge base / Using Streamlit / Why does Streamlit restrict nested st.columns?
+    url: /knowledge-base/using-streamlit/why-streamlit-restrict-nested-columns
+    visible: false
   - category: Knowledge base / Streamlit Components
     url: /knowledge-base/components
   - category: Knowledge base / Streamlit Components / How do I add a Component to the sidebar?


### PR DESCRIPTION
## 📚 Context

We are introducing columns in columns with 1.18. A lot of users complained about this in the past and couldn't understand why there's a restriction at all. With the new feature, this should become less but I'm sure there will still be some people who complain. So I thought it might make sense to explain why these restrictions are in place. 

Warning: I did not test this since I have no clue how to do that!

## 🧠 Description of Changes

<!-- What was specifically changed? Which files, algorithms, links, media? -->
<!-- Please add them here as a bulleted list -->
- Add a page `why-streamlit-restrict-nested-columns.md` in the KB section
- Link the file from `index.md`

**Revised:**

![CleanShot 2023-02-01 at 01 38 30](https://user-images.githubusercontent.com/5103165/215916258-5559398b-398b-4081-a312-565ec6ddeb41.png)

**Current:**

None

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Spec for columns inside columns](https://www.notion.so/streamlit/Product-spec-ce90f98d2bf64307a72b14b5fc8f6f27)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
