### PR TITLE
Update mysql and snowflake tutorials for st.connection

### DIFF
--- a/content/kb/tutorials/databases/mysql.md
+++ b/content/kb/tutorials/databases/mysql.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/mysql
 
 ## Introduction
 
-This guide explains how to securely access a **_remote_** MySQL database from Streamlit Community Cloud. It uses [st.experimental_connection](/library/api-reference/connections/st.experimental_connection) and Streamlit's [secrets management](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management). **The below example code will only work on Streamlit version >= 1.22, when `st.experimental_connection` was added.**
+This guide explains how to securely access a **_remote_** MySQL database from Streamlit Community Cloud. It uses [st.experimental_connection](/library/api-reference/connections/st.experimental_connection) and Streamlit's [secrets management](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management). The below example code will **only work on Streamlit version >= 1.22**, when `st.experimental_connection` was added.
 
 ## Create a MySQL database
 

--- a/content/kb/tutorials/databases/mysql.md
+++ b/content/kb/tutorials/databases/mysql.md
@@ -81,7 +81,6 @@ Copy the code below to your Streamlit app and run it. Make sure to adapt `query`
 # streamlit_app.py
 
 import streamlit as st
-import pandas
 
 # Initialize connection.
 conn = st.experimental_connection('mysql', type='sql')

--- a/content/kb/tutorials/databases/mysql.md
+++ b/content/kb/tutorials/databases/mysql.md
@@ -81,6 +81,7 @@ Copy the code below to your Streamlit app and run it. Make sure to adapt `query`
 # streamlit_app.py
 
 import streamlit as st
+import pandas
 
 # Initialize connection.
 conn = st.experimental_connection('mysql', type='sql')
@@ -89,8 +90,8 @@ conn = st.experimental_connection('mysql', type='sql')
 df = conn.query('SELECT * from mytable;', ttl=600)
 
 # Print results.
-for person, pet in zip(df['person'], df['pet']):
-    st.write(f"{person} has a :{pet}:")
+for row in df.itertuples():
+    st.write(f"{row.person} has a :{row.pet}:")
 ```
 
 See `st.experimental_connection` above? This handles secrets retrieval, setup, query caching and retries. In this case, we set `ttl=600` to ensure the query result is cached for no longer than 10 minutes. Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Learn more in [Connecting to data](/library/advanced-features/connecting-to-data) and [Caching](/library/advanced-features/caching).

--- a/content/kb/tutorials/databases/mysql.md
+++ b/content/kb/tutorials/databases/mysql.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/mysql
 
 ## Introduction
 
-This guide explains how to securely access a **_remote_** MySQL database from Streamlit Community Cloud. It uses [st.experimental_connection](/library/api-reference/connections/st.experimental_connection) and Streamlit's [secrets management](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+This guide explains how to securely access a **_remote_** MySQL database from Streamlit Community Cloud. It uses [st.experimental_connection](/library/api-reference/connections/st.experimental_connection) and Streamlit's [secrets management](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management). **The below example code will only work on Streamlit version >= 1.22, when `st.experimental_connection` was added.**
 
 ## Create a MySQL database
 

--- a/content/kb/tutorials/databases/mysql.md
+++ b/content/kb/tutorials/databases/mysql.md
@@ -93,7 +93,7 @@ for row in df.itertuples():
     st.write(f"{row.name} has a :{row.pet}:")
 ```
 
-See `st.experimental_connection` above? This handles secrets retrieval, setup, query caching and retries. By default, `query()` results are cached without expiring. In this case, we set `ttl=600` to ensure the query result is cached for no longer than 10 minutes. You can also set `ttl=None` to disable caching. Learn more in [Connecting to data](/library/advanced-features/connecting-to-data) and [Caching](/library/advanced-features/caching).
+See `st.experimental_connection` above? This handles secrets retrieval, setup, query caching and retries. By default, `query()` results are cached without expiring. In this case, we set `ttl=600` to ensure the query result is cached for no longer than 10 minutes. You can also set `ttl=None` to disable caching. Learn more in [Caching](/library/advanced-features/caching).
 
 If everything worked out (and you used the example table we created above), your app should look like this:
 

--- a/content/kb/tutorials/databases/mysql.md
+++ b/content/kb/tutorials/databases/mysql.md
@@ -35,7 +35,7 @@ INSERT INTO mytable VALUES ('Mary', 'dog'), ('John', 'cat'), ('Robert', 'bird');
 
 ## Add username and password to your local app secrets
 
-Your local Streamlit app will read secrets from a file `.streamlit/secrets.toml` in your app's root directory. Create this file if it doesn't exist yet and add the database name, user, and password of your MySQL server as shown below:
+Your local Streamlit app will read secrets from a file `.streamlit/secrets.toml` in your app's root directory. Learn more about [Streamlit secrets management here](/library/advanced-features/secrets-management). Create this file if it doesn't exist yet and add the database name, user, and password of your MySQL server as shown below:
 
 ```toml
 # .streamlit/secrets.toml

--- a/content/kb/tutorials/databases/mysql.md
+++ b/content/kb/tutorials/databases/mysql.md
@@ -93,7 +93,7 @@ for person, pet in zip(df['person'], df['pet']):
     st.write(f"{person} has a :{pet}:")
 ```
 
-See `st.experimental_connection` above? This handles secrets retrieval, setup, query caching and retries. In this case, we set `ttl=600` to ensure the query result is cached for no longer than 10 minutes. Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Learn more in[Connecting to data](/library/advanced-features/connecting-to-data) and [Caching](/library/advanced-features/caching).
+See `st.experimental_connection` above? This handles secrets retrieval, setup, query caching and retries. In this case, we set `ttl=600` to ensure the query result is cached for no longer than 10 minutes. Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Learn more in [Connecting to data](/library/advanced-features/connecting-to-data) and [Caching](/library/advanced-features/caching).
 
 If everything worked out (and you used the example table we created above), your app should look like this:
 

