### PR TITLE
Emphasize where data editor limitations are noted

### DIFF
--- a/content/library/api/widgets/data_editor.md
+++ b/content/library/api/widgets/data_editor.md
@@ -12,7 +12,7 @@ This is an experimental feature. Experimental features and their APIs may change
 
 <Tip>
 
-This page only contains information on the `st.experimental_data_editor` API. For a deeper dive into working with DataFrames and the data editor's capabilities, read [Dataframes](/library/advanced-features/dataframes).
+This page only contains information on the `st.experimental_data_editor` API. For a deeper dive into working with DataFrames and the data editor's capabilities and limitations, read [Dataframes](/library/advanced-features/dataframes).
 
 </Tip>
 


### PR DESCRIPTION
## 📚 Context
The note about limited data types being supported by the data editor is on a different page than the widget's main documentation. #636 in response to forum question.

## 🧠 Description of Changes
The tip at the top of the page was edited to note that limitations exist and are documented on the DataFrame page linked in same.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
