### PR TITLE
Add 1.20.0 related changes

### DIFF
--- a/content/library/advanced-features/configuration.md
+++ b/content/library/advanced-features/configuration.md
@@ -72,7 +72,7 @@ streamlit config show
 The command above will print something like this:
 
 ```toml
-# Streamlit version: 1.19.0
+# Streamlit version: 1.20.0
 
 [global]
 
@@ -136,9 +136,9 @@ fixMatplotlib = true
 # Default: true
 postScriptGC = true
 
-# Handle script rerun requests immediately, rather than waiting for script execution to reach a yield point. Enabling this will make Streamlit much more responsive to user interaction, but it can lead to race conditions in apps that mutate session_state data outside of explicit session_state assignment statements.
-# Default: false
-fastReruns = false
+# Handle script rerun requests immediately, rather than waiting for script execution to reach a yield point. This makes Streamlit much more responsive to user interaction, but it can lead to race conditions in apps that mutate session_state data outside of explicit session_state assignment statements.
+# Default: true
+fastReruns = true
 
 
 [server]
@@ -203,6 +203,14 @@ enableWebsocketCompression = false
 # Enable serving files from a `static` directory in the running app's directory.
 # Default: false
 enableStaticServing = false
+
+# Server certificate file for connecting via HTTPS. Must be set at the same time as "server.sslKeyFile".
+# ['DO NOT USE THIS OPTION IN A PRODUCTION ENVIRONMENT. It has not gone through security audits or performance tests. For the production environment, we recommend performing SSL termination by the load balancer or the reverse proxy.']
+# sslCertFile =
+
+# Cryptographic key file for connecting via HTTPS. Must be set at the same time as "server.sslCertFile".
+# ['DO NOT USE THIS OPTION IN A PRODUCTION ENVIRONMENT. It has not gone through security audits or performance tests. For the production environment, we recommend performing SSL termination by the load balancer or the reverse proxy.']
+# sslKeyFile =
 
 [browser]
 

--- a/content/library/advanced-features/dataframes.md
+++ b/content/library/advanced-features/dataframes.md
@@ -26,7 +26,7 @@ df = pd.DataFrame(
 st.dataframe(df, use_container_width=True)
 ```
 
-<Cloud src="https://doc-dataframe-basic.streamlit.app/?embedded=true" height="300px"/>
+<Cloud src="https://doc-dataframe-basic.streamlit.app/?embed=true" height="300px"/>
 
 ## Additional UI features
 
@@ -66,7 +66,7 @@ st.markdown(f"Your favorite command is **{favorite_command}** 🎈")
 
 <Collapse title="View interactive app">
 
-<Cloud src="https://doc-data-editor.streamlit.app/?embedded=true" height="300px"/>
+<Cloud src="https://doc-data-editor.streamlit.app/?embed=true" height="300px"/>
 
 </Collapse>
 
@@ -92,7 +92,7 @@ The data editor supports pasting in tabular data from Google Sheets, Excel, Noti
 
 <Collapse title="View interactive app">
 
-<Cloud src="https://doc-data-editor-clipboard.streamlit.app/?embedded=true" height="400px"/>
+<Cloud src="https://doc-data-editor-clipboard.streamlit.app/?embed=true" height="400px"/>
 
 </Collapse>
 
@@ -119,7 +119,7 @@ edited_df = st.experimental_data_editor(df, num_rows=”dynamic”)
 
 <Collapse title="View interactive app">
 
-<Cloud src="https://doc-data-editor-clipboard.streamlit.app/?embedded=true" height="400px"/>
+<Cloud src="https://doc-data-editor-clipboard.streamlit.app/?embed=true" height="400px"/>
 
 </Collapse>
 
@@ -145,7 +145,7 @@ This can be useful when working with large dataframes and you only need to know 
 
 <Collapse title="View interactive app">
 
-<Cloud src="https://doc-data-editor-changed.streamlit.app/?embedded=true" height="700px"/>
+<Cloud src="https://doc-data-editor-changed.streamlit.app/?embed=true" height="700px"/>
 
 </Collapse>
 

