### PR TITLE
Rename “Privacy Policy” → "Privacy Notice”

### DIFF
--- a/content/gdpr-banner.md
+++ b/content/gdpr-banner.md
@@ -5,4 +5,4 @@ title: We value your privacy.
 
 We would like to use cookies to help us understand how users interact with this website. This is used, for example, to find out which parts of this site should be further improved.
 
-More information can be found in our [privacy policy](www.streamlit.io/privacy-policy).
+More information can be found in our [privacy notice](www.streamlit.io/privacy-policy).

--- a/content/gdpr-banner.md
+++ b/content/gdpr-banner.md
@@ -5,4 +5,4 @@ title: We value your privacy.
 
 We would like to use cookies to help us understand how users interact with this website. This is used, for example, to find out which parts of this site should be further improved.
 
-More information can be found in our [privacy notice](www.streamlit.io/privacy-policy).
+More information can be found in our [Privacy Notice](www.streamlit.io/privacy-policy).

--- a/content/library/advanced-features/configuration.md
+++ b/content/library/advanced-features/configuration.md
@@ -44,7 +44,7 @@ To set configuration options on Streamlit Community Cloud, read [Optionally, add
 ## Telemetry
 
 As mentioned during the installation process, Streamlit collects usage statistics. You can find out
-more by reading our [privacy policy](https://streamlit.io/privacy-policy), but the high-level
+more by reading our [privacy notice](https://streamlit.io/privacy-policy), but the high-level
 summary is that although we collect telemetry data we cannot see and do not store information
 contained in Streamlit apps.
 

--- a/content/library/advanced-features/configuration.md
+++ b/content/library/advanced-features/configuration.md
@@ -44,7 +44,7 @@ To set configuration options on Streamlit Community Cloud, read [Optionally, add
 ## Telemetry
 
 As mentioned during the installation process, Streamlit collects usage statistics. You can find out
-more by reading our [privacy notice](https://streamlit.io/privacy-policy), but the high-level
+more by reading our [Privacy Notice](https://streamlit.io/privacy-policy), but the high-level
 summary is that although we collect telemetry data we cannot see and do not store information
 contained in Streamlit apps.
 

--- a/content/streamlit-cloud/get-started/manage-your-app.md
+++ b/content/streamlit-cloud/get-started/manage-your-app.md
@@ -274,4 +274,4 @@ Common reasons why users show up anonymously are:
 2. Given viewer viewed app in April 2022, when the Streamlit team was honing user identification for this feature
 3. Given viewer disconnected their SSO and GitHub accounts previously
 
-See Streamlit's general Privacy Policy [here](https://streamlit.io/privacy-policy).
+See Streamlit's general [Privacy Notice](https://streamlit.io/privacy-policy).


### PR DESCRIPTION
## 📚 Context

The Docs Team has received a small request from Legal to update update mentions of "Privacy Policy" to "Privacy Notice" in the docs.

## 🧠 Description of Changes

- Renames "Privacy Policy" to "Privacy Notice".

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Minor-Privacy-Policy-Privacy-Notice-update-request-fbd70199f7ee47f990abee043a18e089)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
