### PR TITLE
Truncate large titles in pagination

### DIFF
--- a/components/navigation/arrowLink.js
+++ b/components/navigation/arrowLink.js
@@ -29,7 +29,7 @@ const ArrowLink = ({ children, link, type, content, target }) => {
               <path d="M7.22017 13.7159L8.70312 12.2393L4.81037 8.35298H13.9318V6.19247H4.81037L8.70312 2.29972L7.22017 0.829545L0.776989 7.27273L7.22017 13.7159Z" />
             </svg>
             <span className={styles.Text}>Previous: </span>
-            {content}
+            <span className={styles.Truncate}>{content}</span>
           </a>
         </Link>
       );
@@ -46,7 +46,7 @@ const ArrowLink = ({ children, link, type, content, target }) => {
             target={target == "_blank" ? target : "_self"}
           >
             <span className={styles.Text}>Next: </span>
-            {content}
+            <span className={styles.Truncate}>{content}</span>
             <svg
               width="14"
               height="14"

--- a/components/navigation/arrowLink.module.css
+++ b/components/navigation/arrowLink.module.css
@@ -1,9 +1,13 @@
 .Container {
-  @apply flex flex-wrap flex-col md:flex-row md:flex-nowrap items-center justify-between mt-20;
+  @apply flex flex-wrap flex-col md:flex-row md:flex-nowrap items-center justify-between mt-20 gap-4;
 }
 
 .Link {
-  @apply border-none text-base tracking-tight font-sans font-normal text-gray-90 leading-7 hover:opacity-70 flex items-center transition-all;
+  @apply overflow-hidden border-none text-base tracking-tight font-sans font-normal text-gray-90 leading-7 hover:opacity-70 flex items-center transition-all;
+}
+
+.Truncate {
+  @apply truncate;
 }
 
 :global(.dark) .Link {


### PR DESCRIPTION
## 📚 Context

This PR fixes and issue I found where pagination titles would go in two lines if you're using a small desktop resolution.

## 🧠 Description of Changes

* Added truncation styles (`truncate`, `overflow-hidden` and `text-ellipsis`) on the `arrowLink` component;
* Added a `gap-4` style on the container, to separate pagination content if they're too close to the other.

**Revised:**

![Screenshot 2023-02-14 at 5 35 04 PM](https://user-images.githubusercontent.com/103376966/218857546-b23a8940-b36e-44e3-9d44-3d227cafee67.png)

**Current:**

![Screenshot 2023-01-25 at 2 36 19 PM](https://user-images.githubusercontent.com/103376966/218857673-65fd61ea-818d-485f-8e83-3d00e458162d.png)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- https://www.notion.so/streamlit/Truncate-large-titles-in-pagination-825336d8632d418299c3839f1d3f5840?pvs=4

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
