### PR TITLE
change set_page_config arguments

### DIFF
--- a/content/library/api/api-reference.md
+++ b/content/library/api/api-reference.md
@@ -1741,8 +1741,8 @@ Configures the default settings of the page.
 
 ```python
 st.set_page_config(
-  title="My app",
-  favicon=":shark:",
+  page_title="My app",
+  page_icon=":shark:",
 )
 ```
 


### PR DESCRIPTION
set_page_config does not allow "title" or "favicon"  but page_title and page_icon