### PR TITLE
Dynamically update blog posts with `NewsFeed` component

### DIFF
--- a/components/blocks/newsEntry.js
+++ b/components/blocks/newsEntry.js
@@ -4,10 +4,27 @@ import classNames from "classnames";
 import styles from "./newsEntry.module.css";
 import Image from "./image";
 
+function convertToUTC(dateStr) {
+  const date = new Date(dateStr);
+  if (isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toISOString();
+}
+
 const NewsEntry = ({ date, title, text, link, image, target }) => {
-  const niceDate = (date) => {
-    let cleanDate = new Date(date);
-    return cleanDate.toLocaleDateString("en-US", {
+  const niceDate = (dateStr) => {
+    const utcDateStr = convertToUTC(dateStr);
+    if (utcDateStr !== null) {
+      const date = new Date(utcDateStr);
+    }
+
+    if (isNaN(date.getTime())) {
+      // dateStr is not a valid date
+      return "No date";
+    }
+
+    return date.toLocaleDateString("en-US", {
       month: "long",
       day: "numeric",
       year: "numeric",
@@ -26,7 +43,7 @@ const NewsEntry = ({ date, title, text, link, image, target }) => {
         <h4 className={styles.Title}>{title}</h4>
         <p className={styles.Text}>{text}</p>
         <ArrowLink
-          link={link}
+          link={link ? link : "#"}
           type="next"
           clean={true}
           className="tiny bold"

--- a/components/blocks/newsFeed.js
+++ b/components/blocks/newsFeed.js
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from "react";
+import GhostContentAPI from "@tryghost/content-api";
+import NewsEntry from "./newsEntry";
+
+const api = new GhostContentAPI({
+  url: "https://streamlit.ghost.io",
+  key: "b48c60c1a281bf21dc9afa9950",
+  version: "v5.0",
+});
+
+function NewsFeed() {
+  const [posts, setPosts] = useState([]);
+
+  useEffect(() => {
+    // fetch 3 posts, including related tags and authors
+    api.posts
+      .browse({ limit: 3, include: "tags,authors" })
+      .then((fetchedPosts) => {
+        console.log(fetchedPosts);
+        setPosts(fetchedPosts);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  }, []);
+
+  return (
+    <div>
+      <div id="result">
+        {posts.map((post) => (
+          <NewsEntry
+            date={post.published_at}
+            title={post.title}
+            text={post.excerpt}
+            link={post.url}
+            image={post.feature_image}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default NewsFeed;

--- a/components/navigation/arrowLink.js
+++ b/components/navigation/arrowLink.js
@@ -4,9 +4,10 @@ import styles from "./arrowLink.module.css";
 
 const ArrowLink = ({ children, link, type, content, target }) => {
   function ArrowType() {
+    const href = link || "#";
     if (type == "back") {
       return (
-        <Link href={link}>
+        <Link href={href}>
           <a
             className={`
               not-link
@@ -35,7 +36,7 @@ const ArrowLink = ({ children, link, type, content, target }) => {
       );
     } else if (type == "next") {
       return (
-        <Link href={link}>
+        <Link href={href}>
           <a
             className={`
               not-link

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "sass": "^1.42.1",
     "slugify": "^1.6.1",
     "tailwindcss": "^3.0.1",
+    "@tryghost/content-api": "1.11.10",
     "unified": "^9.2.2",
     "uuid": "^8.3.2"
   },

--- a/pages/index.js
+++ b/pages/index.js
@@ -22,7 +22,7 @@ import TileContainer from "../components/layouts/tileContainer";
 import RefCard from "../components/blocks/refCard";
 
 import { H1, H2 } from "../components/blocks/headers";
-import NewsEntry from "../components/blocks/newsEntry";
+import NewsFeed from "../components/blocks/newsFeed";
 import Button from "../components/blocks/button";
 import InlineCallout from "../components/blocks/inlineCallout";
 import NoteSplit from "../components/blocks/noteSplit";
@@ -92,18 +92,6 @@ export default function Home({ window, menu, gdpr_data }) {
               <Tile size="half" background="unset" color="unset" dark={{ background: "unset", color: 'white', border_color: 'gray-90' }} border_color="gray-40" icon="edit" title="Feature title" text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Eleifend a facilisis sagittis, vitae nibh massa in facilisis et. Pretium eget non cursus purus tempus porta sodales." link="/tutorials/get-started" />
               <Tile size="half" background="unset" color="unset" dark={{ background: "unset", color: 'white', border_color: 'gray-90' }} border_color="gray-40" img="/logo.svg" title="Feature title" text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Eleifend a facilisis sagittis, vitae nibh massa in facilisis et. Pretium eget non cursus purus tempus porta sodales." link="/tutorials/get-started" />
             </TileContainer> */}
-
-            {/* <NewsContainer>
-              <NewsEntry
-                date="2022-02-20T16:30:00.000Z"
-                title="Announcement: Streamlit Community Cloud Maintenance"
-                text="Streamlit Community Cloud will have a maintenance event on Sunday, February 20th at 7:00 am PST. The maintenance event will last for no more than 5 minutes."
-                link="https://discuss.streamlit.io/c/official-announcements/"
-              />
-              <NewsEntry date="2022-02-17T16:08:45.000Z" title="Calculating distances in cosmology with Streamlit" text="Learn how three friends made the cosmology on-the-go app CosmΩracle." link="https://blog.streamlit.io/calculating-distances-in-cosmology-with-streamlit/" />
-              <NewsEntry date="2021-02-07T16:30:00.000Z" title="Monthly Rewind > January 2022" text="Your January look-back at new features and great community content." link="https://blog.streamlit.io/monthly-rewind-january-2022/" />
-              <Button link="https://blog.streamlit.io/">View all updates</Button>
-            </NewsContainer> */}
 
             <H2>How to use our docs</H2>
             <InlineCalloutContainer>
@@ -232,30 +220,8 @@ export default function Home({ window, menu, gdpr_data }) {
             <H2 className="no-b-m">Latest blog posts</H2>
 
             <NewsContainer>
-              <NewsEntry
-                date="2023-04-27T16:05:00.000Z"
-                title="The ultimate athlete management dashboard for biomechanics"
-                text="Learn how to measure jump impulse, max force, and asymmetry with Python and Streamlit"
-                link="https://blog.streamlit.io/the-ultimate-athlete-management-dashboard-for-biomechanics/"
-                image="/blog-1.svg"
-                target="_blank"
-              />
-              <NewsEntry
-                date="2023-04-20T16:05:00.000Z"
-                title="Create an animated data story with ipyvizzu and Streamlit"
-                text="A tutorial on using ipyvizzu and ipyvizzu-story"
-                link="https://blog.streamlit.io/create-an-animated-data-story-with-ipyvizzu-and-streamlit/"
-                image="/blog-2.svg"
-                target="_blank"
-              />
-              <NewsEntry
-                date="2023-04-13T16:05:00.000Z"
-                title="Introducing a chemical molecule component for your Streamlit apps"
-                text="Integrate a fully featured molecule editor with just a few lines of code!"
-                link="https://blog.streamlit.io/introducing-a-chemical-molecule-component-for-your-streamlit-apps/"
-                image="/blog-3.svg"
-                target="_blank"
-              />
+              <NewsFeed />
+
               <Button link="https://blog.streamlit.io/" target="_blank">
                 View all updates
               </Button>


### PR DESCRIPTION
## 📚 Context

Dynamically update blog posts with a new `NewsFeed` component.

The blog posts on the documentation homepage are handpicked by maintainers. New blog posts are added to https://blog.streamlit.io daily, but the docs team doesn't have the capacity to submit daily PRs to update them on our site. Additionally, the Marketing team has to inform the Docs team anytime there's an update.  This process is too manual and considered a chore. Let's automate it.

## 🧠 Description of Changes

- Adds a new component `<NewsFeed />`, that used the [GhostContentAPI](https://ghost.org/docs/content-api/) to fetch the latest three blog posts and passes them into the existing `<NewsEntry>` component. 


## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
