### PR TITLE
Fix ttl=None -> ttl=0 to disable caching in tutorials

### DIFF
--- a/content/kb/tutorials/databases/mysql.md
+++ b/content/kb/tutorials/databases/mysql.md
@@ -93,7 +93,7 @@ for row in df.itertuples():
     st.write(f"{row.name} has a :{row.pet}:")
 ```
 
-See `st.experimental_connection` above? This handles secrets retrieval, setup, query caching and retries. By default, `query()` results are cached without expiring. In this case, we set `ttl=600` to ensure the query result is cached for no longer than 10 minutes. You can also set `ttl=None` to disable caching. Learn more in [Caching](/library/advanced-features/caching).
+See `st.experimental_connection` above? This handles secrets retrieval, setup, query caching and retries. By default, `query()` results are cached without expiring. In this case, we set `ttl=600` to ensure the query result is cached for no longer than 10 minutes. You can also set `ttl=0` to disable caching. Learn more in [Caching](/library/advanced-features/caching).
 
 If everything worked out (and you used the example table we created above), your app should look like this:
 

--- a/content/kb/tutorials/databases/snowflake.md
+++ b/content/kb/tutorials/databases/snowflake.md
@@ -117,7 +117,7 @@ for row in df.itertuples():
     st.write(f"{row.NAME} has a :{row.PET}:")
 ```
 
-See `st.experimental_connection` above? This handles secrets retrieval, setup, query caching and retries. By default, `query()` results are cached without expiring. In this case, we set `ttl=600` to ensure the query result is cached for no longer than 10 minutes. You can also set `ttl=None` to disable caching. Learn more in [Caching](/library/advanced-features/caching).
+See `st.experimental_connection` above? This handles secrets retrieval, setup, query caching and retries. By default, `query()` results are cached without expiring. In this case, we set `ttl=600` to ensure the query result is cached for no longer than 10 minutes. You can also set `ttl=0` to disable caching. Learn more in [Caching](/library/advanced-features/caching).
 
 If everything worked out (and you used the example table we created above), your app should look like this:
 


### PR DESCRIPTION
## 📚 Context

Realized I had a brain fart last week and put in the wrong argument to disable caching in the two tutorials.

I scanned all the other docs and references, afaict this is the only place where I/we got it wrong. Also confirmed with Vincent that this new version is correct.

## 🧠 Description of Changes

- Switch `ttl=None` -> `ttl=0` for how to disable caching in the query methods of SQL and SnowparkConnection, as specified in the MySQL and Snowflake tutorials.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
