### PR TITLE
Remove NextJS' Incremental Static Regeneration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,3 @@
-const fs = require("fs");
-
 module.exports = {
   webpack: (configuration) => {
     configuration.module.rules.push(

--- a/pages/404.js
+++ b/pages/404.js
@@ -68,6 +68,5 @@ export async function getStaticProps(context) {
 
   return {
     props: props,
-    revalidate: 60,
   };
 }

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -349,7 +349,6 @@ export async function getStaticProps(context) {
 
   return {
     props: props,
-    revalidate: 60,
   };
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -297,6 +297,5 @@ export async function getStaticProps(context) {
 
   return {
     props: props,
-    revalidate: 60,
   };
 }


### PR DESCRIPTION
## 📚 Context

While we were working on a completely different thing (#623), @snehankekre noticed a performance issue on the API reference page (see [comment](https://github.com/streamlit/docs/pull/623#issuecomment-1521661248)).

Upon doing some research and testing, I noticed we were using NextJS' [ISR](https://nextjs.org/docs/pages/building-your-application/rendering/incremental-static-regeneration) in our pages, which is not compatible with [static exports](https://nextjs.org/docs/app/building-your-application/deploying/static-exports).

Removing that directive makes the static HTML export work again, making the site super fast, and (I believe) not causing any visualization issues nor errors.

## 🧠 Description of Changes

* Removed `revalidate: 60,` from the `return` statement in `getStaticProps`;

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

- Unblocks #623 

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
