### PR TITLE
Remove Community Cloud support for Python 3.7

### DIFF
--- a/content/streamlit-cloud/get-started/deploy-an-app/index.md
+++ b/content/streamlit-cloud/get-started/deploy-an-app/index.md
@@ -53,7 +53,7 @@ You can connect to private data sources by using [secrets management](/streamlit
 
 <Tip>
 
-Streamlit Community Cloud supports Python 3.7 - Python 3.11, and defaults to version 3.9. You can select a version of your choice from the "Python version" dropdown in the "Advanced settings" modal.
+Streamlit Community Cloud supports Python 3.8 - Python 3.11, and defaults to version 3.9. You can select a version of your choice from the "Python version" dropdown in the "Advanced settings" modal.
 
 </Tip>
 

--- a/content/streamlit-cloud/troubleshooting.md
+++ b/content/streamlit-cloud/troubleshooting.md
@@ -180,7 +180,7 @@ Once a user is added to a repository on GitHub, it will take at most 15 minutes 
 Here are some limitations and known issues that we're actively working to resolve. If you find an issue [please let us know](mailto:support@streamlit.io)!
 
 - When you print something to the Cloud logs, you may need to do a `sys.stdout.flush()` before it shows up.
-- Apps execute in a Linux environment running Debian Buster (slim) with Python 3.7. There is no way to change these, and we may upgrade the environment at any point. If we do upgrade it, we will *usually* not touch existing apps, so they'll continue to work as expected. But if there's a critical fix in the update, we *may* force-upgrade all apps.
+- Apps execute in a Linux environment running Debian Buster (slim). There is no way to change this and we may upgrade the environment at any point. If we do upgrade it, we will *usually* not touch existing apps, so they'll continue to work as expected. But if there's a critical fix in the update, we *may* force-upgrade all apps.
 - Matplotlib [doesn't work well with threads](https://matplotlib.org/3.3.2/faq/howto_faq.html#working-with-threads). So if you're using Matplotlib you should wrap your code with locks as shown in the snippet below. This Matplotlib bug is more prominent when you share your app apps since you're more likely to get more concurrent users then.
 
   ```python


### PR DESCRIPTION
Community Cloud no longer supports Python 3.7. Supported Python versions updated.

## 🌐 References
Notion: [Doc Request: Update Python versions for Cloud](https://www.notion.so/snowflake-corp/Docs-Request-Update-Python-versions-for-cloud-and-core-97bf405e11bc4692a42e60138bf96b77?pvs=4)

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.