--- a/content/library/advanced-features/static-file-serving.md
+++ b/content/library/advanced-features/static-file-serving.md
@@ -1,0 +1,55 @@
+---
+title: Static file serving
+slug: /library/advanced-features/static-file-serving
+---
+
+# Static file serving
+
+Streamlit apps can host and serve small, static media files to support media embedding use cases that
+won't work with the normal [media elements](https://docs.streamlit.io/library/api-reference/media).
+
+To enable this feature, set `enableStaticServing = true` under `[server]` in your config file,
+or environment variable `STREAMLIT_SERVER_ENABLE_STATIC_SERVING=true`.
+
+Media stored in the folder `./static/` relative to the running app file is served at path
+`app/static/[filename]`, such as `http://localhost:8501/app/static/cat.png`.
+
+## Details on usage
+
+- Files with the following extensions will be served normally: `".jpg", ".jpeg", ".png", ".gif"`. Any other
+  file will be sent with header `Content-Type:text/plain` which will cause browsers to render in plain text.
+  This is included for security - other file types that need to render should be hosted outside the app.
+- Streamlit also sets `X-Content-Type-Options:nosniff` for all files rendered from the static directory.
+- For apps running on Streamlit Community Cloud:
+  - Files available in the Github repo will always be served. Any files generated while the app is running,
+    such as based on user interaction (file upload, etc), are not guaranteed to persist across user sessions.
+  - Apps which store and serve many files, or large files, may run into resource limits and be shut down.
+
+## Example usage
+
+- Put an image `cat.png` in the folder `./static/`
+- Add `enableStaticServing = true` under `[server]` in your `.streamlit/config.toml`
+- Any media in the `./static/` folder is served at the relative URL like `app/static/cat.png`
+
+```toml
+# .streamlit/config.toml
+
+[server]
+enableStaticServing = true
+```
+
+```python
+# app.py
+import streamlit as st
+
+with st.echo():
+    st.title("CAT")
+
+    st.markdown("[![Click me](app/static/cat.png)](https://streamlit.io)")
+
+```
+
+Additional resources:
+
+- <https://docs.streamlit.io/library/advanced-features/configuration>
+- <https://static.streamlit.app/>

--- a/content/library/api-cheat-sheet.md
+++ b/content/library/api-cheat-sheet.md
@@ -5,7 +5,7 @@ slug: /library/cheatsheet
 
 # Cheat Sheet
 
