### PR TITLE
Don't prepend $ to commands that should be run from a terminal

### DIFF
--- a/content/kb/tutorials/deploy/docker.md
+++ b/content/kb/tutorials/deploy/docker.md
@@ -249,7 +249,7 @@ The `-p` flag publishes the container’s port 8501 to your server’s 8501 port
 If all went well, you should see an output similar to the following:
 
 ```
-$ docker run -p 8501:8501 streamlit
+docker run -p 8501:8501 streamlit
 
   You can now view your Streamlit app in your browser.
 

--- a/content/library/advanced-features/dataframes.md
+++ b/content/library/advanced-features/dataframes.md
@@ -210,6 +210,18 @@ st.experimental_data_editor({
 })
 ```
 
+## Handling large datasets
+
+`st.dataframe` and `st.data_editor` have been designed to theoretically handle tables with millions of rows thanks to their highly performant implementation using the glide-data-grid library and HTML canvas. However, the maximum amount of data that an app can realistically handle will depend on several other factors, including:
+
+1. The maximum size of WebSocket messages: Streamlit's WebSocket messages are configurable via the `server.maxMessageSize` [config option](/library/advanced-features/configuration#view-all-configuration-options), which limits the amount of data that can be transferred via the WebSocket connection at once.
+2. The server memory: The amount of data that your app can handle will also depend on the amount of memory available on your server. If the server's memory is exceeded, the app may become slow or unresponsive.
+3. The user's browser memory: Since all the data needs to be transferred to the user's browser for rendering, the amount of memory available on the user's device can also affect the app's performance. If the browser's memory is exceeded, it may crash or become unresponsive.
+
+In addition to these factors, a slow network connection can also significantly slow down apps that handle large datasets.
+
+When handling large datasets with more than 150,000 rows, Streamlit applies additional optimizations and disables column sorting. This can help to reduce the amount of data that needs to be processed at once and improve the app's performance.
+
 ## Limitations
 
 While Streamlit's data editing capabilities offer a lot of functionality, there are some limitations to be aware of:

--- a/content/library/api/performance/experimental-memo.md
+++ b/content/library/api/performance/experimental-memo.md
@@ -27,7 +27,7 @@ st.write(load_data())
 And a warning will be logged to your terminal:
 
 ```bash
-$ streamlit run app.py
+streamlit run app.py
 
   You can now view your Streamlit app in your browser.
   Local URL: http://localhost:8501

--- a/content/library/components/components-api.md
+++ b/content/library/components/components-api.md
@@ -106,32 +106,32 @@ Clone the [component-template GitHub repo](https://github.com/streamlit/componen
 
    ```shell
    # React template
-   $ template/my_component/frontend
-   $ npm install    # Initialize the project and install npm dependencies
-   $ npm run start  # Start the Webpack dev server
+   template/my_component/frontend
+   npm install    # Initialize the project and install npm dependencies
+   npm run start  # Start the Webpack dev server
 
    # or
 
    # TypeScript-only template
-   $ template-reactless/my_component/frontend
-   $ npm install    # Initialize the project and install npm dependencies
-   $ npm run start  # Start the Webpack dev server
+   template-reactless/my_component/frontend
+   npm install    # Initialize the project and install npm dependencies
+   npm run start  # Start the Webpack dev server
    ```
 
 2. _From a separate terminal_, run the Streamlit app (Python) that declares and uses the component:
 
    ```shell
    # React template
-   $ cd template
-   $ . venv/bin/activate # or similar to activate the venv/conda environment where Streamlit is installed
-   $ streamlit run my_component/__init__.py # run the example
+   cd template
+   . venv/bin/activate # or similar to activate the venv/conda environment where Streamlit is installed
+   streamlit run my_component/__init__.py # run the example
 
    # or
 
    # TypeScript-only template
