### PR TITLE
Use pip+venv in get-started/installation.md

### DIFF
--- a/content/library/get-started/installation.md
+++ b/content/library/get-started/installation.md
@@ -119,7 +119,7 @@ xcode-select --install
    python -m venv venv
    ```
 
-   When you run the command above, a directory called `venv` will appear in `myprojects/`. This file is where your virtual environment and its dependencies are install.
+   When you run the command above, a directory called `venv` will appear in `myprojects/`. This directory is where your virtual environment and its dependencies are install.
 
 3. Install Streamlit in your environment:
 

--- a/content/library/get-started/installation.md
+++ b/content/library/get-started/installation.md
@@ -79,7 +79,7 @@ Next you'll need to set up your environment.
 
 Streamlit's officially-supported environment manager for macOS and Linux is [Pipenv](https://pypi.org/project/pipenv/). See instructions on how to install and use it below.
 
-### Install Pip
+### Install `pip`
 
 Install `pip`. More details about installing `pip` can be found in [pip's documentation](https://pip.pypa.io/en/stable/installation/#supported-methods).
 

--- a/content/library/get-started/installation.md
+++ b/content/library/get-started/installation.md
@@ -77,7 +77,7 @@ Next you'll need to set up your environment.
 
 ## Install Streamlit on macOS/Linux
 
-Streamlit's officially-supported environment manager for macOS and Linux is [Pipenv](https://pypi.org/project/pipenv/). See instructions on how to install and use it below.
+Streamlit's officially-supported environment manager for macOS and Linux is [pip](https://pypi.org/project/pip/). See instructions on how to install and use it below.
 
 ### Install `pip`
 

--- a/content/library/get-started/installation.md
+++ b/content/library/get-started/installation.md
@@ -28,9 +28,9 @@ you're working on.
 
 Below are a few tools you can use for environment management:
 
+- [venv](https://docs.python.org/3/library/venv.html)
 - [pipenv](https://pipenv-fork.readthedocs.io/en/latest/)
 - [poetry](https://python-poetry.org/)
-- [venv](https://docs.python.org/3/library/venv.html)
 - [virtualenv](https://virtualenv.pypa.io/en/latest/)
 - [conda](https://www.anaconda.com/distribution/)
 
@@ -54,13 +54,13 @@ Next you'll need to set up your environment.
 
 3. In the terminal that appears, type:
 
-   ```sh
+   ```bash
    pip install streamlit
    ```
 
 4. Test that the installation worked:
 
-   ```sh
+   ```bash
    streamlit hello
    ```
 
@@ -71,13 +71,13 @@ Next you'll need to set up your environment.
 1. In Anaconda Navigator, open a terminal in your environment (see step 2 above).
 2. In the terminal that appears, use Streamlit as usual:
 
-   ```sh
+   ```bash
    streamlit run myfile.py
    ```
 
 ## Install Streamlit on macOS/Linux
 
-Streamlit's officially-supported environment manager for macOS and Linux is [pip](https://pypi.org/project/pip/). See instructions on how to install and use it below.
+Streamlit's officially-supported package manager and environment manager for macOS and Linux are [pip](https://pypi.org/project/pip/) and [venv](https://docs.python.org/3/library/venv.html), respectively. `venv` is a part of [The Python Standard Library](https://docs.python.org/3/library/index.html) and comes bundled with your installation of Python. See instructions on how to install and use `pip` below.
 
 ### Install `pip`
 