--- a/content/kb/tutorials/databases/mysql.md
+++ b/content/kb/tutorials/databases/mysql.md
@@ -91,7 +91,7 @@ df = conn.query('SELECT * from mytable;', ttl=600)
 
 # Print results.
 for row in df.itertuples():
-    st.write(f"{row.person} has a :{row.pet}:")
+    st.write(f"{row.name} has a :{row.pet}:")
 ```
 
 See `st.experimental_connection` above? This handles secrets retrieval, setup, query caching and retries. In this case, we set `ttl=600` to ensure the query result is cached for no longer than 10 minutes. Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Learn more in [Connecting to data](/library/advanced-features/connecting-to-data) and [Caching](/library/advanced-features/caching).

--- a/content/kb/tutorials/databases/mysql.md
+++ b/content/kb/tutorials/databases/mysql.md
@@ -93,7 +93,7 @@ for row in df.itertuples():
     st.write(f"{row.name} has a :{row.pet}:")
 ```
 
-See `st.experimental_connection` above? This handles secrets retrieval, setup, query caching and retries. In this case, we set `ttl=600` to ensure the query result is cached for no longer than 10 minutes. Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Learn more in [Connecting to data](/library/advanced-features/connecting-to-data) and [Caching](/library/advanced-features/caching).
+See `st.experimental_connection` above? This handles secrets retrieval, setup, query caching and retries. By default, `query()` results are cached without expiring. In this case, we set `ttl=600` to ensure the query result is cached for no longer than 10 minutes. You can also set `ttl=None` to disable caching. Learn more in [Connecting to data](/library/advanced-features/connecting-to-data) and [Caching](/library/advanced-features/caching).
 
 If everything worked out (and you used the example table we created above), your app should look like this:
 

--- a/content/kb/tutorials/databases/mysql.md
+++ b/content/kb/tutorials/databases/mysql.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/mysql
 
 ## Introduction
 
