### PR TITLE
Remove release notes from menu

### DIFF
--- a/content/menu.md
+++ b/content/menu.md
@@ -454,8 +454,6 @@ site_menu:
   #   url: /streamlit-community-cloud/additional-features
   - category: Streamlit Community Cloud / Trust and Security
     url: /streamlit-community-cloud/trust-and-security
-  - category: Streamlit Community Cloud / Release notes
-    url: https://streamlit-cloud-release-notes-app-main-jfmm83.streamlit.app/
   - category: Streamlit Community Cloud / Troubleshooting
     url: /streamlit-community-cloud/troubleshooting
 


### PR DESCRIPTION
## 📚 Context

This PR removes the Release notes link from the menu per TC's request, since the app is pretty much dead all the time, and the team would like to fully deprecate it to come up with a better solution. For more details see [this thread](https://snowflake.slack.com/archives/C03DQN6QA5U/p1686295936419049).

## 🧠 Description of Changes

– Removed entry from `menu.md`;

**Revised:**

<img width="299" alt="Screenshot 2023-06-16 at 1 54 07 PM" src="https://github.com/streamlit/docs/assets/103376966/10ff6021-a82d-428d-91da-fc803c6eee5a">

**Current:**

![Screenshot 2023-06-16 at 11 40 38 AM](https://github.com/streamlit/docs/assets/103376966/1a988882-ed6d-4192-bf28-c40dfb5523a9)

## 💥 Impact

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- https://snowflake.slack.com/archives/C03DQN6QA5U/p1686295936419049

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
