### PR TITLE
Remove 'view standalone Streamlit app' text from `cloud.js` and `stoutput.py`

### DIFF
--- a/components/blocks/cloud.js
+++ b/components/blocks/cloud.js
@@ -18,9 +18,9 @@ const Cloud = ({ src, height }) => {
           allow="camera;clipboard-read;clipboard-write;"
           key={src}
         />
-        <a href={src} target="_blank" className={styles.Caption}>
+        {/* <a href={src} target="_blank" className={styles.Caption}>
           (view standalone Streamlit app)
-        </a>
+        </a> */}
       </section>
     );
   } else {
@@ -33,9 +33,9 @@ const Cloud = ({ src, height }) => {
           allow="camera;clipboard-read;clipboard-write;"
           key={src}
         />
-        <a href={src} target="_blank" className={styles.Caption}>
+        {/* <a href={src} target="_blank" className={styles.Caption}>
           (view standalone Streamlit app)
-        </a>
+        </a> */}
       </section>
     );
   }

--- a/python/stoutput.py
+++ b/python/stoutput.py
@@ -53,9 +53,6 @@ class StOutput(Directive):
                         %(additional_styles)s
                     "
                 ></iframe>
-                <sup><a href="%(src)s" target="_blank">
-                    (view standalone Streamlit app)
-                </a></sup>
             """
             % {"src": src, "additional_styles": additional_styles},
         )


### PR DESCRIPTION
## 📚 Context

With Streamlit Community Cloud rolling out oEmbed support, embedded apps with automatically have a footer linking to the standalone app URL.

## 🧠 Description of Changes

- Removes the `<a>` element link text "view standalone Streamlit app", as it is automatically added by Community Cloud.

**Revised:**

![image](https://github.com/streamlit/docs/assets/20672874/4ec2f16e-d527-409b-baf1-57ca37af33c7)

**Current:**

![image](https://github.com/streamlit/docs/assets/20672874/8485f1fb-976c-4aa4-abec-a9468f3f46ba)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
