### PR TITLE
Hide deprecated API pages from search

### DIFF
--- a/scripts/build-search-index.js
+++ b/scripts/build-search-index.js
@@ -7,7 +7,16 @@ const parser = require("node-html-parser");
 const algoliasearch = require("algoliasearch");
 const { convert } = require("html-to-text");
 
-const SKIP_THESE = ["/menu", "/404", "/500"];
+const SKIP_THESE = [
+  "/menu",
+  "/404",
+  "/500",
+  "/library/api-reference/performance/st.cache",
+  "/library/api-reference/performance/st.experimental_memo",
+  "/library/api-reference/performance/st.experimental_singleton",
+  "/library/api-reference/performance/st.experimental_singleton.clear",
+  "/library/api-reference/utilities/st.experimental_show",
+];
 
 function getAllFilesInDirectory(articleDirectory, files) {
   files = files ? files : [];


### PR DESCRIPTION
## 📚 Context

From @sfc-gh-jrieke: if I search e.g. for “experimental” on the docs, it’s showing the deprecated “Experimental cache primitives” as the first result. Can we maybe hide deprecated pages from the search? Or at least rank them lower in the results?

![image](https://github.com/streamlit/docs/assets/20672874/f86f5603-1cf8-4fc1-8ed5-5b2fcec878fc)

## 🧠 Description of Changes

- Adds deprecated API pages for our old caching commands and `st.experimental_show` to the list of pages that should be skipped when creating the search index.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/snowflake-corp/Hide-deprecated-pages-from-search-on-docs-70e94e9a62f64f81a03951eb2d3ad4d3)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