@@ -85,13 +85,13 @@ Install `pip`. More details about installing `pip` can be found in [pip's docume
 
 On a macOS:
 
-```sh
+```bash
 python -m ensurepip --upgrade
 ```
 
 On Ubuntu with Python 3:
 
-```sh
+```bash
 sudo apt-get install python3-pip
 ```
 
@@ -101,7 +101,7 @@ For other Linux distributions, see [How to install PIP for Python](https://www.m
 
 On macOS, you'll need to install Xcode command line tools. They are required to compile some of Streamlit's Python dependencies during installation. To install Xcode command line tools, run:
 
-```sh
+```bash
 xcode-select --install
 ```
 
@@ -109,48 +109,50 @@ xcode-select --install
 
 1. Navigate to your project folder:
 
-   ```sh
+   ```bash
    cd myproject
    ```
 
 2. Create a new virtual environment in that folder and activate that environment:
 
-   ```sh
-   python -m venv venv
+   ```bash
+   python -m venv .venv
    ```
 
-   When you run the command above, a directory called `venv` will appear in `myprojects/`. This directory is where your virtual environment and its dependencies are installed.
+   When you run the command above, a directory called `.venv` will appear in `myprojects/`. This directory is where your virtual environment and its dependencies are installed.
 
 3. Install Streamlit in your environment:
 
-   ```sh
+   ```bash
    pip install streamlit
    ```
 
 4. Test that the installation worked:
 
-   ```sh
+   ```bash
    streamlit hello
    ```
 
    Streamlit's Hello app should appear in a new tab in your web browser!
 
+   <Cloud src="https://doc-mpa-hello.streamlit.app/?embed=true" height="700" />
+
 ### Use your new environment
 
-1. Any time you want to use the new environment, you first need to go to your project folder (where the `venv` directory lives) and run:
+1. Any time you want to use the new environment, you first need to go to your project folder (where the `.venv` directory lives) and run:
 
-   ```sh
-   source ./venv/bin/activate
+   ```bash
+   source .venv/bin/activate
    ```
 
 2. Now you can use Python and Streamlit as usual:
 
-   ```sh
+   ```bash
    streamlit run myfile.py
    ```
 
    To stop the Streamlit server, press `ctrl-C`.
 
-3. When you're done using this environment, just type `deactivate` to return to your normal shell.
+3. When you're done using this environment, type `deactivate` to return to your normal shell.
 
 Now that you've installed Streamlit, take a few minutes to read through [Main concepts](/library/get-started/main-concepts) to understand Streamlit's data flow model.

--- a/content/library/get-started/installation.md
+++ b/content/library/get-started/installation.md
@@ -140,7 +140,7 @@ xcode-select --install
 1. Any time you want to use the new environment, you first need to go to your project folder (where the `venv` directory lives) and run:
 
    ```sh
-   source ./venvn/bin/activate
+   source ./venv/bin/activate
    ```
 
 2. Now you can use Python and Streamlit as usual:

--- a/content/library/get-started/installation.md
+++ b/content/library/get-started/installation.md
@@ -119,7 +119,7 @@ xcode-select --install
    python -m venv venv
    ```
 
-   When you run the command above, a directory called `venv` will appear in `myprojects/`. This directory is where your virtual environment and its dependencies are install.
+   When you run the command above, a directory called `venv` will appear in `myprojects/`. This directory is where your virtual environment and its dependencies are installed.
 
 3. Install Streamlit in your environment:
 

--- a/content/library/get-started/installation.md
+++ b/content/library/get-started/installation.md
@@ -79,29 +79,23 @@ Next you'll need to set up your environment.
 
 Streamlit's officially-supported environment manager for macOS and Linux is [Pipenv](https://pypi.org/project/pipenv/). See instructions on how to install and use it below.
 
-### Install Pipenv
+### Install Pip
 
-1. Install `pip`. More details about installing `pip` can be found in [pip's documentation](https://pip.pypa.io/en/stable/installation/#supported-methods).
+Install `pip`. More details about installing `pip` can be found in [pip's documentation](https://pip.pypa.io/en/stable/installation/#supported-methods).
 
-   On a macOS:
+On a macOS:
 
-   ```sh
-   python -m ensurepip --upgrade
-   ```
+```sh
+python -m ensurepip --upgrade
+```
 
-   On Ubuntu with Python 3:
+On Ubuntu with Python 3:
 
-   ```sh
-   sudo apt-get install python3-pip
-   ```
+```sh
+sudo apt-get install python3-pip
+```
 
-   For other Linux distributions, see [How to install PIP for Python](https://www.makeuseof.com/tag/install-pip-for-python/).
-
-2. Install `pipenv`.
-
-   ```sh
-   pip3 install pipenv
-   ```
+For other Linux distributions, see [How to install PIP for Python](https://www.makeuseof.com/tag/install-pip-for-python/).
 
 ### Install Xcode command line tools on macOS
 
@@ -119,24 +113,18 @@ xcode-select --install
    cd myproject
    ```
 
-2. Create a new Pipenv environment in that folder and activate that environment:
+2. Create a new virtual environment in that folder and activate that environment:
 
    ```sh
-   pipenv shell
+   python -m venv venv
    ```
 
-   When you run the command above, a file called `Pipfile` will appear in `myprojects/`. This file is where your Pipenv environment and its dependencies are declared.
+   When you run the command above, a directory called `venv` will appear in `myprojects/`. This file is where your virtual environment and its dependencies are install.
 
 3. Install Streamlit in your environment:
 
    ```sh
    pip install streamlit
-   ```
-
-   Or if you want to create an easily-reproducible environment, replace `pip` with `pipenv` every time you install something:
-
-   ```sh
-   pipenv install streamlit
    ```
 
 4. Test that the installation worked:
@@ -149,10 +137,10 @@ xcode-select --install
 
 ### Use your new environment
 
-1. Any time you want to use the new environment, you first need to go to your project folder (where the `Pipenv` file lives) and run:
+1. Any time you want to use the new environment, you first need to go to your project folder (where the `venv` directory lives) and run:
 
    ```sh
-   pipenv shell
+   source ./venvn/bin/activate
    ```
 
 2. Now you can use Python and Streamlit as usual:
@@ -163,6 +151,6 @@ xcode-select --install
 
    To stop the Streamlit server, press `ctrl-C`.
 
-3. When you're done using this environment, just type `exit` or press `ctrl-D` to return to your normal shell.
+3. When you're done using this environment, just type `deactivate` to return to your normal shell.
 
 Now that you've installed Streamlit, take a few minutes to read through [Main concepts](/library/get-started/main-concepts) to understand Streamlit's data flow model.


### PR DESCRIPTION
## 📚 Context

<!-- Why do you want to make this change? What background should the reviewer know? -->

## 🧠 Description of Changes

Spec: https://www.notion.so/snowflake-corp/Migrate-to-pip-for-dependencies-management-and-drop-pipenv-2ab55d45ed2a4ae3be500c70cd2e73b9

We migrated from `pipenv` to `pip` for dependency management, so I'm updating the documentation to recommend pip+venv for virtual environment management.

I'm opening this as a draft because I'd like to add documentation on the constraints files that advanced users might want to use for installation, but the constraints files aren't finished yet.
https://www.notion.so/snowflake-corp/Constraint-files-Spec-deded93f49fc43ebb01624124bd8b1bc

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
