### PR TITLE
Remove Streamlit Core support for Python 3.7

### DIFF
--- a/content/kb/tutorials/deploy/kubernetes.md
+++ b/content/kb/tutorials/deploy/kubernetes.md
@@ -88,7 +88,7 @@ Docker builds images by reading the instructions from a `Dockerfile`. A `Docke
 Here's an example `Dockerfile` that you can add to the root of your directory.
 
 ```docker
-FROM python:3.7-slim
+FROM python:3.8-slim
 
 RUN groupadd --gid 1000 appuser \
     && useradd --uid 1000 --gid 1000 -ms /bin/bash appuser

--- a/content/kb/using-streamlit/sanity-checks.md
+++ b/content/kb/using-streamlit/sanity-checks.md
@@ -15,7 +15,7 @@ guaranteeing compatibility with _at least_ the last three minor versions of Pyth
 As new versions of Python are released, we will try to be compatible with the new version as soon
 as possible, though frequently we are at the mercy of other Python packages to support these new versions as well.
 
-Streamlit currently supports versions 3.7, 3.8, 3.9, 3.10, and 3.11 of Python.
+Streamlit currently supports versions 3.8, 3.9, 3.10, and 3.11 of Python.
 
 ## Check #1: Is Streamlit running?
 
@@ -125,7 +125,7 @@ Streamlit includes [pyarrow](https://arrow.apache.org/docs/python/) as an instal
 Using cached pyarrow-1.0.1.tar.gz (1.3 MB)
   Installing build dependencies ... error
   ERROR: Command errored out with exit status 1:
-   command: 'c:\users\streamlit\appdata\local\programs\python\python38-32\python.exe' 'c:\users\streamlit\appdata\local\programs\python\python38-32\lib\site-packages\pip' install --ignore-installed --no-user --prefix 'C:\Users\streamlit\AppData\Local\Temp\pip-build-env-s7owjrle\overlay' --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'cython >= 0.29' 'numpy==1.14.5; python_version<'"'"'3.7'"'"'' 'numpy==1.16.0; python_version>='"'"'3.7'"'"'' setuptools setuptools_scm wheel
+   command: 'c:\users\streamlit\appdata\local\programs\python\python38-32\python.exe' 'c:\users\streamlit\appdata\local\programs\python\python38-32\lib\site-packages\pip' install --ignore-installed --no-user --prefix 'C:\Users\streamlit\AppData\Local\Temp\pip-build-env-s7owjrle\overlay' --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'cython >= 0.29' 'numpy==1.14.5; python_version<'"'"'3.8'"'"'' 'numpy==1.16.0; python_version>='"'"'3.8'"'"'' setuptools setuptools_scm wheel
        cwd: None
 
   Complete output (319 lines):

--- a/content/library/components/components-api.md
+++ b/content/library/components/components-api.md
@@ -95,7 +95,7 @@ To make the process of creating bi-directional Streamlit Components easier, we'v
 
 To build a Streamlit Component, you need the following installed in your development environment:
 
-- Python 3.7 - Python 3.11
+- Python 3.8 - Python 3.11
 - Streamlit 0.63+
 - [nodejs](https://nodejs.org/en/)
 - [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/)

--- a/content/library/components/components-api.md
+++ b/content/library/components/components-api.md
@@ -96,7 +96,7 @@ To make the process of creating bi-directional Streamlit Components easier, we'v
 To build a Streamlit Component, you need the following installed in your development environment:
 
 - Python 3.8 - Python 3.11
-- Streamlit 0.63+
+- Streamlit 1.11.1 or higher
 - [nodejs](https://nodejs.org/en/)
 - [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/)
 

--- a/content/library/get-started/installation.md
+++ b/content/library/get-started/installation.md
@@ -16,7 +16,7 @@ slug: /library/get-started/installation
 Before you get started, you're going to need a few things:
 
 - Your favorite IDE or text editor
-- [Python 3.7 - Python 3.11](https://www.python.org/downloads/)
+- [Python 3.8 - Python 3.11](https://www.python.org/downloads/)
 - [PIP](https://pip.pypa.io/en/stable/installation/)
 
 ## Set up your virtual environment

--- a/content/streamlit-cloud/get-started/deploy-an-app/index.md
+++ b/content/streamlit-cloud/get-started/deploy-an-app/index.md
@@ -53,7 +53,7 @@ You can connect to private data sources by using [secrets management](/streamlit
 
 <Tip>
 
-Streamlit Community Cloud supports Python 3.7 - Python 3.11, and defaults to version 3.9. You can select a version of your choice from the "Python version" dropdown in the "Advanced settings" modal.
+Streamlit Community Cloud supports Python 3.8 - Python 3.11, and defaults to version 3.9. You can select a version of your choice from the "Python version" dropdown in the "Advanced settings" modal.
 
 </Tip>
 

--- a/content/streamlit-cloud/troubleshooting.md
+++ b/content/streamlit-cloud/troubleshooting.md
@@ -180,7 +180,6 @@ Once a user is added to a repository on GitHub, it will take at most 15 minutes 
 Here are some limitations and known issues that we're actively working to resolve. If you find an issue [please let us know](mailto:support@streamlit.io)!
 
 - When you print something to the Cloud logs, you may need to do a `sys.stdout.flush()` before it shows up.
-- Apps execute in a Linux environment running Debian Buster (slim). There is no way to change this and we may upgrade the environment at any point. If we do upgrade it, we will *usually* not touch existing apps, so they'll continue to work as expected. But if there's a critical fix in the update, we *may* force-upgrade all apps.
 - Matplotlib [doesn't work well with threads](https://matplotlib.org/3.3.2/faq/howto_faq.html#working-with-threads). So if you're using Matplotlib you should wrap your code with locks as shown in the snippet below. This Matplotlib bug is more prominent when you share your app apps since you're more likely to get more concurrent users then.
 
   ```python

--- a/content/streamlit-cloud/troubleshooting.md
+++ b/content/streamlit-cloud/troubleshooting.md
@@ -180,7 +180,7 @@ Once a user is added to a repository on GitHub, it will take at most 15 minutes 
 Here are some limitations and known issues that we're actively working to resolve. If you find an issue [please let us know](mailto:support@streamlit.io)!
 
 - When you print something to the Cloud logs, you may need to do a `sys.stdout.flush()` before it shows up.
-- Apps execute in a Linux environment running Debian Buster (slim) with Python 3.7. There is no way to change these, and we may upgrade the environment at any point. If we do upgrade it, we will *usually* not touch existing apps, so they'll continue to work as expected. But if there's a critical fix in the update, we *may* force-upgrade all apps.
+- Apps execute in a Linux environment running Debian Buster (slim). There is no way to change this and we may upgrade the environment at any point. If we do upgrade it, we will *usually* not touch existing apps, so they'll continue to work as expected. But if there's a critical fix in the update, we *may* force-upgrade all apps.
 - Matplotlib [doesn't work well with threads](https://matplotlib.org/3.3.2/faq/howto_faq.html#working-with-threads). So if you're using Matplotlib you should wrap your code with locks as shown in the snippet below. This Matplotlib bug is more prominent when you share your app apps since you're more likely to get more concurrent users then.
 
   ```python


### PR DESCRIPTION
## 📚 Context
Streamlit no longer supports Python 3.7 as of Streamlit version 1.24.0

## 🌐 References
Notion: [Doc Request: Update Python versions for Cloud](https://www.notion.so/snowflake-corp/Docs-Request-Update-Python-versions-for-cloud-and-core-97bf405e11bc4692a42e60138bf96b77?pvs=4)

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.