### PR TITLE
project folder name consistency

### DIFF
--- a/content/library/get-started/installation.md
+++ b/content/library/get-started/installation.md
@@ -119,7 +119,7 @@ xcode-select --install
    python -m venv .venv
    ```
 
-   When you run the command above, a directory called `.venv` will appear in `myprojects/`. This directory is where your virtual environment and its dependencies are installed.
+   When you run the command above, a directory called `.venv` will appear in `myproject/`. This directory is where your virtual environment and its dependencies are installed.
 
 3. Install Streamlit in your environment:
 


### PR DESCRIPTION
In macOS installation, the hypothetical project folder was called both "myproject" and "myprojects" conflictingly. Both references made singular for consistency.

## 📚 Context
Typo fix

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
