### PR TITLE
Update S3 and GCS tutorials to use FilesConnection

### DIFF
--- a/content/kb/tutorials/databases/aws-s3.md
+++ b/content/kb/tutorials/databases/aws-s3.md
@@ -111,7 +111,7 @@ for row in df.itertuples():
     st.write(f"{row.Owner} has a :{row.Pet}:")
 ```
 
-See `st.experimental_connection` above? This handles secrets retrieval, setup, result caching and retries. By default, `read()` results are cached without expiring. In this case, we set `ttl=600` to ensure the file contents is cached for no longer than 10 minutes. You can also set `ttl=None` to disable caching. Learn more in [Caching](/library/advanced-features/caching).
+See `st.experimental_connection` above? This handles secrets retrieval, setup, result caching and retries. By default, `read()` results are cached without expiring. In this case, we set `ttl=600` to ensure the file contents is cached for no longer than 10 minutes. You can also set `ttl=0` to disable caching. Learn more in [Caching](/library/advanced-features/caching).
 
 If everything worked out (and you used the example file given above), your app should look like this:
 

--- a/content/kb/tutorials/databases/aws-s3.md
+++ b/content/kb/tutorials/databases/aws-s3.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/aws-s3
 
 ## Introduction
 
-This guide explains how to securely access files on AWS S3 from Streamlit Community Cloud. It uses [Streamlit FilesConnection](https://github.com/streamlit/files-connection), the [s3fs](https://github.com/dask/s3fs) library and optionally Streamlit's [secrets management](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+This guide explains how to securely access files on AWS S3 from Streamlit Community Cloud. It uses [Streamlit FilesConnection](https://github.com/streamlit/files-connection), the [s3fs](https://github.com/dask/s3fs) library and optionally Streamlit's [secrets management](/library/advanced-features/secrets-management).
 
 ## Create an S3 bucket and add a file
 

--- a/content/kb/tutorials/databases/gcs.md
+++ b/content/kb/tutorials/databases/gcs.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/gcs
 
 ## Introduction
 
-This guide explains how to securely access files on Google Cloud Storage from Streamlit Community Cloud. It uses the [google-cloud-storage](https://googleapis.dev/python/storage/latest/index.html) library and Streamlit's [secrets management](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management).
+This guide explains how to securely access files on Google Cloud Storage from Streamlit Community Cloud. It uses [Streamlit FilesConnection](https://github.com/streamlit/files-connection), the [gcsfs](https://github.com/fsspec/gcsfs) library and Streamlit's [secrets management](/library/advanced-features/secrets-management).
 
 ## Create a Google Cloud Storage bucket and add a file
 

--- a/content/kb/tutorials/databases/gcs.md
+++ b/content/kb/tutorials/databases/gcs.md
@@ -136,7 +136,7 @@ for row in df.itertuples():
     st.write(f"{row.Owner} has a :{row.Pet}:")
 ```
 
-See `st.experimental_connection` above? This handles secrets retrieval, setup, result caching and retries. By default, `read()` results are cached without expiring. In this case, we set `ttl=600` to ensure the file contents is cached for no longer than 10 minutes. You can also set `ttl=None` to disable caching. Learn more in [Caching](/library/advanced-features/caching).
+See `st.experimental_connection` above? This handles secrets retrieval, setup, result caching and retries. By default, `read()` results are cached without expiring. In this case, we set `ttl=600` to ensure the file contents is cached for no longer than 10 minutes. You can also set `ttl=0` to disable caching. Learn more in [Caching](/library/advanced-features/caching).
 
 If everything worked out (and you used the example file given above), your app should look like this:
 

--- a/content/kb/tutorials/databases/gcs.md
+++ b/content/kb/tutorials/databases/gcs.md
@@ -50,7 +50,7 @@ If you do need to enable the API for programmatic access in your project, head o
 
 ## Create a service account and key file
 
-To use the Google Cloud Storage API from Streamlit Community Cloud, you need a Google Cloud Platform service account (a special type for programmatic data access). Go to the Service Accounts page and create an account with <b>Viewer</b> permission.
+To use the Google Cloud Storage API from Streamlit, you need a Google Cloud Platform service account (a special type for programmatic data access). Go to the Service Accounts page and create an account with <b>Viewer</b> permission.
 
 <Flex>
 <Image alt="GCS screenshot 8" src="/images/databases/gcs-8.png" />
@@ -80,7 +80,7 @@ Your local Streamlit app will read secrets from a file `.streamlit/secrets.toml`
 ```toml
 # .streamlit/secrets.toml
 
-[gcp_service_account]
+[connections.gcs]
 type = "service_account"
 project_id = "xxx"
 private_key_id = "xxx"
@@ -105,13 +105,15 @@ As the `secrets.toml` file above is not committed to GitHub, you need to pass it
 
 ![Secrets manager screenshot](/images/databases/edit-secrets.png)
 
-## Add google-cloud-storage to your requirements file
+## Add FilesConnection and gcsfs to your requirements file
 
-Add the [google-cloud-storage](https://googleapis.dev/python/storage/latest/index.html) package to your `requirements.txt` file, preferably pinning its version (replace `x.x.x` with the version you want installed):
+Add the [FilesConnection](https://github.com/streamlit/files-connection) and [gcsfs](https://github.com/fsspec/gcsfs) packages to your `requirements.txt` file, preferably pinning the versions (replace `x.x.x` with the version you want installed):
 
 ```bash
 # requirements.txt
