### PR TITLE
Clean up algolia search markup

### DIFF
--- a/scripts/build-search-index.js
+++ b/scripts/build-search-index.js
@@ -5,7 +5,7 @@ const utils = require("../lib/utils.js");
 const contentDirectory = path.join(process.cwd(), ".next/server/pages");
 const parser = require("node-html-parser");
 const algoliasearch = require("algoliasearch");
-const { convert, compile } = require("html-to-text");
+const { convert } = require("html-to-text");
 
 const SKIP_THESE = ["/menu", "/404", "/500"];
 


### PR DESCRIPTION
## 📚 Context

This PR fixes an issue reported by @sfc-gh-tteixeira, to clean up (or "massage") the way we're sending the markup data to Algolia.

## 🧠 Description of Changes

* Added `<form>` tags to the `remove_tags` array, to remove the `Is this page helpful?` section;
* Created a `compileOptions` object, to ignore `href` attributes and `<img>` tags.

**Revised:**

![Screenshot 2023-02-14 at 6 44 25 PM](https://user-images.githubusercontent.com/103376966/218870165-d0f1b020-2453-4976-8b82-04a66820ccf1.png)

**Current:**

![Screenshot 2023-02-02 at 2 38 48 PM](https://user-images.githubusercontent.com/103376966/218869580-651b62b0-0eba-47ec-933f-0daf440fc985.png)

## 💥 Impact

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

## 🌐 References

- https://www.notion.so/streamlit/Fix-the-way-links-are-shown-in-docs-search-bar-f726850159aa4b93bafd19761dd30e9c?pvs=4

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
