### PR TITLE
Fix `border-radius` on code snippets and callouts

### DIFF
--- a/components/blocks/autofunction.module.css
+++ b/components/blocks/autofunction.module.css
@@ -50,7 +50,7 @@
 }
 
 .CodeBlockContainer pre {
-  @apply p-4 bg-gray-90 text-white font-medium rounded-md relative py-6 px-8 leading-relaxed;
+  @apply p-4 bg-gray-90 text-white font-medium rounded-xl relative py-6 px-8 leading-relaxed;
 }
 
 .CodeBlockContainer pre code {

--- a/styles/admonition.scss
+++ b/styles/admonition.scss
@@ -1,6 +1,6 @@
 // Styles for notes, warnings, etc., inside API reference page
 div.admonition {
-  @apply p-4 rounded-md mt-8 mb-12;
+  @apply p-4 rounded-xl mt-8 mb-12;
 
   // Title
   p.first.admonition-title {


### PR DESCRIPTION
## 📚 Context

This PR fixes an issue to please @jrieke's OCD, by making callouts and code blocks in the docs site match the new embedded apps' `border-radius`.

## 🧠 Description of Changes

* Updated `border-radius` property in `codeBlock.module.css`;
* Updated `border-radius` property in `styles/admonition.scss`;

**Revised:**

![Screenshot 2023-05-31 at 2 11 07 PM](https://github.com/streamlit/docs/assets/103376966/63307b6b-7c20-418a-b7d9-71ef1c4ce9c9)

**Current:**

![CleanShot 2023-05-23 at 01 21 59](https://github.com/streamlit/docs/assets/103376966/d4c26502-397a-44fa-8ae3-8178450aba92)

## 💥 Impact

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

- https://www.notion.so/snowflake-corp/Papercut-Request-border-radius-on-docs-pages-2232736b272c462ba65a8a860b7bd90d?pvs=4

> **Note**
> I didn't add this style to our docstring table, because it caused some issues with our borders and color heading backgrounds there. See screenshot below 👇 

![Screenshot 2023-05-31 at 2 16 31 PM](https://github.com/streamlit/docs/assets/103376966/a69cb4a2-2cce-4174-8b7c-1c7375682acf)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
