### PR TITLE
Allow clipboard read/write access to iframes via Cloud.js

### DIFF
--- a/components/blocks/cloud.js
+++ b/components/blocks/cloud.js
@@ -15,7 +15,7 @@ const Cloud = ({ src, height }) => {
           src={`${src}`}
           height={height}
           className={styles.Iframe}
-          allow="camera;"
+          allow="camera;clipboard-read;clipboard-write;"
           key={src}
         />
         <a href={src} target="_blank" className={styles.Caption}>
@@ -30,7 +30,7 @@ const Cloud = ({ src, height }) => {
           loading="lazy"
           src={`${src}`}
           className={classNames(styles.Iframe, styles.VideoAspectRatio)}
-          allow="camera;"
+          allow="camera;clipboard-read;clipboard-write;"
           key={src}
         />
         <a href={src} target="_blank" className={styles.Caption}>


### PR DESCRIPTION
## 📚 Context

In our [Dataframes deepdive](https://docs.streamlit.io/library/advanced-features/dataframes), users are supposed to be able to interact with embedded apps and copy cells from and paste cells into the app (for `st.experimental_data_editor`). Currently, this functionality is lacking because the `<Cloud>` component does not give the iframe sufficient permissions

## 🧠 Description of Changes

- Allowed iframes in cloud.js `clipboard-read` and `clipboard-write` permissions.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/streamlit/Feature-Allow-clipboard-read-write-access-to-iframes-via-Cloud-js-02d04561ac4f4d90a42b68d7e2554ee3)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
