### PR TITLE
Add data editor and column config apps

### DIFF
--- a/python/api-examples-source/data.barchart_column.py
+++ b/python/api-examples-source/data.barchart_column.py
@@ -1,0 +1,32 @@
+import pandas as pd
+import streamlit as st
+
+
+@st.cache_data
+def load_data():
+    return pd.DataFrame(
+        {
+            "sales": [
+                [0, 4, 26, 80, 100, 40],
+                [80, 20, 80, 35, 40, 100],
+                [10, 20, 80, 80, 70, 0],
+                [10, 100, 20, 100, 30, 100],
+            ],
+        }
+    )
+
+
+data_df = load_data()
+
+st.data_editor(
+    data_df,
+    column_config={
+        "sales": st.column_config.BarChartColumn(
+            "Sales (last 6 months)",
+            help="The sales volume in the last 6 months",
+            y_min=0,
+            y_max=100,
+        ),
+    },
+    hide_index=True,
+)

--- a/python/api-examples-source/data.checkbox_column.py
+++ b/python/api-examples-source/data.checkbox_column.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import streamlit as st
+
+
+@st.cache_data
+def load_data():
+    return pd.DataFrame(
+        {
+            "widgets": ["st.selectbox", "st.number_input", "st.text_area", "st.button"],
+            "favorite": [True, False, False, True],
+        }
+    )
+
+
+data_df = load_data()
+
+st.data_editor(
+    data_df,
+    column_config={
+        "favorite": st.column_config.CheckboxColumn(
+            "Your favorite?",
+            help="Select your **favorite** widgets",
+            default=False,
+        )
+    },
+    disabled=["widgets"],
+    hide_index=True,
+)

--- a/python/api-examples-source/data.column.py
+++ b/python/api-examples-source/data.column.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import streamlit as st
+
+
+@st.cache_data
+def load_data():
+    return pd.DataFrame(
+        {
+            "widgets": ["st.selectbox", "st.number_input", "st.text_area", "st.button"],
+        }
+    )
+
+
+data_df = load_data()
+
+st.data_editor(
+    data_df,
+    column_config={
+        "widgets": st.column_config.Column(
+            "Streamlit Widgets",
+            help="Streamlit **widget** commands 🎈",
+            width="medium",
+            required=True,
+        )
+    },
+    hide_index=True,
+    num_rows="dynamic",
+)

--- a/python/api-examples-source/data.data_editor.py
+++ b/python/api-examples-source/data.data_editor.py
@@ -14,7 +14,7 @@ def load_data():
 
 
 df = load_data()
-edited_df = st.experimental_data_editor(df, use_container_width=True)
+edited_df = st.data_editor(df, use_container_width=True)
 
 favorite_command = edited_df.loc[edited_df["rating"].idxmax()]["command"]
 st.markdown(f"Your favorite command is **{favorite_command}** 🎈")

--- a/python/api-examples-source/data.data_editor1.py
+++ b/python/api-examples-source/data.data_editor1.py
@@ -14,7 +14,7 @@ def load_data():
 
 
 df = load_data()
-edited_df = st.experimental_data_editor(df, num_rows="dynamic", use_container_width=True)
+edited_df = st.data_editor(df, num_rows="dynamic", use_container_width=True)
 
 favorite_command = edited_df.loc[edited_df["rating"].idxmax()]["command"]
 st.markdown(f"Your favorite command is **{favorite_command}** 🎈")

--- a/python/api-examples-source/data.data_editor3.py
+++ b/python/api-examples-source/data.data_editor3.py
@@ -29,6 +29,4 @@ def load_data():
 
 
 df = load_data()
-edited_df = st.experimental_data_editor(
-    df, use_container_width=True, num_rows="dynamic"
-)
+edited_df = st.data_editor(df, use_container_width=True, num_rows="dynamic")

--- a/python/api-examples-source/data.data_editor4.py
+++ b/python/api-examples-source/data.data_editor4.py
@@ -20,6 +20,6 @@ def load_data():
 
 df = load_data()
 
-st.experimental_data_editor(df, key="data_editor", num_rows="dynamic")
+st.data_editor(df, key="data_editor", num_rows="dynamic")
 st.write("Here's the session state:")
 st.write(st.session_state["data_editor"])

