### PR TITLE
Update example in public google sheets tutorial to not use `gsheetsdb`

### DIFF
--- a/content/kb/tutorials/databases/public-gsheet.md
+++ b/content/kb/tutorials/databases/public-gsheet.md
@@ -67,8 +67,8 @@ def load_data(sheets_url):
 df = load_data(st.secrets["public_gsheets_url"])
 
 # Print results.
-for _, row in df.iterrows():
-    st.write(f"{row.name} has a :{row.pet}:")
+for row in df.itertuples():
+    st.write(f"{row.Index} has a :{row.pet}:")
 ```
 
 See `st.cache_data` above? Without it, Streamlit would run the query every time the app reruns (e.g. on a widget interaction). With `st.cache_data`, it only runs when the query changes or after 10 minutes (that's what `ttl` is for). Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Learn more in [Caching](/library/advanced-features/caching).

--- a/content/kb/tutorials/databases/public-gsheet.md
+++ b/content/kb/tutorials/databases/public-gsheet.md
@@ -62,13 +62,13 @@ import streamlit as st
 @st.cache_data(ttl=600)
 def load_data(sheets_url):
     csv_url = sheets_url.replace("/edit#gid=", "/export?format=csv&gid=")
-    return pd.read_csv(csv_url, index_col=0)
+    return pd.read_csv(csv_url)
 
 df = load_data(st.secrets["public_gsheets_url"])
 
 # Print results.
 for row in df.itertuples():
-    st.write(f"{row.Index} has a :{row.pet}:")
+    st.write(f"{row.name} has a :{row.pet}:")
 ```
 
 See `st.cache_data` above? Without it, Streamlit would run the query every time the app reruns (e.g. on a widget interaction). With `st.cache_data`, it only runs when the query changes or after 10 minutes (that's what `ttl` is for). Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Learn more in [Caching](/library/advanced-features/caching).


### PR DESCRIPTION
## 📚 Context

Fixes #589. TODO: update the private gooogle sheet tutorial to use a `gsheetsdb` alternative in a separate PR.

## 🧠 Description of Changes

- Replaces the use of the deprecated `gsheetsdb` library with `pandas`.

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/219328476-e626633c-422c-4805-875c-99873d678a09.png)
![image](https://user-images.githubusercontent.com/20672874/219328227-335a641c-6fb7-45bc-97a0-b44beaeaad52.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/219328717-3b667b8f-308c-43e4-b4eb-0c74acd25357.png)
![image](https://user-images.githubusercontent.com/20672874/219328776-c803a926-d3e9-4e0a-aae7-df10311a7e06.png)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Example-code-in-public-google-sheets-tutorial-is-broken-2a46c3eabdec4453bf6057b4fa651ccc)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
