### PR TITLE
Package compatibility warning including protobuf

### DIFF
--- a/content/streamlit-cloud/get-started/deploy-an-app/app-dependencies.md
+++ b/content/streamlit-cloud/get-started/deploy-an-app/app-dependencies.md
@@ -33,7 +33,9 @@ Streamlit looks at your requirements file's filename to determine which Python d
 Only include packages in your requirements file that are not distributed with a standard Python
 installation. If [any of the modules from base Python](https://docs.python.org/3/py-modindex.html)
 are included in the requirements file, you will get an error when you try to deploy. Additionally, we recommend that you
-use the latest version of Streamlit to ensure full Streamlit Community Cloud functionality.
+use the latest version of Streamlit to ensure full Streamlit Community Cloud functionality. Be sure to take note of
+Streamlit's [current requirements](https://github.com/streamlit/streamlit/blob/develop/lib/dev-requirements.txt)
+for package compatibility when planning your environment, especially `protobuf<4,>=3.12`.
 
 </Note>
 

--- a/content/streamlit-cloud/get-started/deploy-an-app/app-dependencies.md
+++ b/content/streamlit-cloud/get-started/deploy-an-app/app-dependencies.md
@@ -34,8 +34,8 @@ Only include packages in your requirements file that are not distributed with a 
 installation. If [any of the modules from base Python](https://docs.python.org/3/py-modindex.html)
 are included in the requirements file, you will get an error when you try to deploy. Additionally, we recommend that you
 use the latest version of Streamlit to ensure full Streamlit Community Cloud functionality. Be sure to take note of
-Streamlit's [current requirements](https://github.com/streamlit/streamlit/blob/develop/lib/dev-requirements.txt)
-for package compatibility when planning your environment, especially `protobuf<4,>=3.12`.
+Streamlit's [current requirements](https://github.com/streamlit/streamlit/blob/develop/lib/setup.py)
+for package compatibility when planning your environment, especially `protobuf>=3.20,<5`.
 
 </Note>
 


### PR DESCRIPTION
Expanded note regarding package management. Warned users to check package compatibility, especially protobuf version.
Closes #639.

## 📚 Context
There has been a lot of confusion about protobuf versions on the forum. Although the pinning of protobuf 3.20.1 on Streamlit Cloud is expected to be resolved, it is still the case that `protobuf<4,>=3.12` may catch some users unaware. Hence it is explicitly noted now with a reminded to check all package requirements as a good practice. 

## 🧠 Description of Changes
The note at the bottom of the [app dependencies](https://docs.streamlit.io/streamlit-community-cloud/get-started/deploy-an-app/app-dependencies) page was expanded to include the mentioned warning.

**Revised:**
![image](https://github.com/streamlit/docs/assets/98661771/d13ac2b7-4def-4fcf-9760-c6ef05fc178f)

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