--- a/python/api-examples-source/data.data_editor_config.py
+++ b/python/api-examples-source/data.data_editor_config.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import streamlit as st
+
+df = pd.DataFrame(
+    [
+        {"command": "st.selectbox", "rating": 4, "is_widget": True},
+        {"command": "st.balloons", "rating": 5, "is_widget": False},
+        {"command": "st.time_input", "rating": 3, "is_widget": True},
+    ]
+)
+edited_df = st.data_editor(
+    df,
+    column_config={
+        "command": "Streamlit Command",
+        "rating": st.column_config.NumberColumn(
+            "Your rating",
+            help="How much do you like this command (1-5)?",
+            min_value=1,
+            max_value=5,
+            step=1,
+            format="%d ⭐",
+        ),
+        "is_widget": "Widget ?",
+    },
+    disabled=["command", "is_widget"],
+    hide_index=True,
+)
+
+favorite_command = edited_df.loc[edited_df["rating"].idxmax()]["command"]
+st.markdown(f"Your favorite command is **{favorite_command}** 🎈")

--- a/python/api-examples-source/data.data_editor_config.py
+++ b/python/api-examples-source/data.data_editor_config.py
@@ -1,13 +1,20 @@
 import pandas as pd
 import streamlit as st
 
-df = pd.DataFrame(
-    [
-        {"command": "st.selectbox", "rating": 4, "is_widget": True},
-        {"command": "st.balloons", "rating": 5, "is_widget": False},
-        {"command": "st.time_input", "rating": 3, "is_widget": True},
-    ]
-)
+
+@st.cache_data
+def load_data():
+    return pd.DataFrame(
+        [
+            {"command": "st.selectbox", "rating": 4, "is_widget": True},
+            {"command": "st.balloons", "rating": 5, "is_widget": False},
+            {"command": "st.time_input", "rating": 3, "is_widget": True},
+        ]
+    )
+
+
+df = load_data()
+
 edited_df = st.data_editor(
     df,
     column_config={

--- a/python/api-examples-source/data.dataframe_config.py
+++ b/python/api-examples-source/data.dataframe_config.py
@@ -1,0 +1,42 @@
+import random
+
+import pandas as pd
+import streamlit as st
+
+
+@st.cache_data
+def load_data():
+    return pd.DataFrame(
+        {
+            "name": ["Roadmap", "Extras", "Issues"],
+            "url": [
+                "https://roadmap.streamlit.app",
+                "https://extras.streamlit.app",
+                "https://issues.streamlit.app",
+            ],
+            "stars": [random.randint(0, 1000) for _ in range(3)],
+            "views_history": [
+                [random.randint(0, 5000) for _ in range(30)] for _ in range(3)
+            ],
+        }
+    )
+
+
+df = load_data()
+
+st.dataframe(
+    df,
+    column_config={
+        "name": "App name",
+        "stars": st.column_config.NumberColumn(
+            "Github Stars",
+            help="Number of stars on GitHub",
+            format="%d ⭐",
+        ),
+        "url": st.column_config.LinkColumn("App URL"),
+        "views_history": st.column_config.LineChartColumn(
+            "Views (past 30 days)", y_min=0, y_max=5000
+        ),
+    },
+    hide_index=True,
+)

--- a/python/api-examples-source/data.date_column.py
+++ b/python/api-examples-source/data.date_column.py
@@ -1,0 +1,35 @@
+from datetime import date
+
+import pandas as pd
+import streamlit as st
+
+
+@st.cache_data
+def load_data():
+    return pd.DataFrame(
+        {
+            "birthday": [
+                date(1980, 1, 1),
+                date(1990, 5, 3),
+                date(1974, 5, 19),
+                date(2001, 8, 17),
+            ]
+        }
+    )
+
+
+data_df = load_data()
+
+st.data_editor(
+    data_df,
+    column_config={
+        "birthday": st.column_config.DateColumn(
+            "Birthday",
+            min_value=date(1900, 1, 1),
+            max_value=date(2005, 1, 1),
+            format="DD.MM.YYYY",
+            step=1,
+        ),
+    },
+    hide_index=True,
+)

--- a/python/api-examples-source/data.datetime_column.py
+++ b/python/api-examples-source/data.datetime_column.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+import pandas as pd
+import streamlit as st
+
+
+@st.cache_data
+def load_data():
+    return pd.DataFrame(
+        {
+            "appointment": [
+                datetime(2024, 2, 5, 12, 30),
+                datetime(2023, 11, 10, 18, 0),
+                datetime(2024, 3, 11, 20, 10),
+                datetime(2023, 9, 12, 3, 0),
+            ]
+        }
+    )
+
+
+data_df = load_data()
+
+st.data_editor(
+    data_df,
+    column_config={
+        "appointment": st.column_config.DatetimeColumn(
+            "Appointment",
+            min_value=datetime(2023, 6, 1),
+            max_value=datetime(2025, 1, 1),
+            format="D MMM YYYY, h:mm a",
+            step=60,
+        ),
+    },
+    hide_index=True,
+)

--- a/python/api-examples-source/data.image_column.py
+++ b/python/api-examples-source/data.image_column.py
@@ -1,0 +1,29 @@
+import pandas as pd
+import streamlit as st
+
+
+@st.cache_data
+def load_data():
+    return pd.DataFrame(
+        {
+            "apps": [
+                "https://storage.googleapis.com/s4a-prod-share-preview/default/st_app_screenshot_image/5435b8cb-6c6c-490b-9608-799b543655d3/Home_Page.png",
+                "https://storage.googleapis.com/s4a-prod-share-preview/default/st_app_screenshot_image/ef9a7627-13f2-47e5-8f65-3f69bb38a5c2/Home_Page.png",
+                "https://storage.googleapis.com/s4a-prod-share-preview/default/st_app_screenshot_image/31b99099-8eae-4ff8-aa89-042895ed3843/Home_Page.png",
+                "https://storage.googleapis.com/s4a-prod-share-preview/default/st_app_screenshot_image/6a399b09-241e-4ae7-a31f-7640dc1d181e/Home_Page.png",
+            ],
+        }
+    )
+
+
+data_df = load_data()
+
+st.data_editor(
+    data_df,
+    column_config={
+        "apps": st.column_config.ImageColumn(
+            "Preview Image", help="Streamlit app preview screenshots"
+        )
+    },
+    hide_index=True,
+)

--- a/python/api-examples-source/data.linechart_column.py
+++ b/python/api-examples-source/data.linechart_column.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import streamlit as st
+
+
+@st.cache_data
+def load_data():
+    return pd.DataFrame(
+        {
+            "sales": [
+                [0, 4, 26, 80, 100, 40],
+                [80, 20, 80, 35, 40, 100],
+                [10, 20, 80, 80, 70, 0],
+                [10, 100, 20, 100, 30, 100],
+            ],
+        }
+    )
+
+
+data_df = load_data()
+
+st.data_editor(
+    data_df,
+    column_config={
+        "sales": st.column_config.LineChartColumn(
+            "Sales (last 6 months)",
+            width="medium",
+            help="The sales volume in the last 6 months",
+            y_min=0,
+            y_max=100,
+        ),
+    },
+    hide_index=True,
+)

--- a/python/api-examples-source/data.link_column.py
+++ b/python/api-examples-source/data.link_column.py
@@ -1,0 +1,32 @@
+import pandas as pd
+import streamlit as st
+
+
+@st.cache_data
+def load_data():
+    return pd.DataFrame(
+        {
+            "apps": [
+                "https://roadmap.streamlit.app",
+                "https://extras.streamlit.app",
+                "https://issues.streamlit.app",
+                "https://30days.streamlit.app",
+            ],
+        }
+    )
+
+
+data_df = load_data()
+
+st.data_editor(
+    data_df,
+    column_config={
+        "apps": st.column_config.LinkColumn(
+            "Trending apps",
+            help="The top trending Streamlit apps",
+            validate="^https://[a-z]+\.streamlit\.app$",
+            max_chars=100,
+        )
+    },
+    hide_index=True,
+)

--- a/python/api-examples-source/data.list_column.py
+++ b/python/api-examples-source/data.list_column.py
@@ -1,0 +1,31 @@
+import pandas as pd
+import streamlit as st
+
+
+@st.cache_data
+def load_data():
+    return pd.DataFrame(
+        {
+            "sales": [
+                [0, 4, 26, 80, 100, 40],
+                [80, 20, 80, 35, 40, 100],
+                [10, 20, 80, 80, 70, 0],
+                [10, 100, 20, 100, 30, 100],
+            ],
+        }
+    )
+
+
+data_df = load_data()
+
+st.data_editor(
+    data_df,
+    column_config={
+        "sales": st.column_config.ListColumn(
+            "Sales (last 6 months)",
+            help="The sales volume in the last 6 months",
+            width="medium",
+        ),
+    },
+    hide_index=True,
+)

--- a/python/api-examples-source/data.number_column.py
+++ b/python/api-examples-source/data.number_column.py
@@ -1,0 +1,29 @@
+import pandas as pd
+import streamlit as st
+
+
+@st.cache_data
+def load_data():
+    return pd.DataFrame(
+        {
+            "price": [20, 950, 250, 500],
+        }
+    )
+
+
+data_df = load_data()
+
+st.data_editor(
+    data_df,
+    column_config={
+        "price": st.column_config.NumberColumn(
+            "Price (in USD)",
+            help="The price of the product in USD",
+            min_value=0,
+            max_value=1000,
+            step=1,
+            format="$%d",
+        )
+    },
+    hide_index=True,
+)

--- a/python/api-examples-source/data.progress_column.py
+++ b/python/api-examples-source/data.progress_column.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import streamlit as st
+
+
+@st.cache_data
+def load_data():
+    return pd.DataFrame(
+        {
+            "sales": [200, 550, 1000, 80],
+        }
+    )
+
+
+data_df = load_data()
+
+st.data_editor(
+    data_df,
+    column_config={
+        "sales": st.column_config.ProgressColumn(
+            "Sales volume",
+            help="The sales volume in USD",
+            format="$%f",
+            min_value=0,
+            max_value=1000,
+        ),
+    },
+    hide_index=True,
+)

--- a/python/api-examples-source/data.selectbox_column.py
+++ b/python/api-examples-source/data.selectbox_column.py
@@ -1,0 +1,36 @@
+import pandas as pd
+import streamlit as st
+
+
+@st.cache_data
+def load_data():
+    return pd.DataFrame(
+        {
+            "category": [
+                "📊 Data Exploration",
+                "📈 Data Visualization",
+                "🤖 LLM",
+                "📊 Data Exploration",
+            ],
+        }
+    )
+
+
+data_df = load_data()
+
+st.data_editor(
+    data_df,
+    column_config={
+        "category": st.column_config.SelectboxColumn(
+            "App Category",
+            help="The category of the app",
+            width="medium",
+            options=[
+                "📊 Data Exploration",
+                "📈 Data Visualization",
+                "🤖 LLM",
+            ],
+        )
+    },
+    hide_index=True,
+)

--- a/python/api-examples-source/data.text_column.py
+++ b/python/api-examples-source/data.text_column.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import streamlit as st
+
+
+@st.cache_data
+def load_data():
+    return pd.DataFrame(
+        {
+            "widgets": ["st.selectbox", "st.number_input", "st.text_area", "st.button"],
+        }
+    )
+
+
+data_df = load_data()
+
+st.data_editor(
+    data_df,
+    column_config={
+        "widgets": st.column_config.TextColumn(
+            "Widgets",
+            help="Streamlit **widget** commands 🎈",
+            default="st.",
+            max_chars=50,
+            validate="^st\.[a-z_]+$",
+        )
+    },
+    hide_index=True,
+)

--- a/python/api-examples-source/data.time_column.py
+++ b/python/api-examples-source/data.time_column.py
@@ -1,0 +1,35 @@
+from datetime import time
+
+import pandas as pd
+import streamlit as st
+
+
+@st.cache_data
+def load_data():
+    return pd.DataFrame(
+        {
+            "appointment": [
+                time(12, 30),
+                time(18, 0),
+                time(9, 10),
+                time(16, 25),
+            ]
+        }
+    )
+
+
+data_df = load_data()
+
+st.data_editor(
+    data_df,
+    column_config={
+        "appointment": st.column_config.TimeColumn(
+            "Appointment",
+            min_value=time(8, 0, 0),
+            max_value=time(19, 0, 0),
+            format="hh:mm a",
+            step=60,
+        ),
+    },
+    hide_index=True,
+)

--- a/python/api-examples-source/hello/requirements.txt
+++ b/python/api-examples-source/hello/requirements.txt
@@ -8,4 +8,4 @@ numpy==1.22.0
 scipy
 altair==4.2.0
 pydeck==0.7.1
-streamlit==1.22.0
+streamlit-nightly==1.22.1.dev20230523

--- a/python/api-examples-source/mpa-hello/requirements.txt
+++ b/python/api-examples-source/mpa-hello/requirements.txt
@@ -9,4 +9,4 @@ scipy
 altair==4.2.0
 pydeck==0.7.1
 opencv-python-headless==4.6.0.66
-streamlit==1.22.0
+streamlit-nightly==1.22.1.dev20230523

--- a/python/api-examples-source/requirements.txt
+++ b/python/api-examples-source/requirements.txt
@@ -8,4 +8,4 @@ numpy==1.22.0
 scipy
 altair==4.2.0
 pydeck==0.7.1
-streamlit==1.22.0
+streamlit-nightly==1.22.1.dev20230523

--- a/python/api-examples-source/theming/requirements.txt
+++ b/python/api-examples-source/theming/requirements.txt
@@ -1,4 +1,4 @@
-streamlit==1.22.0
+streamlit-nightly==1.22.1.dev20230523
 vega_datasets
 altair==4.2.0
 plotly==5.1.0


### PR DESCRIPTION
## 🧠 Description of Changes

- Adds 14 apps corresponding to each data editor column type
- Bumps apps to `streamlit-nightly==1.22.1.dev20230523` so column config is supported
- Removes `experimental_` prefix from existing data editor apps

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
