### PR TITLE
Update Streamlit Cloud Python versions

### DIFF
--- a/content/streamlit-cloud/get-started/deploy-an-app/index.md
+++ b/content/streamlit-cloud/get-started/deploy-an-app/index.md
@@ -49,7 +49,7 @@ You can connect to private data sources either by using [secrets management](/st
 
 <Tip>
 
-Streamlit Community Cloud supports Python 3.7 - Python 3.10, and defaults to version 3.9. You can select a version of your choice from the "Python version" dropdown in the "Advanced settings" modal.
+Streamlit Community Cloud supports Python 3.7 - Python 3.11, and defaults to version 3.9. You can select a version of your choice from the "Python version" dropdown in the "Advanced settings" modal.
 
 </Tip>
 


### PR DESCRIPTION
Streamlit Cloud now supports Python version 3.11 and a note in the get-started/deploy-an-app docs was updated accordingly.
<img src="https://github.com/streamlit/docs/assets/98661771/0543cb14-5ce2-43fb-a546-f5da16fcc342" width=60%>

## 📚 Context
A user mentioned on the forum that they had read Python 3.10 was the latest supported version. A search of the docs showed a note about Streamlit Cloud that was still saying 3.10.

## 🧠 Description of Changes
Highest supported version changed from Python 3.10 to Python 3.11 in note within Get Started/Deploy an App of Streamlit Cloud docs.

## 💥 Impact

Size:
- [X] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->

## 🌐 References
https://discuss.streamlit.io/t/python-version/43928

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
