### PR TITLE
Change info about edited_cells

### DIFF
--- a/content/library/advanced-features/dataframes.md
+++ b/content/library/advanced-features/dataframes.md
@@ -153,11 +153,11 @@ Use all we've learned so far and apply them to the above embedded app. Try editi
 
 ![data-editor-session-state.gif](/images/data-editor-session-state.gif)
 
-Notice how edits to the table are reflected in session state: when you make any edits, a rerun is triggered which sends the edits to the backend via `st.experimental_data_editor`'s keyed widget state. Its widget state is a JSON object containing three properties: **edited_cells**, **added_rows**, and **deleted rows:**.
+Notice how edits to the table are reflected in session state: when you make any edits, a rerun is triggered which sends the edits to the backend via `st.experimental_data_editor`'s keyed widget state. Its widget state is a JSON object containing three properties: **edited_rows**, **added_rows**, and **deleted rows:**.
 
-- `edited_cells` maps a cell's row number and column name to the edited value (e.g. `{0: {"col1": ..., "col2": ...}}`).
-- `added_rows` is a list of newly added rows. Each row is a dictionary where the keys are the column indices and the values are the new cell values (e.g. `[{"col1": ..., "col2": ...}]`).
-- `deleted_rows` is a list of row indices that have been deleted from the table (e.g. `[0, 2]`).
+- `edited_rows` is a dictionary containing all edits. Keys are row numbers and values are dictionaries that map column names to edits (e.g. `{0: {"col1": ..., "col2": ...}}`). 
+- `added_rows` is a list of newly added rows. Each value is a dictionary with the same format as above (e.g. `[{"col1": ..., "col2": ...}]`).
+- `deleted_rows` is a list of row numbers that have been deleted from the table (e.g. `[0, 2]`).
 
 ### Bulk edits
 

--- a/content/library/advanced-features/dataframes.md
+++ b/content/library/advanced-features/dataframes.md
@@ -155,9 +155,9 @@ Use all we've learned so far and apply them to the above embedded app. Try editi
 
 Notice how edits to the table are reflected in session state: when you make any edits, a rerun is triggered which sends the edits to the backend via `st.experimental_data_editor`'s keyed widget state. Its widget state is a JSON object containing three properties: **edited_cells**, **added_rows**, and **deleted rows:**.
 
-- `edited_cells` maps a cell position to the edited value: `row:column` → `value` .
-- `added_rows` is a list of newly added rows to the table. Each row is a dictionary where the keys are the column indices and the values are the corresponding cell values.
-- `deleted_rows` is a list of row indices that have been deleted from the table.
+- `edited_cells` maps a cell's row number and column name to the edited value (e.g. `{0: {"col1": ..., "col2": ...}}`).
+- `added_rows` is a list of newly added rows. Each row is a dictionary where the keys are the column indices and the values are the new cell values (e.g. `[{"col1": ..., "col2": ...}]`).
+- `deleted_rows` is a list of row indices that have been deleted from the table (e.g. `[0, 2]`).
 
 ### Bulk edits
 


### PR DESCRIPTION
## 📚 Context

<!-- Why do you want to make this change? What background should the reviewer know? -->
With the de-experimentalization of data editor, we are changing the session state format of st.data_editor a bit. This PR updates it. Don't merge before 1.23 is released. Might also change a few more things, which I'll add to this PR. 

## 🧠 Description of Changes

<!-- What was specifically changed? Which files, algorithms, links, media? -->
<!-- Please add them here as a bulleted list -->

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
