### PR TITLE
Fix session state format

### DIFF
--- a/content/library/advanced-features/dataframes.md
+++ b/content/library/advanced-features/dataframes.md
@@ -155,7 +155,7 @@ Use all we've learned so far and apply them to the above embedded app. Try editi
 
 Notice how edits to the table are reflected in session state: when you make any edits, a rerun is triggered which sends the edits to the backend via `st.experimental_data_editor`'s keyed widget state. Its widget state is a JSON object containing three properties: **edited_cells**, **added_rows**, and **deleted rows:**.
 
-- `edited_cells` maps a cell position to the edited value: `column:row` → `value` .
+- `edited_cells` maps a cell position to the edited value: `row:column` → `value` .
 - `added_rows` is a list of newly added rows to the table. Each row is a dictionary where the keys are the column indices and the values are the corresponding cell values.
 - `deleted_rows` is a list of row indices that have been deleted from the table.
 


### PR DESCRIPTION
## 📚 Context

<!-- Why do you want to make this change? What background should the reviewer know? -->
Docs mention the session state format for `st.experimental_data_editor` has `column:row` but it actually is `row:column`. 

## 🧠 Description of Changes

<!-- What was specifically changed? Which files, algorithms, links, media? -->
<!-- Please add them here as a bulleted list -->

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
