### PR TITLE
Fix incorrect link to st.columns API in KB article

### DIFF
--- a/content/kb/using-streamlit/why-streamlit-restrict-nested-columns.md
+++ b/content/kb/using-streamlit/why-streamlit-restrict-nested-columns.md
@@ -5,17 +5,17 @@ slug: /knowledge-base/using-streamlit/why-streamlit-restrict-nested-columns
 
 # Why does Streamlit restrict nested `st.columns`?
 
-Starting in version 1.18.0, Streamlit allows nesting [`st.columns`](/library/api-reference/widgets/st.columns) inside other 
+Starting in version 1.18.0, Streamlit allows nesting [`st.columns`](/library/api-reference/layout/st.columns) inside other
 `st.columns` with the following restrictions:
 
-- In the main area of the app, columns can be nested up to one level of nesting. 
-- In the sidebar, columns cannot be nested. 
+- In the main area of the app, columns can be nested up to one level of nesting.
+- In the sidebar, columns cannot be nested.
 
-These restrictions are in place to make Streamlit apps look good on all device sizes. Nesting columns multiple times often leads to a bad UI. 
-You might be able to make it look good on one screen size but as soon as a user on a different screen views the app, 
+These restrictions are in place to make Streamlit apps look good on all device sizes. Nesting columns multiple times often leads to a bad UI.
+You might be able to make it look good on one screen size but as soon as a user on a different screen views the app,
 they will have a bad experience. Some columns will be tiny, others will be way too long, and complex layouts will look out of place.
-Streamlit tries its best to automatically resize elements to look good across devices, without any help from the developer. 
-But for complex layouts with multiple levels of nesting, this is not possible. 
+Streamlit tries its best to automatically resize elements to look good across devices, without any help from the developer.
+But for complex layouts with multiple levels of nesting, this is not possible.
 
-We are always working on improving layout options though! So if you have a use case that requires a more complex layout, 
-please [open a GitHub issue](https://github.com/streamlit/streamlit/issues), ideally with a sketch of what you want to do. 
+We are always working on improving layout options though! So if you have a use case that requires a more complex layout,
+please [open a GitHub issue](https://github.com/streamlit/streamlit/issues), ideally with a sketch of what you want to do.


### PR DESCRIPTION
## 📚 Context

@sfc-gh-jesmith [pointed out](https://www.notion.so/streamlit/Fix-link-to-st-columns-on-nested-columns-page-0b5bd43741e2412ba23a18028cd8bcdc) that our KB article on nested columns contains an incorrect link to the `st.columns` API reference.

## 🧠 Description of Changes

- Replaces the broken link with the right one.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Fix-link-to-st-columns-in-nested-column-KB-article-4fb7a3547af44b6691d4de2e64ab89fd)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