-This is a summary of the docs, as of [Streamlit v1.19.0](https://pypi.org/project/streamlit/1.15.0/).
+This is a summary of the docs, as of [Streamlit v1.20.0](https://pypi.org/project/streamlit/1.15.0/).
 
 <Masonry>
 

--- a/content/library/api/charts/altair_chart.md
+++ b/content/library/api/charts/altair_chart.md
@@ -263,4 +263,4 @@ To use images instead of emojis, replace the line containing `.mark_text()` with
 
 Now that you've learned how to annotate charts, the sky's the limit! We've extended the above example to let you interactively paste your favorite emoji and set its position on the chart with Streamlit widgets. 👇
 
-<Cloud src="https://example-time-series-annotation.streamlit.app/?embedded=true" height="700" />
+<Cloud src="https://example-time-series-annotation.streamlit.app/?embed=true" height="700" />

--- a/content/library/api/data/dataframe.md
+++ b/content/library/api/data/dataframe.md
@@ -34,7 +34,7 @@ df = load_data()
 st.dataframe(df, use_container_width=st.session_state.use_container_width)
 ```
 
-<Cloud src="https://doc-dataframe2.streamlit.app/?embedded=true" height="350" />
+<Cloud src="https://doc-dataframe2.streamlit.app/?embed=true" height="350" />
 
 ### Interactivity
 

--- a/content/library/api/widgets/radio.md
+++ b/content/library/api/widgets/radio.md
@@ -36,7 +36,7 @@ with col2:
     )
 ```
 
-<Cloud src="https://doc-radio1.streamlit.app/?embedded=true" height="300" />
+<Cloud src="https://doc-radio1.streamlit.app/?embed=true" height="300" />
 
 ### Featured videos
 

--- a/content/library/api/widgets/selectbox.md
+++ b/content/library/api/widgets/selectbox.md
@@ -37,4 +37,4 @@ with col2:
     )
 ```
 
-<Cloud src="https://doc-selectbox1.streamlit.app/?embedded=true" height="300" />
+<Cloud src="https://doc-selectbox1.streamlit.app/?embed=true" height="300" />

--- a/content/library/api/widgets/text_input.md
+++ b/content/library/api/widgets/text_input.md
@@ -45,4 +45,4 @@ with col2:
         st.write("You entered: ", text_input)
 ```
 
-<Cloud src="https://doc-text-input1.streamlit.app/?embedded=true" height="400" />
+<Cloud src="https://doc-text-input1.streamlit.app/?embed=true" height="400" />

--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -23,9 +23,9 @@ _Release date: March 09, 2023_
 
 **Notable Changes**
 
-- 🔐 Added support for configuring SSL to [serve apps directly over HTTPS](https://docs.streamlit.io/library/advanced-features/https-support) ([#5969](https://github.com/streamlit/streamlit/pull/5969)).
-- 🖼️ Granular control over app embedding behavior with the `/?embed` and `/?embed_options` query parameters. Learn how to use this feature in our [docs](https://docs.streamlit.io/streamlit-community-cloud/get-started/deploy-an-app#embed-apps) ([#6011](https://github.com/streamlit/streamlit/pull/6011), [#6019](https://github.com/streamlit/streamlit/pull/6019)).
-- ⚡ Enabled the `runner.fastReruns` [configuration option](https://docs.streamlit.io/library/advanced-features/configuration#view-all-configuration-options) by default to make apps much more responsive to user interaction ([#6200](https://github.com/streamlit/streamlit/pull/6200)).
+- 🔐 Added support for configuring SSL to [serve apps directly over HTTPS](/library/advanced-features/https-support) ([#5969](https://github.com/streamlit/streamlit/pull/5969)).
+- 🖼️ Granular control over app embedding behavior with the `/?embed` and `/?embed_options` query parameters. Learn how to use this feature in our [docs](/streamlit-community-cloud/get-started/deploy-an-app#embed-apps) ([#6011](https://github.com/streamlit/streamlit/pull/6011), [#6019](https://github.com/streamlit/streamlit/pull/6019)).
+- ⚡ Enabled the `runner.fastReruns` [configuration option](/library/advanced-features/configuration#view-all-configuration-options) by default to make apps much more responsive to user interaction ([#6200](https://github.com/streamlit/streamlit/pull/6200)).
 
 **Other Changes**
 

--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -17,6 +17,27 @@ pip install --upgrade streamlit
 
 </Tip>
 
+## **Version 1.20.0**
+
+_Release date: March 09, 2023_
+
+**Notable Changes**
+
+- 🔐 Added support for configuring SSL to [serve apps directly over HTTPS](https://docs.streamlit.io/library/advanced-features/https-support) ([#5969](https://github.com/streamlit/streamlit/pull/5969)).
+- 🖼️ Granular control over app embedding behavior with the `/?embed` and `/?embed_options` query parameters. Learn how to use this feature in our [docs](https://docs.streamlit.io/streamlit-community-cloud/get-started/deploy-an-app#embed-apps) ([#6011](https://github.com/streamlit/streamlit/pull/6011), [#6019](https://github.com/streamlit/streamlit/pull/6019)).
+- ⚡ Enabled the `runner.fastReruns` [configuration option](https://docs.streamlit.io/library/advanced-features/configuration#view-all-configuration-options) by default to make apps much more responsive to user interaction ([#6200](https://github.com/streamlit/streamlit/pull/6200)).
+
+**Other Changes**
+
+- 🍔 Cleaned up the hamburger menu by removing the least used options ([#6080](https://github.com/streamlit/streamlit/pull/6080)).
+- 🖨️ Design changes to ensure apps being printed or saved as a PDF look good ([#6180](https://github.com/streamlit/streamlit/pull/6180)).
+- 🐞 Bug fix: improved `dtypes` checking in `st.experimental_data_editor` ([#6185](https://github.com/streamlit/streamlit/issues/6185), [#6188](https://github.com/streamlit/streamlit/pull/6188)).
+- 🐛 Bug fix: properly position `st.metric`'s `help` tooltip when not inside columns ([#6168](https://github.com/streamlit/streamlit/pull/6168)).
+- 🪲 Bug fix: regression in retrieving messages from the server's `ForwardMsgCache` ([#6210](https://github.com/streamlit/streamlit/pull/6210)).
+- 🌀 Bug fix: `st.cache_data` docstring for the `show_spinner` param now lists `str` as a supported type ([#6207](https://github.com/streamlit/streamlit/issues/6207), [#6213](https://github.com/streamlit/streamlit/pull/6213)).
+- ⏱️ Made ping and websocket timeouts far more forgiving ([#6212](https://github.com/streamlit/streamlit/pull/6212)).
+- 🗺️ `st.map` and `st.pydeck_chart` docs state that Streamlit's Mapbox token will not work indefinitely ([#6143](https://github.com/streamlit/streamlit/pull/6143)).
+
 ## **Version 1.19.0**
 
 _Release date: February 23, 2023_

--- a/content/library/get-started/multipage-apps/create-a-multi-page-app.md
+++ b/content/library/get-started/multipage-apps/create-a-multi-page-app.md
@@ -254,7 +254,7 @@ page_names_to_funcs[demo_name]()
 
 </details>
 
-<Cloud src="https://doc-hello.streamlit.app/?embedded=true" height="700" />
+<Cloud src="https://doc-hello.streamlit.app/?embed=true" height="700" />
 
 Notice how large the file is! Each app “page” is written as a function, and the selectbox is used to pick which page to display. As our app grows, maintaining the code requires a lot of additional overhead. Moreover, we’re limited by the `st.selectbox` UI to choose which “page” to run, we cannot customize individual page titles with `st.set_page_config`, and we’re unable to navigate between pages using URLs.
 
@@ -559,7 +559,7 @@ streamlit run Hello.py
 
 That’s it! The `Hello.py` script now corresponds to the main page of your app, and other scripts that Streamlit finds in the pages folder will also be present in the new page selector that appears in the sidebar.
 
-<Cloud src="https://doc-mpa-hello.streamlit.app/?embedded=true" height="700" />
+<Cloud src="https://doc-mpa-hello.streamlit.app/?embed=true" height="700" />
 
 ## Next steps
 

--- a/content/menu.md
+++ b/content/menu.md
@@ -321,6 +321,8 @@ site_menu:
     url: /library/advanced-features/prerelease
   - category: Streamlit library / Advanced features/ Working with timezones
     url: /library/advanced-features/timezone-handling
+  - category: Streamlit library / Advanced features/ Static file serving
+    url: /library/advanced-features/static-file-serving
   - category: Streamlit library / Advanced features/ HTTPS support
     url: /library/advanced-features/https-support
   - category: Streamlit library / Components

--- a/content/streamlit-cloud/get-started/deploy-an-app/index.md
+++ b/content/streamlit-cloud/get-started/deploy-an-app/index.md
@@ -87,19 +87,90 @@ This subdomain is unique to your app and can be used to share your app with othe
 
 ### Embed apps
 
-Streamlit Community Cloud supports embedding **public** apps using the subdomain scheme. To embed a public app, add the query parameter `/?embedded=true` to the end of the `*streamlit.app` subdomain URL.
+Streamlit Community Cloud supports embedding **public** apps using the subdomain scheme. To embed a public app, add the query parameter `/?embed=true` to the end of the `*streamlit.app` subdomain URL.
 
-For example, say you want to embed the Streamlit Docs' PyDeck app: [https://doc-pydeck-chart.streamlit.app/](https://doc-pydeck-chart.streamlit.app/). The URL to include in your iframe is: [https://doc-pydeck-chart.streamlit.app/?embedded=true](https://doc-pydeck-chart.streamlit.app/?embedded=true).
+For example, say you want to embed the Streamlit Docs' radio button app: [https://doc-radio1.streamlit.app/](https://doc-radio1.streamlit.app/). The URL to include in your iframe is: [https://doc-radio1.streamlit.app/?embed=true](https://doc-radio1.streamlit.app/?embed=true):
 
-If you want to hide the chrome, scrollbars, and hamburger menu in your embedded apps, you can add the `/?embed=true` query parameter instead to the end of the `*streamlit.app` subdomain URL.
+```js
+<iframe
+  src="https://doc-radio1.streamlit.app/?embed=true"
+  height="250"
+  style="width:100%;border:none;"
+></iframe>
+```
 
-For example: [https://doc-pydeck-chart.streamlit.app/?embed=true](https://doc-pydeck-chart.streamlit.app/?embed=true).
+<Cloud src="https://doc-radio1.streamlit.app/?embed=true" height="250" style="width:100%;border:none;"></Cloud>
 
 <Important>
 
 There will be no official support for embedding private apps.
 
 </Important>
+
+In addition to allowing you to embed apps via iframes, the `?embed=true` query parameter also does the following:
+
+- Removes the toolbar with the hamburger menu
+- Removes the padding at the top and bottom of the app
+- Removes the footer
+- Removes the colored line from the top of the app
+
+To allow more granular control over the embedding behavior, Streamlit lets you optionally specify one or more instances of the `?embed_options` query parameter. The supported values for `?embed_options` are listed below:
+
+1. Embed (default)
+
+   ```js
+   /?embed=true
+   ```
+
+2. Show toolbar
+
+   ```js
+   /?embed=true&embed_options=show_toolbar
+   ```
+
+3. Show padding
+
+   ```js
+   /?embed=true&embed_options=show_padding
+   ```
+
+4. Show footer
+
+   ```js
+   /?embed=true&embed_options=show_footer
+   ```
+
+5. Show colored line
+
+   ```js
+   /?embed=true&embed_options=show_colored_line
+   ```
+
+6. Disable scrolling
+
+   ```js
+   /?embed=true&embed_options=disable_scrolling
+   ```
+
+7. Open with light theme
+
+   ```js
+   /?embed=true&embed_options=light_theme
+   ```
+
+8. Open with dark theme
+
+   ```js
+   /?embed=true&embed_options=dark_theme
+   ```
+
+You can also combine the params:
+
+```js
+/?embed=true&embed_options=show_toolbar&embed_options=show_padding&embed_options=show_footer&embed_options=show_colored_line&embed_options=disable_scrolling
+```
+
+Both `?embed` and `?embed_options` are invisible to [st.experimental_get_query_params](/library/api-reference/utilities/st.experimental_get_query_params) and [st.experimental_set_query_params](/library/api-reference/utilities/st.experimental_set_query_params). The former ignores the embed query parameters and does not return them, while the latter disallows setting embed query parameters.
 
 ### Custom subdomains
 

--- a/public/_redirects
+++ b/public/_redirects
@@ -864,3 +864,4 @@
 /streamlit-cloud/get-started/manage-your-app /streamlit-community-cloud/get-started/manage-your-app
 /streamlit-cloud/trust-and-security /streamlit-community-cloud/trust-and-security
 /streamlit-cloud/troubleshooting /streamlit-community-cloud/troubleshooting
+/knowledge-base/using-streamlit/how-host-static-files /library/advanced-features/static-file-serving

--- a/python/api-examples-source/hello/requirements.txt
+++ b/python/api-examples-source/hello/requirements.txt
@@ -8,4 +8,4 @@ numpy==1.22.0
 scipy
 altair==4.2.0
 pydeck==0.7.1
-streamlit==1.19.0
+streamlit==1.20.0

--- a/python/api-examples-source/mpa-hello/requirements.txt
+++ b/python/api-examples-source/mpa-hello/requirements.txt
@@ -9,4 +9,4 @@ scipy
 altair==4.2.0
 pydeck==0.7.1
 opencv-python-headless==4.6.0.66
-streamlit==1.19.0
+streamlit==1.20.0

--- a/python/api-examples-source/requirements.txt
+++ b/python/api-examples-source/requirements.txt
@@ -8,4 +8,4 @@ numpy==1.22.0
 scipy
 altair==4.2.0
 pydeck==0.7.1
-streamlit==1.19.0
+streamlit==1.20.0

--- a/python/api-examples-source/theming/requirements.txt
+++ b/python/api-examples-source/theming/requirements.txt
@@ -1,4 +1,4 @@
-streamlit==1.19.0
+streamlit==1.20.0
 vega_datasets
 altair==4.2.0
 plotly==5.1.0

--- a/python/stoutput.py
+++ b/python/stoutput.py
@@ -28,7 +28,6 @@ class StOutput(Directive):
     final_argument_whitespace = True
 
     def run(self):
-
         src = self.arguments[0]
 
         if not src.startswith("https://"):
@@ -47,7 +46,7 @@ class StOutput(Directive):
             text="""
                 <iframe
                     loading="lazy"
-                    src="%(src)s?embedded=true"
+                    src="%(src)s?embed=true"
                     style="
                         width: 100%%;
                         border: none;


### PR DESCRIPTION
## 📚 Context

Documents Streamlit v1.20.0

## 🧠 Description of Changes

-Added 1.20.0 release notes to changelog
- Added docs for `?embed` and `?embed_options`
- Updated `stoutput.py` to use `?embed=true` instead of `?embedded`
- Bumped docstring version from 1.19.0 to 1.20.0
- Bumped docs apps to version 1.20.0
- Moved static file serving docs to Advanced features and setup redirect from KB
- Updated config options to include `sslCertFile`, `sslKeyFile`, and `fastReruns=true`
- Bumped cheatsheet to 1.20.0
- Replaced `?embedded` with `?embed` in embedded apps

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
