### PR TITLE
Fix `<iframe>` refreshing issue

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -17,13 +17,13 @@ Router.events.on("routeChangeStart", () => NProgress.start());
 Router.events.on("routeChangeComplete", () => NProgress.done());
 Router.events.on("routeChangeError", () => NProgress.done());
 
-useEffect(() => {
-  if (navigator.platform.match("Mac") === null) {
-    document.body.classList.add("mac");
-  }
-}, []);
-
 function StreamlitDocs({ Component, pageProps }) {
+  useEffect(() => {
+    if (navigator.platform.match("Mac") === null) {
+      document.body.classList.add("mac");
+    }
+  }, []);
+
   return (
     <AppContextProvider>
       <Component {...pageProps} />


### PR DESCRIPTION
## 📚 Context

This PR fixes an issue reported by @jrieke where embedded cloud apps were refreshing when the window was resized.

@snehankekre I did a bunch of manual testing already, but would be nice to do some more, checking responsiveness and whatnot, to ensure removing this "unused" code doesn't lead to any side effects

## 🧠 Description of Changes

* Removed some tech debt we had, an old function that calculated the window's `width` and `height`, presumably to be used in the sidenav.

**Revised:**

https://github.com/streamlit/docs/assets/103376966/c76941d2-8804-462c-9c1a-59d7a2bf6f20

**Current:**

https://github.com/streamlit/docs/assets/103376966/dd7fa453-b269-4056-afe2-7321d3343b2f

## 💥 Impact

Size:

- [] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

## 🌐 References

- https://www.notion.so/snowflake-corp/Papercut-Request-iframes-refreshing-on-docs-page-d7429b40a19c4849985300a590828d1d?pvs=4

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