-google-cloud-storage==x.x.x
+gcsfs==x.x.x
+# Direct pypi install coming soon
+git+https://github.com/streamlit/files-connection
 ```
 
 ## Write your Streamlit app
@@ -122,35 +124,19 @@ Copy the code below to your Streamlit app and run it. Make sure to adapt the nam
 # streamlit_app.py
 
 import streamlit as st
-from google.oauth2 import service_account
-from google.cloud import storage
+from st_files_connection import FilesConnection
 
-# Create API client.
-credentials = service_account.Credentials.from_service_account_info(
-    st.secrets["gcp_service_account"]
-)
-client = storage.Client(credentials=credentials)
-
-# Retrieve file contents.
-# Uses st.cache_data to only rerun when the query changes or after 10 min.
-@st.cache_data(ttl=600)
-def read_file(bucket_name, file_path):
-    bucket = client.bucket(bucket_name)
-    content = bucket.blob(file_path).download_as_string().decode("utf-8")
-    return content
-
-bucket_name = "streamlit-bucket"
-file_path = "myfile.csv"
-
-content = read_file(bucket_name, file_path)
+# Create connection object and retrieve file contents.
+# Specify input format is a csv and to cache the result for 600 seconds.
+conn = st.experimental_connection('gcs', type=FilesConnection)
+df = conn.read("streamlit-bucket/myfile.csv", input_format="csv", ttl=600)
 
 # Print results.
-for line in content.strip().split("\n"):
-    name, pet = line.split(",")
-    st.write(f"{name} has a :{pet}:")
+for row in df.itertuples():
+    st.write(f"{row.Owner} has a :{row.Pet}:")
 ```
 
-See `st.cache_data` above? Without it, Streamlit would run the query every time the app reruns (e.g. on a widget interaction). With `st.cache_data`, it only runs when the query changes or after 10 minutes (that's what `ttl` is for). Watch out: If your database updates more frequently, you should adapt `ttl` or remove caching so viewers always see the latest data. Learn more in [Caching](/library/advanced-features/caching).
+See `st.experimental_connection` above? This handles secrets retrieval, setup, result caching and retries. By default, `read()` results are cached without expiring. In this case, we set `ttl=600` to ensure the file contents is cached for no longer than 10 minutes. You can also set `ttl=None` to disable caching. Learn more in [Caching](/library/advanced-features/caching).
 
 If everything worked out (and you used the example file given above), your app should look like this:
 

--- a/content/kb/tutorials/databases/mysql.md
+++ b/content/kb/tutorials/databases/mysql.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/mysql
 
 ## Introduction
 
-This guide explains how to securely access a **_remote_** MySQL database from Streamlit Community Cloud. It uses [st.experimental_connection](/library/api-reference/connections/st.experimental_connection) and Streamlit's [secrets management](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management). The below example code will **only work on Streamlit version >= 1.22**, when `st.experimental_connection` was added.
+This guide explains how to securely access a **_remote_** MySQL database from Streamlit Community Cloud. It uses [st.experimental_connection](/library/api-reference/connections/st.experimental_connection) and Streamlit's [secrets management](/library/advanced-features/secrets-management). The below example code will **only work on Streamlit version >= 1.22**, when `st.experimental_connection` was added.
 
 ## Create a MySQL database
 

--- a/content/kb/tutorials/databases/snowflake.md
+++ b/content/kb/tutorials/databases/snowflake.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/snowflake
 
 ## Introduction
 
-This guide explains how to securely access a Snowflake database from Streamlit. It uses [st.experimental_connection](/library/api-reference/connections/st.experimental_connection), the [Snowpark Python](https://docs.snowflake.com/en/developer-guide/snowpark/python/index) library and Streamlit's [secrets management](/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management). The below example code **will only work on Streamlit version >= 1.22**, when `st.experimental_connection` was added.
+This guide explains how to securely access a Snowflake database from Streamlit. It uses [st.experimental_connection](/library/api-reference/connections/st.experimental_connection), the [Snowpark Python](https://docs.snowflake.com/en/developer-guide/snowpark/python/index) library and Streamlit's [secrets management](/library/advanced-features/secrets-management). The below example code **will only work on Streamlit version >= 1.22**, when `st.experimental_connection` was added.
 
 Skip to the bottom for information about [connecting using Snowflake Connector for Python](#using-the-snowflake-connector-for-python).
 

--- a/public/images/databases/myfile.csv
+++ b/public/images/databases/myfile.csv
@@ -1,3 +1,4 @@
+Owner,Pet
 Mary,dog
 John,cat
 Robert,bird


### PR DESCRIPTION
## 📚 Context

Updating cloud file store tutorials following the st.experimental_connection launch!

## 🧠 Description of Changes

- Update S3 tutorial to use st.experimental_connection and [FilesConnection](https://github.com/streamlit/files-connection)
- Update GCS tutorial to use st.experimental_connection and [FilesConnection](https://github.com/streamlit/files-connection)
- Switch MySQL, Snowflake, S3, GCS tutorials (the st.connection ones so far) to link to the [new Secrets Management page](https://docs.streamlit.io/library/advanced-features/secrets-management).

**Revised:**

- https://deploy-preview-629--streamlit-docs.netlify.app/knowledge-base/tutorials/databases/aws-s3
- https://deploy-preview-629--streamlit-docs.netlify.app/knowledge-base/tutorials/databases/gcs

**Current:**

- https://docs.streamlit.io/knowledge-base/tutorials/databases/aws-s3
- https://docs.streamlit.io/knowledge-base/tutorials/databases/gcs

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
