### PR TITLE
Fix incorrect final screenshot in MSSQL Server tutorial

### DIFF
--- a/content/kb/tutorials/databases/mssql.md
+++ b/content/kb/tutorials/databases/mssql.md
@@ -190,4 +190,4 @@ See `st.cache_data` above? Without it, Streamlit would run the query every time 
 
 If everything worked out (and you used the example table we created above), your app should look like this:
 
-![Finished app screenshot](/images/databases/snowflake-4.png)
+![Finished app screenshot](/images/databases/streamlit-app.png)


### PR DESCRIPTION
## 📚 Context

The final screenshot in the Connect Streamlit to Microsoft SQL Server tutorial shows the Snowsight UI instead of the completed Streamlit app

## 🧠 Description of Changes

- Replaced the Snowsight UI screenshot in `Connect Streamlit to Microsoft SQL Server` with one of a Streamlit app.

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/226339827-65056310-192f-4717-bfa2-55736f70675b.png)

**Current:**

![image](https://user-images.githubusercontent.com/20672874/226339963-fc8c862e-e593-4757-a729-9b2ebbd034eb.png)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/snowflake-corp/Replace-wrong-screenshot-in-SQL-Server-tutorial-bdf8c8a354e84778adad6ec3e081dd8e)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
