### PR TITLE
Replace `*.streamlitapp.com` with `*.streamlit.app`

### DIFF
--- a/content/library/api/api-reference.md
+++ b/content/library/api/api-reference.md
@@ -233,7 +233,7 @@ nlu.load('sentiment').predict('I love NLU! <3')
 A library with useful Streamlit extras. Created by [@arnaudmiribel](https://github.com/arnaudmiribel/).
 
 ```python
-mention(label="An awesome Streamlit App", icon="streamlit",  url="https://extras.streamlitapp.com",)
+mention(label="An awesome Streamlit App", icon="streamlit",  url="https://extras.streamlit.app",)
 ```
 
 </ComponentCard>

--- a/content/library/api/text/text-elements.md
+++ b/content/library/api/text/text-elements.md
@@ -202,7 +202,7 @@ nlu.load('sentiment').predict('I love NLU! <3')
 A library with useful Streamlit extras. Created by [@arnaudmiribel](https://github.com/arnaudmiribel/).
 
 ```python
-mention(label="An awesome Streamlit App", icon="streamlit",  url="https://extras.streamlitapp.com",)
+mention(label="An awesome Streamlit App", icon="streamlit",  url="https://extras.streamlit.app",)
 ```
 
 </ComponentCard>


### PR DESCRIPTION
## 📚 Context

Streamlit Community Cloud apps changed their url form months ago from `*.streamlitapp.com` to `*.streamlit.app`. A few embedded docs apps use the old form, leading to some users seeing the error below. This PR switches the urls to the latter form.

![image](https://github.com/streamlit/docs/assets/20672874/844e9380-9867-4778-add9-47166257ba23)


## 🧠 Description of Changes

- Replaced _all_ occurrences of `*.streamlitapp.com` to `*.streamlit.app`.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/snowflake-corp/Bug-Replace-streamlitapp-com-with-streamlit-app-d104d240826649ae8d632a7e8d2aad78)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
