### PR TITLE
Add `st.experimental_data_editor` example apps to repo

### DIFF
--- a/python/api-examples-source/data.data_editor.py
+++ b/python/api-examples-source/data.data_editor.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import streamlit as st
+
+
+@st.cache_data
+def load_data():
+    return pd.DataFrame(
+        [
+            {"command": "st.selectbox", "rating": 4, "is_widget": True},
+            {"command": "st.balloons", "rating": 5, "is_widget": False},
+            {"command": "st.time_input", "rating": 3, "is_widget": True},
+        ]
+    )
+
+
+df = load_data()
+edited_df = st.experimental_data_editor(df)
+
+favorite_command = edited_df.loc[edited_df["rating"].idxmax()]["command"]
+st.markdown(f"Your favorite command is **{favorite_command}** 🎈")

--- a/python/api-examples-source/data.data_editor1.py
+++ b/python/api-examples-source/data.data_editor1.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import streamlit as st
+
+
+@st.cache_data
+def load_data():
+    return pd.DataFrame(
+        [
+            {"command": "st.selectbox", "rating": 4, "is_widget": True},
+            {"command": "st.balloons", "rating": 5, "is_widget": False},
+            {"command": "st.time_input", "rating": 3, "is_widget": True},
+        ]
+    )
+
+
+df = load_data()
+edited_df = st.experimental_data_editor(df, num_rows="dynamic")
+
+favorite_command = edited_df.loc[edited_df["rating"].idxmax()]["command"]
+st.markdown(f"Your favorite command is **{favorite_command}** 🎈")

--- a/python/api-examples-source/requirements.txt
+++ b/python/api-examples-source/requirements.txt
@@ -8,4 +8,4 @@ numpy==1.22.0
 scipy
 altair==4.2.0
 pydeck==0.7.1
-streamlit==1.18.1
+streamlit-nightly==1.18.2.dev20230215


### PR DESCRIPTION
## 📚 Context

Streamlit 1.19.0 is going to include the release of a new command: `st.experimental_data_editor`. We need to embed a few related apps in the docstrings in the core repo.

## 🧠 Description of Changes

- Adds two example apps for `st.experimental_data_editor` that once deployed will be embedded in the core repo docstrings.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Release-add-st-experimental_data_editor-apps-to-docs-repo-c36ff1526bad4204bcac5aec37cff144)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
