### PR TITLE
Upgrade: Allow generate.py to accept version override

### DIFF
--- a/python/generate.py
+++ b/python/generate.py
@@ -18,6 +18,8 @@ from numpydoc.docscrape import NumpyDocString
 import stoutput
 import utils
 
+VERSION = streamlit.__version__
+
 # Set up logging to print debug messages to stdout
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
@@ -47,7 +49,7 @@ def strip_code_prompts(rst_string):
 def get_github_source(func):
     """Returns a link to the source code on GitHub for a given command."""
     repo_prefix = (
-        f"https://github.com/streamlit/streamlit/blob/{streamlit.__version__}/lib/"
+        f"https://github.com/streamlit/streamlit/blob/{VERSION}/lib/"
     )
 
     if hasattr(func, "__dict__"):
@@ -497,5 +499,7 @@ def get_streamlit_docstring_dict():
 
 
 if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        VERSION = sys.argv[1]
     data = get_streamlit_docstring_dict()
-    utils.write_to_existing_dict(streamlit.__version__, data)
+    utils.write_to_existing_dict(VERSION, data)


### PR DESCRIPTION
generate.py will now accept an optional argument to set the version number recorded within streamlit.json

`python generate.py` will default to reading `streamlit.__version__`

`python generate.py 1.24.0` will use version '1.24.0' as the entry in streamlit.json (including source urls within the items)

## 📚 Context
Manual edits are necessary when generating docstrings for new releases. This reduces those manual edits.

## 🧠 Description of Changes
A global variable `VERSION = streamlit.__version__` is set in the script and overwritten with any provided argument. (If no argument is given, the default of `streamlit.__version__` is used.) 

## 💥 Impact
Internal

## 🌐 References
https://www.notion.so/snowflake-corp/Upgrade-Allow-generate-py-to-parse-version-input-8b62a2c4bcc9417c855240af0606ad57?pvs=4

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.