### PR TITLE
Link to func's GitHub source next to func signatures in the API ref

### DIFF
--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -276,7 +276,19 @@ const Autofunction = ({
   body = (
     <Table
       head={{
-        title: "Function signature",
+        title: (
+          <>
+            Function signature
+            <a
+              className={styles.Title.a}
+              href={functionObject.source}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              [source]
+            </a>
+          </>
+        ),
         content: `<p class='code'> ${functionObject.signature}</p> `,
       }}
       body={

--- a/components/blocks/table.module.css
+++ b/components/blocks/table.module.css
@@ -41,3 +41,7 @@
 .TitleCell {
   @apply font-bold mb-0;
 }
+
+.TitleCell a {
+  @apply float-right mb-0 text-sm;
+}


### PR DESCRIPTION
## 📚 Context

Users have no direct/easy way to inspect the source code of Streamlit commands in the pubic API from the API reference page in our docs.

## 🧠 Description of Changes

- Adds a text `[source]` to the Autofunction table in the API reference, next to the function heading, that hyperlinks to the command's GitHub source URL

**Revised:**

![image](https://user-images.githubusercontent.com/20672874/227154749-8ead21ae-8a80-4a7b-9bb3-98c8e86fd00c.png)


**Current:**

![image](https://user-images.githubusercontent.com/20672874/227154854-e74c2ccc-4a84-4781-8a7e-25d22ed41d87.png)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
