### PR TITLE
Add KB article on how to host static files

### DIFF
--- a/content/kb/using-streamlit/how-host-static-files.md
+++ b/content/kb/using-streamlit/how-host-static-files.md
@@ -1,0 +1,55 @@
+---
+title: How to host static files in Streamlit?
+slug: /knowledge-base/using-streamlit/how-host-static-files
+---
+
+# How to host static files in Streamlit?
+
+Streamlit apps can host and serve small, static media files to support media embedding use cases that
+won't work with the normal [media elements](https://docs.streamlit.io/library/api-reference/media).
+
+To enable this feature, set `enableStaticServing = true` under `[server]` in your config file,
+or environment variable `STREAMLIT_SERVER_ENABLE_STATIC_SERVING=true`.
+
+Media stored in the folder `./static/` relative to the running app file is served at path
+`app/static/[filename]`, such as `http://localhost:8501/app/static/cat.png`.
+
+## Details on usage
+
+- Files with the following extensions will be served normally: `".jpg", ".jpeg", ".png", ".gif"`. Any other
+  file will be sent with header `Content-Type:text/plain` which will cause browsers to render in plain text.
+  This is included for security - other file types that need to render should be hosted outside the app.
+- Streamlit also sets `X-Content-Type-Options:nosniff` for all files rendered from the static directory.
+- For apps running on Streamlit Community Cloud:
+  - Files available in the Github repo will always be served. Any files generated while the app is running,
+    such as based on user interaction (file upload, etc), are not guaranteed to persist across user sessions.
+  - Apps which store and serve many files, or large files, may run into resource limits and be shut down.
+
+## Example usage
+
+- Put an image `cat.png` in the folder `./static/`
+- Add `enableStaticServing = true` under `[server]` in your `.streamlit/config.toml`
+- Any media in the `./static/` folder is served at the relative URL like `app/static/cat.png`
+
+```toml
+# .streamlit/config.toml
+
+[server]
+enableStaticServing = true
+```
+
+```python
+# app.py
+import streamlit as st
+
+with st.echo():
+    st.title("CAT")
+
+    st.markdown("[![Click me](app/static/cat.png)](https://streamlit.io)")
+
+```
+
+Additional resources:
+
+- <https://docs.streamlit.io/library/advanced-features/configuration>
+- <https://static.streamlit.app/>

--- a/content/kb/using-streamlit/index.md
+++ b/content/kb/using-streamlit/index.md
@@ -31,3 +31,4 @@ Here are some frequently asked questions about using Streamlit. If you feel some
 - [How do I create an anchor link?](/knowledge-base/using-streamlit/create-anchor-link)
 - [How do I enable camera access?](/knowledge-base/using-streamlit/enable-camera)
 - [Why does Streamlit restrict nested `st.columns`?](/knowledge-base/using-streamlit/why-streamlit-restrict-nested-columns)
+- [How to host static files in Streamlit?](/knowledge-base/using-streamlit/how-host-static-files)

--- a/content/menu.md
+++ b/content/menu.md
@@ -487,6 +487,9 @@ site_menu:
   - category: Knowledge base / Using Streamlit / Why does Streamlit restrict nested st.columns?
     url: /knowledge-base/using-streamlit/why-streamlit-restrict-nested-columns
     visible: false
+  - category: Knowledge base / Using Streamlit / How to host static files in Streamlit?
+    url: /knowledge-base/using-streamlit/how-host-static-files
+    visible: false
   - category: Knowledge base / Streamlit Components
     url: /knowledge-base/components
   - category: Knowledge base / Streamlit Components / How do I add a Component to the sidebar?


### PR DESCRIPTION
## 📚 Context

Add a KB article for static file serving (merged in https://github.com/streamlit/streamlit/pull/5691)

## 🧠 Description of Changes

- Add a knowledge base article for hosting static files
- Link it from the "Using Streamlit" index

**Revised:**

https://deploy-preview-586--streamlit-docs.netlify.app/knowledge-base/using-streamlit/how-host-static-files

**Current:**

Page does not exist

## 💥 Impact

We have docs for the new feature!

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

## 🌐 References

- [ ] [Notion](https://www.notion.so/streamlit/Ability-to-serve-static-files-88a97775bd6a49d5a71f190a8e3c7dbf)

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