-   $ cd template-reactless
-   $ . venv/bin/activate # or similar to activate the venv/conda environment where Streamlit is installed
-   $ streamlit run my_component/__init__.py # run the example
+   cd template-reactless
+   . venv/bin/activate # or similar to activate the venv/conda environment where Streamlit is installed
+   streamlit run my_component/__init__.py # run the example
    ```
 
 After running the steps above, you should see a Streamlit app in your browser that looks like this:

--- a/content/library/components/publish-component.md
+++ b/content/library/components/publish-component.md
@@ -35,8 +35,8 @@ The [component-template](https://github.com/streamlit/component-template) GitHub
 4. Create a release build of your frontend code. This will add a new directory, `frontend/build/`, with your compiled frontend in it:
 
    ```shell
-   $ cd frontend
-   $ npm run build
+   cd frontend
+   npm run build
    ```
 
 5. Pass the build folder's path as the `path` parameter to `declare_component`. (If you're using the template Python file, you can set `_RELEASE = True` at the top of the file):
@@ -64,7 +64,7 @@ Once you've changed the default `my_component` references, compiled the HTML and
    ```shell
     # Run this from your component's top-level directory; that is,
     # the directory that contains `setup.py`
-    $ python setup.py sdist bdist_wheel
+    python setup.py sdist bdist_wheel
    ```
 
 ### Upload your wheel to PyPI

--- a/content/library/get-started/create-an-app.md
+++ b/content/library/get-started/create-an-app.md
@@ -60,7 +60,7 @@ Streamlit is more than just a way to make data apps, it’s also a community of 
    Did you know you can also pass a URL to `streamlit run`? This is great when combined with GitHub Gists. For example:
 
    ```bash
-   $ streamlit run https://raw.githubusercontent.com/streamlit/demo-uber-nyc-pickups/master/streamlit_app.py
+   streamlit run https://raw.githubusercontent.com/streamlit/demo-uber-nyc-pickups/master/streamlit_app.py
    ```
 
    </Tip>
@@ -402,7 +402,7 @@ That's it for getting started, now you can go and build your own apps! If you
 run into difficulties here are a few things you can do.
 
 - Check out our [community forum](https://discuss.streamlit.io/) and post a question
-- Quick help from command line with `$ streamlit help`
+- Quick help from command line with `streamlit help`
 - Go through our [Knowledge Base](/knowledge-base) for tips, step-by-step tutorials, and articles that answer your questions about creating and deploying Streamlit apps.
 - Read more documentation! Check out:
   - [Advanced features](/library/advanced-features) for things like caching, theming, and adding statefulness to apps.

--- a/content/library/get-started/main-concepts.md
+++ b/content/library/get-started/main-concepts.md
@@ -34,10 +34,10 @@ useful when configuring an IDE like PyCharm to work with Streamlit:
 
 ```bash
 # Running
-$ python -m streamlit run your_script.py
+python -m streamlit run your_script.py
 
 # is equivalent to:
-$ streamlit run your_script.py
+streamlit run your_script.py
 ```
 
 <Tip>

--- a/pages/style-guide.js
+++ b/pages/style-guide.js
@@ -112,7 +112,7 @@ export default function StyleGuide() {
             </li>
             <li>
               Quick help from command line with{" "}
-              <span className="inline_code">$ streamlit --help</span>
+              <span className="inline_code">streamlit --help</span>
             </li>
             <li>
               Read more documentation! Check out:
@@ -197,7 +197,7 @@ ls -l myscript.sh`}
             </p>
             <Code
               language="bash"
-              code={`$ streamlit run
+              code={`streamlit run
 https://raw.githubusercontent.com/streamlit/demo-uber-nyc-pickups/master/streamlit_app.py`}
             />
           </Tip>


### PR DESCRIPTION
## 📚 Context

`$` or `#` prompt characters are generally used in docs to indicate that commands that follow must be executed via the terminal emulator / command-line via a non-root and root user, respectively.  However, it can cause frustration to users who click the copy button on these code blocks and expect to run the pasted code. It isn't obvious that `$` or `#` isn't part of the command.

## 🧠 Description of Changes

- Removes the prompt characters from code blocks.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
