### PR TITLE
Fix link to Anaconda Navigator

### DIFF
--- a/content/library/get-started/installation.md
+++ b/content/library/get-started/installation.md
@@ -40,13 +40,13 @@ Streamlit's officially-supported environment manager on Windows is [Anaconda Nav
 
 ### Install Anaconda
 
-If you don't have Anaconda install yet, follow the steps provided on the [Anaconda installation page](https://docs.anaconda.com/anaconda/install/windows/).
+If you don't have Anaconda install yet, follow the steps provided on the [Anaconda installation page](https://docs.anaconda.com/free/anaconda/install/windows/).
 
 ### Create a new environment with Streamlit
 
 Next you'll need to set up your environment.
 
-1. Follow the steps provided by Anaconda to [set up and manage your environment](https://docs.anaconda.com/anaconda/navigator/getting-started/#managing-environments) using the Anaconda Navigator.
+1. Follow the steps provided by Anaconda to [set up and manage your environment](https://docs.anaconda.com/free/navigator/getting-started/#navigator-managing-environments) using the Anaconda Navigator.
 
 2. Select the "▶" icon next to your new environment. Then select "Open terminal":
 

--- a/content/library/get-started/installation.md
+++ b/content/library/get-started/installation.md
@@ -36,7 +36,7 @@ Below are a few tools you can use for environment management:
 
 ## Install Streamlit on Windows
 
-Streamlit's officially-supported environment manager on Windows is [Anaconda Navigator](https://docs.anaconda.com/anaconda/navigator/).
+Streamlit's officially-supported environment manager on Windows is [Anaconda Navigator](https://docs.anaconda.com/free/navigator/).
 
 ### Install Anaconda
 


### PR DESCRIPTION
## 📚 Context

The old link gives a 404

## 🧠 Description of Changes

* I changed the navigator link to https://docs.anaconda.com/free/navigator/

**Revised:**

Screenshots will be identical

**Current:**

Screenshots will be identical

## 💥 Impact

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

Skipping

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