-This guide explains how to securely access a **_remote_** MySQL database from Streamlit Community Cloud. It uses the [mysql-connector-python](https://github.com/mysql/mysql-connector-python) library and Streamlit's [secrets management](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+This guide explains how to securely access a **_remote_** MySQL database from Streamlit Community Cloud. It uses [st.experimental_connection](/library/api-reference/connections/st.experimental_connection) and Streamlit's [secrets management](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
 
 ## Create a MySQL database
 
@@ -40,17 +40,18 @@ Your local Streamlit app will read secrets from a file `.streamlit/secrets.toml`
 ```toml
 # .streamlit/secrets.toml
 
-[mysql]
+[connections.mysql]
+dialect = "mysql"
 host = "localhost"
 port = 3306
 database = "xxx"
-user = "xxx"
+username = "xxx"
 password = "xxx"
 ```
 
 <Important>
 
-When copying your app secrets to Streamlit Community Cloud, be sure to replace the values of **host**, **port**, **database**, **user**, and **password** with those of your _remote_ MySQL database!
+When copying your app secrets to Streamlit Community Cloud, be sure to replace the values of **host**, **port**, **database**, **username**, and **password** with those of your _remote_ MySQL database!
 
 Add this file to `.gitignore` and don't commit it to your GitHub repo!
 
@@ -62,13 +63,14 @@ As the `secrets.toml` file above is not committed to GitHub, you need to pass it
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 
-## Add mysql-connector-python to your requirements file
+## Add dependencies to your requirements file
 
-Add the [mysql-connector-python](https://github.com/mysql/mysql-connector-python) package to your `requirements.txt` file, preferably pinning its version (replace `x.x.x` with the version you want installed):
+Add the [mysqlclient](https://github.com/PyMySQL/mysqlclient) and [SQLAlchemy](https://github.com/sqlalchemy/sqlalchemy) packages to your `requirements.txt` file, preferably pinning its version (replace `x.x.x` with the version you want installed):
 
 ```bash
 # requirements.txt
-mysql-connector-python==x.x.x
+mysqlclient==x.x.x
+SQLAlchemy==x.x.x
 ```
 
 ## Write your Streamlit app
@@ -79,32 +81,19 @@ Copy the code below to your Streamlit app and run it. Make sure to adapt `query`
 # streamlit_app.py
 
 import streamlit as st
-import mysql.connector
 
 # Initialize connection.
-# Uses st.cache_resource to only run once.
-@st.cache_resource
-def init_connection():
-    return mysql.connector.connect(**st.secrets["mysql"])
-
-conn = init_connection()
+conn = st.experimental_connection('mysql', type='sql')
 
 # Perform query.
-# Uses st.cache_data to only rerun when the query changes or after 10 min.
-@st.cache_data(ttl=600)
-def run_query(query):
-    with conn.cursor() as cur:
-        cur.execute(query)
-        return cur.fetchall()
-
-rows = run_query("SELECT * from mytable;")
+df = conn.query('SELECT * from mytable;', ttl=600)
 
 # Print results.
-for row in rows:
-    st.write(f"{row[0]} has a :{row[1]}:")
+for person, pet in zip(df['person'], df['pet']):
+    st.write(f"{person} has a :{pet}:")
 ```
 
-See `st.cache_data` above? Without it, Streamlit would run the query every time the app reruns (e.g. on a widget interaction). With `st.cache_data`, it only runs when the query changes or after 10 minutes (that's what `ttl` is for). Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Learn more in [Caching](/library/advanced-features/caching).
+See `st.experimental_connection` above? This handles secrets retrieval, setup, query caching and retries. In this case, we set `ttl=600` to ensure the query result is cached for no longer than 10 minutes. Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Learn more in[Connecting to data](/library/advanced-features/connecting-to-data) and [Caching](/library/advanced-features/caching).
 
 If everything worked out (and you used the example table we created above), your app should look like this:
 

--- a/content/kb/tutorials/databases/snowflake.md
+++ b/content/kb/tutorials/databases/snowflake.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/snowflake
 
 ## Introduction
 
-This guide explains how to securely access a Snowflake database from Streamlit. It uses [st.experimental_connection](/library/api-reference/connections/st.experimental_connection), the [snowpark-python](https://docs.snowflake.com/en/developer-guide/snowpark/python/index) library and Streamlit's [secrets management](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management). **The below example code will only work on Streamlit version >= 1.22, when `st.experimental_connection` was added.**
+This guide explains how to securely access a Snowflake database from Streamlit. It uses [st.experimental_connection](/library/api-reference/connections/st.experimental_connection), the [Snowpark Python](https://docs.snowflake.com/en/developer-guide/snowpark/python/index) library and Streamlit's [secrets management](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management). **The below example code will only work on Streamlit version >= 1.22, when `st.experimental_connection` was added.**
 
 Skip to the bottom for information about [connecting using Snowflake Connector for Python](#using-the-snowflake-connector-for-python).
 
@@ -38,7 +38,7 @@ INSERT INTO MYTABLE VALUES ('Mary', 'dog'), ('John', 'cat'), ('Robert', 'bird');
 SELECT * FROM MYTABLE;
 ```
 
-Before you execute the queries, first determine which Snowflake UI / web interface you're using. The examples below use [SnowSight](https://docs.snowflake.com/en/user-guide/ui-snowsight). You can also use [Classic Console Worksheets](https://docs.snowflake.com/en/user-guide/ui-worksheet) or any other means of running Snowflake SQL statements.
+Before you execute the queries, first determine which Snowflake UI / web interface you're using. The examples below use [Snowsight](https://docs.snowflake.com/en/user-guide/ui-snowsight). You can also use [Classic Console Worksheets](https://docs.snowflake.com/en/user-guide/ui-worksheet) or any other means of running Snowflake SQL statements.
 
 ### Execute queries in a Worksheet
 
@@ -60,7 +60,7 @@ Make sure to note down the name of your warehouse, database, and schema. ☝️
 
 ## Install snowflake-snowpark-python
 
-You can find the instructions and prerequisites for installing snowflake-snowpark-python in the [Snowpark Developer Guide](https://docs.snowflake.com/en/developer-guide/snowpark/python/setup).
+You can find the instructions and prerequisites for installing `snowflake-snowpark-python` in the [Snowpark Developer Guide](https://docs.snowflake.com/en/developer-guide/snowpark/python/setup).
 
 ```sh
 pip install "snowflake-snowpark-python[pandas]"
@@ -69,7 +69,7 @@ pip install "snowflake-snowpark-python[pandas]"
 Particular prerequisites to highlight:
 
 - Currently, only python 3.8 is supported.
-- Ensure you have the correct pyarrow version installed for your version of snowflake-snowpark-python. When in doubt, try uninstalling pyarrow before installing snowflake-snowpark-python.
+- Ensure you have the correct pyarrow version installed for your version of `snowflake-snowpark-python`. When in doubt, try uninstalling pyarrow before installing snowflake-snowpark-python.
 
 ## Add connection parameters to your local app secrets
 
@@ -89,7 +89,7 @@ schema = "xxx"
 client_session_keep_alive = true
 ```
 
-If you created the database from the previous step, the names of your database and schema are `PETS` and `PUBLIC`, respectively. **Streamlit will also use Snowflake config and credentials from a [snowsql config file](https://docs.snowflake.com/en/user-guide/snowsql-config#snowsql-config-file) if available.**
+If you created the database from the previous step, the names of your database and schema are `PETS` and `PUBLIC`, respectively. **Streamlit will also use Snowflake config and credentials from a [SnowSQL config file](https://docs.snowflake.com/en/user-guide/snowsql-config#snowsql-config-file) if available.**
 
 <Important>
 
@@ -208,4 +208,4 @@ This tutorial assumes a local Streamlit app, however you can also connect to Sno
 
 - [Include information about dependencies](/streamlit-community-cloud/get-started/deploy-an-app/app-dependencies) using a `requirements.txt` file with `snowflake-snowpark-python` and any other dependencies.
 - [Add your secrets](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management#deploy-an-app-and-set-up-secrets) to your Community Cloud app.
-- For apps using snowpark-python, you should also ensure the app is [running on python 3.8](/streamlit-community-cloud/get-started/deploy-an-app#advanced-settings-for-deployment).
+- For apps using `snowflake-snowpark-python`, you should also ensure the app is [running on python 3.8](/streamlit-community-cloud/get-started/deploy-an-app#advanced-settings-for-deployment).

--- a/content/kb/tutorials/databases/snowflake.md
+++ b/content/kb/tutorials/databases/snowflake.md
@@ -63,7 +63,7 @@ Make sure to note down the name of your warehouse, database, and schema. ☝️
 You can find the instructions and prerequisites for installing snowflake-snowpark-python in the [Snowpark Developer Guide](https://docs.snowflake.com/en/developer-guide/snowpark/python/setup).
 
 ```sh
-pip install snowflake-snowpark-python
+pip install "snowflake-snowpark-python[pandas]"
 ```
 
 Particular prerequisites to highlight:

--- a/content/kb/tutorials/databases/snowflake.md
+++ b/content/kb/tutorials/databases/snowflake.md
@@ -117,7 +117,7 @@ for row in df.itertuples():
     st.write(f"{row.NAME} has a :{row.PET}:")
 ```
 
-See `st.experimental_connection` above? This handles secrets retrieval, setup, query caching and retries. By default, `query()` results are cached without expiring. In this case, we set `ttl=600` to ensure the query result is cached for no longer than 10 minutes. You can also set `ttl=None` to disable caching. Learn more in [Connecting to data](/library/advanced-features/connecting-to-data) and [Caching](/library/advanced-features/caching).
+See `st.experimental_connection` above? This handles secrets retrieval, setup, query caching and retries. By default, `query()` results are cached without expiring. In this case, we set `ttl=600` to ensure the query result is cached for no longer than 10 minutes. You can also set `ttl=None` to disable caching. Learn more in [Caching](/library/advanced-features/caching).
 
 If everything worked out (and you used the example table we created above), your app should look like this:
 

--- a/content/kb/tutorials/databases/snowflake.md
+++ b/content/kb/tutorials/databases/snowflake.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/snowflake
 
 ## Introduction
 
-This guide explains how to securely access a Snowflake database from Streamlit. It uses [st.experimental_connection](/library/api-reference/connections/st.experimental_connection), the [Snowpark Python](https://docs.snowflake.com/en/developer-guide/snowpark/python/index) library and Streamlit's [secrets management](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management). **The below example code will only work on Streamlit version >= 1.22, when `st.experimental_connection` was added.**
+This guide explains how to securely access a Snowflake database from Streamlit. It uses [st.experimental_connection](/library/api-reference/connections/st.experimental_connection), the [Snowpark Python](https://docs.snowflake.com/en/developer-guide/snowpark/python/index) library and Streamlit's [secrets management](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management). The below example code **will only work on Streamlit version >= 1.22**, when `st.experimental_connection` was added.
 
 Skip to the bottom for information about [connecting using Snowflake Connector for Python](#using-the-snowflake-connector-for-python).
 
@@ -89,7 +89,7 @@ schema = "xxx"
 client_session_keep_alive = true
 ```
 
-If you created the database from the previous step, the names of your database and schema are `PETS` and `PUBLIC`, respectively. **Streamlit will also use Snowflake config and credentials from a [SnowSQL config file](https://docs.snowflake.com/en/user-guide/snowsql-config#snowsql-config-file) if available.**
+If you created the database from the previous step, the names of your database and schema are `PETS` and `PUBLIC`, respectively. Streamlit will also use **Snowflake config and credentials** from a [SnowSQL config file](https://docs.snowflake.com/en/user-guide/snowsql-config#snowsql-config-file) if available.
 
 <Important>
 
@@ -160,7 +160,7 @@ pip install snowflake-sqlalchemy
 
 Installing `snowflake-sqlalchemy` will also install all necessary dependencies.
 
-Configuring credentials follows the `SQLConnection` format which is slightly different. See the [Snowflake SQLAlchemy Configuration Parameters documentation](https://docs.snowflake.com/en/developer-guide/python-connector/sqlalchemy#connection-parameters) for more details.
+Configuring credentials follows the `SQLConnection` format which is slightly different. See the Snowflake SQLAlchemy [Configuration Parameters](https://docs.snowflake.com/en/developer-guide/python-connector/sqlalchemy#connection-parameters) documentation for more details.
 
 ```toml
 # .streamlit/secrets.toml

--- a/content/kb/tutorials/databases/snowflake.md
+++ b/content/kb/tutorials/databases/snowflake.md
@@ -132,13 +132,14 @@ The same [SnowparkConnection](/library/api-reference/connections/st.connections.
 
 import streamlit as st
 
-# Initialize connection and access underlying Snowpark session.
-session = st.experimental_connection('snowpark').session
+# Initialize connection.
+conn = st.experimental_connection('snowpark')
 
-# Load the table as a dataframe using Snowpark API.
+# Load the table as a dataframe using the Snowpark Session.
 @st.cache_data
 def load_table():
-    return session.table('mytable').to_pandas()
+    with conn.safe_session() as session:
+        return session.table('mytable').to_pandas()
 
 df = load_table()
 
@@ -146,6 +147,8 @@ df = load_table()
 for row in df.itertuples():
     st.write(f"{row.NAME} has a :{row.PET}:")
 ```
+
+This example uses `with conn.safe_session()` to provide thread safety. `conn.session` also works directly, but does not guarantee thread safety.
 
 ## Using the Snowflake Connector for Python
 

--- a/content/kb/tutorials/databases/snowflake.md
+++ b/content/kb/tutorials/databases/snowflake.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/snowflake
 
 ## Introduction
 
-This guide explains how to securely access a Snowflake database from Streamlit. It uses [st.experimental_connection](/library/api-reference/connections/st.experimental_connection), the [snowpark-python](https://docs.snowflake.com/en/developer-guide/snowpark/python/index) library and Streamlit's [secrets management](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+This guide explains how to securely access a Snowflake database from Streamlit. It uses [st.experimental_connection](/library/api-reference/connections/st.experimental_connection), the [snowpark-python](https://docs.snowflake.com/en/developer-guide/snowpark/python/index) library and Streamlit's [secrets management](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management). **The below example code will only work on Streamlit version >= 1.22, when `st.experimental_connection` was added.**
 
 Skip to the bottom for information about [connecting using Snowflake Connector for Python](#using-the-snowflake-connector-for-python).
 
@@ -60,11 +60,16 @@ Make sure to note down the name of your warehouse, database, and schema. ☝️
 
 ## Install snowflake-snowpark-python
 
-You can find the instructions and prerequisites for installing snowflake-snowpark-python in the [Snowpark Developer Guide](https://docs.snowflake.com/en/developer-guide/snowpark/python/setup). Currently, only python 3.8 is supported.
+You can find the instructions and prerequisites for installing snowflake-snowpark-python in the [Snowpark Developer Guide](https://docs.snowflake.com/en/developer-guide/snowpark/python/setup).
 
 ```sh
 pip install snowflake-snowpark-python
 ```
+
+Particular prerequisites to highlight:
+
+- Currently, only python 3.8 is supported.
+- Ensure you have the correct pyarrow version installed for your version of snowflake-snowpark-python. When in doubt, try uninstalling pyarrow before installing snowflake-snowpark-python.
 
 ## Add connection parameters to your local app secrets
 
@@ -84,7 +89,7 @@ schema = "xxx"
 client_session_keep_alive = true
 ```
 
-If you created the database from the previous step, the names of your database and schema are `PETS` and `PUBLIC`, respectively. Streamlit will also use Snowflake config and credentials from a [snowsql config file](https://docs.snowflake.com/en/user-guide/snowsql-config#snowsql-config-file) if available.
+If you created the database from the previous step, the names of your database and schema are `PETS` and `PUBLIC`, respectively. **Streamlit will also use Snowflake config and credentials from a [snowsql config file](https://docs.snowflake.com/en/user-guide/snowsql-config#snowsql-config-file) if available.**
 
 <Important>
 
@@ -118,19 +123,19 @@ If everything worked out (and you used the example table we created above), your
 
 ![Finished app screenshot](/images/databases/snowflake-app.png)
 
-### Using Snowpark Session
+### Using a Snowpark Session
 
-The SnowparkConnection also provides access to the [Snowpark Session](https://docs.snowflake.com/en/developer-guide/snowpark/reference/python/session.html) for DataFrame-style operations that run natively inside Snowflake. Using this approach, you can rewrite the app above as follows:
+The same [SnowparkConnection](/library/api-reference/connections/st.connections.snowparkconnection) used above also provides access to the [Snowpark Session](https://docs.snowflake.com/en/developer-guide/snowpark/reference/python/session.html) for DataFrame-style operations that run natively inside Snowflake. Using this approach, you can rewrite the app above as follows:
 
 ```python
 # streamlit_app.py
 
 import streamlit as st
 
-# Initialize connection.
+# Initialize connection and access underlying Snowpark session.
 session = st.experimental_connection('snowpark').session
 
-# Load the table as a dataframe
+# Load the table as a dataframe using Snowpark API.
 @st.cache_data
 def load_table():
     return session.table('mytable').to_pandas()
@@ -141,14 +146,6 @@ df = load_table()
 for row in df.itertuples():
     st.write(f"{row.NAME} has a :{row.PET}:")
 ```
-
-## Connecting to Snowflake from Community Cloud
-
-This tutorial assumes a local Streamlit app, however you can also connect to Snowflake from apps hosted in Community Cloud. The main additional steps are:
-
-- [Include information about dependencies](/streamlit-community-cloud/get-started/deploy-an-app/app-dependencies) using a `requirements.txt` file with `snowflake-snowpark-python` and any other dependencies.
-- [Add your secrets](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management#deploy-an-app-and-set-up-secrets) to your Community Cloud app.
-- For apps using snowpark-python, you should also ensure the app is [running on python 3.8](/streamlit-community-cloud/get-started/deploy-an-app#advanced-settings-for-deployment).
 
 ## Using the Snowflake Connector for Python
 
@@ -201,3 +198,11 @@ df = conn.query('SELECT * from mytable;', ttl=600)
 for row in df.itertuples():
     st.write(f"{row.name} has a :{row.pet}:")
 ```
+
+## Connecting to Snowflake from Community Cloud
+
+This tutorial assumes a local Streamlit app, however you can also connect to Snowflake from apps hosted in Community Cloud. The main additional steps are:
+
+- [Include information about dependencies](/streamlit-community-cloud/get-started/deploy-an-app/app-dependencies) using a `requirements.txt` file with `snowflake-snowpark-python` and any other dependencies.
+- [Add your secrets](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management#deploy-an-app-and-set-up-secrets) to your Community Cloud app.
+- For apps using snowpark-python, you should also ensure the app is [running on python 3.8](/streamlit-community-cloud/get-started/deploy-an-app#advanced-settings-for-deployment).

--- a/content/kb/tutorials/databases/snowflake.md
+++ b/content/kb/tutorials/databases/snowflake.md
@@ -73,7 +73,7 @@ Particular prerequisites to highlight:
 
 ## Add connection parameters to your local app secrets
 
-Your local Streamlit app will read secrets from a file `.streamlit/secrets.toml` in your app’s root directory. Create this file if it doesn’t exist yet and add your Snowflake username, password, [account identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html), and the name of your warehouse, database, and schema as shown below:
+Your local Streamlit app will read secrets from a file `.streamlit/secrets.toml` in your app’s root directory. Learn more about [Streamlit secrets management here](/library/advanced-features/secrets-management). Create this file if it doesn’t exist yet and add your Snowflake username, password, [account identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html), and the name of your warehouse, database, and schema as shown below:
 
 ```toml
 # .streamlit/secrets.toml
@@ -148,7 +148,7 @@ for row in df.itertuples():
     st.write(f"{row.NAME} has a :{row.PET}:")
 ```
 
-This example uses `with conn.safe_session()` to provide thread safety. `conn.session` also works directly, but does not guarantee thread safety.
+This example uses `with conn.safe_session()` to provide thread safety. `conn.session` also works directly, but does not guarantee thread safety. If everything worked out (and you used the example table we created above), your app should look the same as the screenshot from the first example above.
 
 ## Using the Snowflake Connector for Python
 
@@ -201,6 +201,8 @@ df = conn.query('SELECT * from mytable;', ttl=600)
 for row in df.itertuples():
     st.write(f"{row.name} has a :{row.pet}:")
 ```
+
+If everything worked out (and you used the example table we created above), your app should look the same as the screenshot from the first example above.
 
 ## Connecting to Snowflake from Community Cloud
 

--- a/content/kb/tutorials/databases/snowflake.md
+++ b/content/kb/tutorials/databases/snowflake.md
@@ -7,7 +7,9 @@ slug: /knowledge-base/tutorials/databases/snowflake
 
 ## Introduction
 
-This guide explains how to securely access a Snowflake database from Streamlit Community Cloud. It uses the [snowflake-connector-python](https://docs.snowflake.com/en/user-guide/python-connector.html) library and Streamlit's [secrets management](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+This guide explains how to securely access a Snowflake database from Streamlit. It uses [st.experimental_connection](/library/api-reference/connections/st.experimental_connection), the [snowpark-python](https://docs.snowflake.com/en/developer-guide/snowpark/python/index) library and Streamlit's [secrets management](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+
+Skip to the bottom for information about [connecting using Snowflake Connector for Python](#using-the-snowflake-connector-for-python).
 
 ## Create a Snowflake database
 
@@ -36,21 +38,11 @@ INSERT INTO MYTABLE VALUES ('Mary', 'dog'), ('John', 'cat'), ('Robert', 'bird');
 SELECT * FROM MYTABLE;
 ```
 
-Before you execute the queries, first determine which Snowflake UI / web interface you're using. You can either use the [classic web interface](https://docs.snowflake.com/en/user-guide/ui-using.html) or the [new web interface](https://docs.snowflake.com/en/user-guide/ui-gs.html).
+Before you execute the queries, first determine which Snowflake UI / web interface you're using. The examples below use [SnowSight](https://docs.snowflake.com/en/user-guide/ui-snowsight). You can also use [Classic Console Worksheets](https://docs.snowflake.com/en/user-guide/ui-worksheet) or any other means of running Snowflake SQL statements.
 
-### Using the Classic Web Interface
+### Execute queries in a Worksheet
 
-To execute the queries in the classic web interface, select **All Queries** and click on **Run**.
-
-<Image alt="AWS screenshot 1" src="/images/databases/snowflake-2.png" />
-
-Make sure to note down the name of your warehouse, database, and schema from the **Context** dropdown menu on the same page:
-
-<Image alt="AWS screenshot 2" src="/images/databases/snowflake-3.png" />
-
-### Using the New Web Interface
-
-To execute the queries in the new web interface, highlight or select all the queries with your mouse, and click the play button in the top right corner.
+To execute the queries in a Worksheet, highlight or select all the queries with your mouse, and click the play button in the top right corner.
 
 <Image alt="AWS screenshot 1" src="/images/databases/snowflake-4.png" />
 
@@ -60,29 +52,31 @@ Be sure to highlight or select **all** the queries (lines 1-10) before clicking 
 
 </Important>
 
-Once you have executed the queries, you should see a preview of the table in the **Results** panel at the bottom of the page. Addionally, you should see your newly created database and schema by expanding the accordion on the left side of the page. Lastly, the warehouse name is displayed on the button to the left of the **Share** button.
+Once you have executed the queries, you should see a preview of the table in the **Results** panel at the bottom of the page. Additionally, you should see your newly created database and schema by expanding the accordion on the left side of the page. Lastly, the warehouse name is displayed on the button to the left of the **Share** button.
 
 <Image alt="AWS screenshot 2" src="/images/databases/snowflake-5.png" />
 
 Make sure to note down the name of your warehouse, database, and schema. ☝️
 
-## Add username and password to your local app secrets
+## Add connection parameters to your local app secrets
 
 Your local Streamlit app will read secrets from a file `.streamlit/secrets.toml` in your app’s root directory. Create this file if it doesn’t exist yet and add your Snowflake username, password, [account identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html), and the name of your warehouse, database, and schema as shown below:
 
-```python
+```toml
 # .streamlit/secrets.toml
 
-[snowflake]
+[connections.snowpark]
+account = "xxx"
 user = "xxx"
 password = "xxx"
-account = "xxx"
+role = "xxx"
 warehouse = "xxx"
 database = "xxx"
 schema = "xxx"
+client_session_keep_alive = true
 ```
 
-If you created the database from the previous step, the names of your database and schema are `PETS` and `PUBLIC`, respectively.
+If you created the database from the previous step, the names of your database and schema are `PETS` and `PUBLIC`, respectively. Streamlit will also use Snowflake config and credentials from a [snowsql config file](https://docs.snowflake.com/en/user-guide/snowsql-config#snowsql-config-file) if available.
 
 <Important>
 
@@ -90,39 +84,13 @@ Add this file to `.gitignore` and don't commit it to your GitHub repo!
 
 </Important>
 
-## Copy your app secrets to the cloud
+## Install snowflake-snowpark-python
 
-As the `secrets.toml` file above is not committed to GitHub, you need to pass its content to your deployed app (on Streamlit Community Cloud) separately. Go to the [app dashboard](https://share.streamlit.io/) and in the app's dropdown menu, click on **Edit Secrets**. Copy the content of `secrets.toml` into the text area. More information is available at [Secrets Management](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+You can find the instructions and prerequisites for installing snowflake-snowpark-python in the [Snowpark Developer Guide](https://docs.snowflake.com/en/developer-guide/snowpark/python/setup). Currently, only python 3.8 is supported.
 
-![Secrets manager screenshot](/images/databases/edit-secrets.png)
-
-## Install the Snowflake Connector for Python on Streamlit Community Cloud
-
-The Snowflake Connector for Python is available on [PyPI](https://pypi.org/project/snowflake-connector-python/) and the installation instructions are found in the [Snowflake documentation](https://docs.snowflake.com/en/user-guide/python-connector-install.html#step-1-install-the-connector). When installing the connector, Snowflake recommends installing specific versions of its dependent libraries. The steps below will help you install the connector and its dependencies on Streamlit Community Cloud:
-
-1. Determine the version of the Snowflake Connector for Python you want to install.
-2. Determine the version of Python you want to use on Streamlit Community Cloud.
-3. To install the connector and the dependent libraries, select the [requirements file](https://github.com/snowflakedb/snowflake-connector-python/tree/main/tested_requirements) for that version of the connector and Python.
-4. Add the raw GitHub URL of the requirements file to your `requirements.txt` file and prepend `-r` to the line.
-   For example, if you want to install version `2.7.9` of the connector on Python 3.9, add the following line to your `requirements.txt` file:
-
-   ```text
-   -r https://raw.githubusercontent.com/snowflakedb/snowflake-connector-python/v2.7.9/tested_requirements/requirements_39.reqs
-   ```
-
-5. On Streamlit Community Cloud, select the appropriate version of Python for your app by clicking "Advanced settings" before you deploy the app:
-
-<div style={{ maxWidth: '65%', marginBottom: '-1em', marginLeft: '6em', marginTop: '-2em' }}>
-    <Image src="/images/streamlit-community-cloud/advanced-settings.png" />
-</div>
-
-That's it! You're ready to use the Snowflake Connector for Python on Streamlit Community Cloud. ❄️🎈
-
-<Tip>
-
-As the Snowflake dependencies [requirements files](https://github.com/snowflakedb/snowflake-connector-python/tree/main/tested_requirements) (`.reqs`) contain the pinned version of the connector, there is **no need** add a separate entry for the connector to requirements.txt.
-
-</Tip>
+```sh
+pip install snowflake-snowpark-python
+```
 
 ## Write your Streamlit app
 
@@ -132,35 +100,71 @@ Copy the code below to your Streamlit app and run it. Make sure to adapt query t
 # streamlit_app.py
 
 import streamlit as st
-import snowflake.connector
 
 # Initialize connection.
-# Uses st.cache_resource to only run once.
-@st.cache_resource
-def init_connection():
-    return snowflake.connector.connect(
-        **st.secrets["snowflake"], client_session_keep_alive=True
-    )
-
-conn = init_connection()
+conn = st.experimental_connection('snowpark')
 
 # Perform query.
-# Uses st.cache_data to only rerun when the query changes or after 10 min.
-@st.cache_data(ttl=600)
-def run_query(query):
-    with conn.cursor() as cur:
-        cur.execute(query)
-        return cur.fetchall()
-
-rows = run_query("SELECT * from mytable;")
+df = conn.query('SELECT * from mytable;', ttl=600)
 
 # Print results.
-for row in rows:
-    st.write(f"{row[0]} has a :{row[1]}:")
+for person, pet in zip(df['person'], df['pet']):
+    st.write(f"{person} has a :{pet}:")
 ```
 
-See `st.cache_data` above? Without it, Streamlit would run the query every time the app reruns (e.g. on a widget interaction). With `st.cache_data`, it only runs when the query changes or after 10 minutes (that's what `ttl` is for). Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Learn more in [Caching](/library/advanced-features/caching).
+See `st.experimental_connection` above? This handles secrets retrieval, setup, query caching and retries. In this case, we set `ttl=600` to ensure the query result is cached for no longer than 10 minutes. Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Learn more in [Connecting to data](/library/advanced-features/connecting-to-data) and [Caching](/library/advanced-features/caching).
 
 If everything worked out (and you used the example table we created above), your app should look like this:
 
 ![Finished app screenshot](/images/databases/snowflake-app.png)
+
+## Connecting to Snowflake from Community Cloud
+
+This tutorial assumes a local Streamlit app, however you can also connect to Snowflake from apps hosted in Community Cloud. The main additional steps are:
+
+- [Include information about dependencies](/streamlit-community-cloud/get-started/deploy-an-app/app-dependencies) using a `requirements.txt` file with `snowflake-snowpark-python` and any other dependencies.
+- [Add your secrets](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management#deploy-an-app-and-set-up-secrets) to your Community Cloud app.
+- For apps using snowpark-python, you should also ensure the app is [running on python 3.8](/streamlit-community-cloud/get-started/deploy-an-app#advanced-settings-for-deployment).
+
+## Using the Snowflake Connector for Python
+
+In some cases, you may prefer to use the [Snowflake Connector for Python](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector) instead of Snowpark Python. Streamlit supports this natively through the [SQLConnection](/library/api-reference/connections/st.connections.sqlconnection) and the [snowflake-sqlalchemy](https://docs.snowflake.com/en/developer-guide/python-connector/sqlalchemy) library.
+
+```bash
+pip install snowflake-sqlalchemy
+```
+
+Installing `snowflake-sqlalchemy` will also install all necessary dependencies.
+
+Configuring credentials follows the `SQLConnection` format which is slightly different. See the [Snowflake SQLAlchemy Configuration Parameters documentation](https://docs.snowflake.com/en/developer-guide/python-connector/sqlalchemy#connection-parameters) for more details. Beyond specifying the URL, additional common parameters like `authenticator` or key pair authentication can be set using `create_engine_kwargs`, as shown below.
+
+```toml
+# .streamlit/secrets.toml
+
+[connections.snowflake]
+url = "snowflake://<user_login_name>:<password>@<account_identifier>/<database_name>/<schema_name>?warehouse=<warehouse_name>&role=<role_name>"
+
+# Alternatively, specify additional connection parameters here
+[connections.snowflake.create_engine_kwargs.connect_args]
+authenticator = "externalbrowser"
+warehouse = "xxx"
+role = "xxx"
+```
+
+Initializing and using the connection in your app is similar. Note that [SQLConnection.query()](https://deploy-preview-622--streamlit-docs.netlify.app/library/api-reference/connections/st.connections.sqlconnection#sqlconnectionquery) supports extra arguments like `params` and `chunksize` which may be useful for more advanced apps.
+
+```python
+# streamlit_app.py
+
+import streamlit as st
+
+# Initialize connection.
+conn = st.experimental_connection('snowflake', type='sql')
+
+# Perform query.
+df = conn.query('SELECT * from mytable;', ttl=600)
+
+# Print results.
+for person, pet in zip(df['person'], df['pet']):
+    st.write(f"{person} has a :{pet}:")
+```

--- a/content/kb/tutorials/databases/snowflake.md
+++ b/content/kb/tutorials/databases/snowflake.md
@@ -117,7 +117,7 @@ for row in df.itertuples():
     st.write(f"{row.NAME} has a :{row.PET}:")
 ```
 
-See `st.experimental_connection` above? This handles secrets retrieval, setup, query caching and retries. In this case, we set `ttl=600` to ensure the query result is cached for no longer than 10 minutes. Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Learn more in [Connecting to data](/library/advanced-features/connecting-to-data) and [Caching](/library/advanced-features/caching).
+See `st.experimental_connection` above? This handles secrets retrieval, setup, query caching and retries. By default, `query()` results are cached without expiring. In this case, we set `ttl=600` to ensure the query result is cached for no longer than 10 minutes. You can also set `ttl=None` to disable caching. Learn more in [Connecting to data](/library/advanced-features/connecting-to-data) and [Caching](/library/advanced-features/caching).
 
 If everything worked out (and you used the example table we created above), your app should look like this:
 

--- a/content/kb/tutorials/databases/snowflake.md
+++ b/content/kb/tutorials/databases/snowflake.md
@@ -100,6 +100,7 @@ Copy the code below to your Streamlit app and run it. Make sure to adapt query t
 # streamlit_app.py
 
 import streamlit as st
+import pandas as pd
 
 # Initialize connection.
 conn = st.experimental_connection('snowpark')
@@ -108,8 +109,8 @@ conn = st.experimental_connection('snowpark')
 df = conn.query('SELECT * from mytable;', ttl=600)
 
 # Print results.
-for person, pet in zip(df['person'], df['pet']):
-    st.write(f"{person} has a :{pet}:")
+for row in df.itertuples():
+    st.write(f"{row.person} has a :{row.pet}:")
 ```
 
 See `st.experimental_connection` above? This handles secrets retrieval, setup, query caching and retries. In this case, we set `ttl=600` to ensure the query result is cached for no longer than 10 minutes. Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Learn more in [Connecting to data](/library/advanced-features/connecting-to-data) and [Caching](/library/advanced-features/caching).
@@ -157,6 +158,7 @@ Initializing and using the connection in your app is similar. Note that [SQLConn
 # streamlit_app.py
 
 import streamlit as st
+import pandas as pd
 
 # Initialize connection.
 conn = st.experimental_connection('snowflake', type='sql')
@@ -165,6 +167,6 @@ conn = st.experimental_connection('snowflake', type='sql')
 df = conn.query('SELECT * from mytable;', ttl=600)
 
 # Print results.
-for person, pet in zip(df['person'], df['pet']):
-    st.write(f"{person} has a :{pet}:")
+for row in df.itertuples():
+    st.write(f"{row.person} has a :{row.pet}:")
 ```

--- a/content/kb/tutorials/databases/snowflake.md
+++ b/content/kb/tutorials/databases/snowflake.md
@@ -58,6 +58,14 @@ Once you have executed the queries, you should see a preview of the table in the
 
 Make sure to note down the name of your warehouse, database, and schema. ☝️
 
+## Install snowflake-snowpark-python
+
+You can find the instructions and prerequisites for installing snowflake-snowpark-python in the [Snowpark Developer Guide](https://docs.snowflake.com/en/developer-guide/snowpark/python/setup). Currently, only python 3.8 is supported.
+
+```sh
+pip install snowflake-snowpark-python
+```
+
 ## Add connection parameters to your local app secrets
 
 Your local Streamlit app will read secrets from a file `.streamlit/secrets.toml` in your app’s root directory. Create this file if it doesn’t exist yet and add your Snowflake username, password, [account identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html), and the name of your warehouse, database, and schema as shown below:
@@ -84,17 +92,9 @@ Add this file to `.gitignore` and don't commit it to your GitHub repo!
 
 </Important>
 
-## Install snowflake-snowpark-python
-
-You can find the instructions and prerequisites for installing snowflake-snowpark-python in the [Snowpark Developer Guide](https://docs.snowflake.com/en/developer-guide/snowpark/python/setup). Currently, only python 3.8 is supported.
-
-```sh
-pip install snowflake-snowpark-python
-```
-
 ## Write your Streamlit app
 
-Copy the code below to your Streamlit app and run it. Make sure to adapt query to use the name of your table.
+Copy the code below to your Streamlit app and run it. Make sure to adapt the query to use the name of your table.
 
 ```python
 # streamlit_app.py


### PR DESCRIPTION
# TODOS

- [x] The MySQL tutorial in particular needs an older copy to be archived to link in the blog post for comparison. Not sure how best to do that (i can easily make a new page and copy the old page with a different slug but want to confirm with @snehankekre if that approach makes sense, or something else). In theory could also use the wayback machine.
- [x] I didn't test the e2e setup although I did test the final code locally. I can do this but didn't know if @snehankekre wanted to do it personally.

## 📚 Context

Updating database tutorials to use st.connection. Depends on pages in https://github.com/streamlit/docs/pull/622

## 🧠 Description of Changes

* Update the MySQL tutorial to use st.connection API
* Update the Snowflake tutorial to use st.connection API

**Revised:**

Here's the main update, there are some other updates too

![image](https://user-images.githubusercontent.com/116604821/234416576-295cb2ae-4103-4040-a245-7859fb8f117e.png)

**Current:**

https://docs.streamlit.io/knowledge-base/tutorials/databases/mysql

## 💥 Impact

Changes the tutorial setup and code

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
