### PR TITLE
Document 1.24.0 related changes

### DIFF
--- a/content/library/advanced-features/configuration.md
+++ b/content/library/advanced-features/configuration.md
@@ -72,7 +72,7 @@ streamlit config show
 The command above will print something like this:
 
 ```toml
-# Streamlit version: 1.23.0
+# Streamlit version: 1.24.0
 
 [global]
 

--- a/content/library/api-cheat-sheet.md
+++ b/content/library/api-cheat-sheet.md
@@ -226,6 +226,24 @@ st.color_picker('Pick a color')
 
 <CodeTile>
 
+#### Build chat-based apps
+
+```python
+# Insert a chat message container.
+>>> with st.chat_message("user"):
+>>>    st.write("Hello 👋")
+>>>    st.line_chart(np.random.randn(30, 3))
+
+# Display a chat input widget.
+>>> st.chat_input("Say something")
+```
+
+Learn how to [build chat-based apps](/knowledge-base/tutorials/build-conversational-apps)
+
+</CodeTile>
+
+<CodeTile>
+
 #### Mutate data
 
 ```python

--- a/content/library/api-cheat-sheet.md
+++ b/content/library/api-cheat-sheet.md
@@ -5,7 +5,7 @@ slug: /library/cheatsheet
 
 # Cheat Sheet
 
-This is a summary of the docs, as of [Streamlit v1.23.0](https://pypi.org/project/streamlit/1.22.0/).
+This is a summary of the docs, as of [Streamlit v1.24.0](https://pypi.org/project/streamlit/1.22.0/).
 
 <Masonry>
 

--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -24,7 +24,7 @@ _Release date: June 27, 2023_
 **Highlights**
 
 - 💬 Introducing `st.chat_message` and `st.chat_input` — two new [chat elements](/library/api-reference/chat) that let you build conversational apps. Learn how to use these features in your LLM-powered chat apps in our [tutorial](/knowledge-base/tutorials/build-conversational-apps).
-- 💾 Streamlit's caching decorators now allow you to override Streamlit's hashing mechanism of input parameters with the keyword-only argument [`hash_funcs`](/library/advanced-features/caching#the-hash_funcs-parameter).
+- 💾 Streamlit's caching decorators now allow you to customize Streamlit's hashing of input parameters with the keyword-only argument [`hash_funcs`](/library/advanced-features/caching#the-hash_funcs-parameter).
 
 **Notable Changes**
 

--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -23,7 +23,7 @@ _Release date: June 27, 2023_
 
 **Highlights**
 
-- 💬 Introducing `st.chat_message` and `st.chat_input` — two new [chat elements](/library/api-reference/chat) that let you build conversational apps. Learn how to use these features to build your own ChatGPT clone in our [tutorial](/knowledge-base/tutorials/build-conversational-apps).
+- 💬 Introducing `st.chat_message` and `st.chat_input` — two new [chat elements](/library/api-reference/chat) that let you build conversational apps. Learn how to use these features in your LLM-powered chat apps in our [tutorial](/knowledge-base/tutorials/build-conversational-apps).
 - 💾 Streamlit's caching decorators now allow you to override Streamlit's hashing mechanism of input parameters with the keyword-only argument [`hash_funcs`](/library/advanced-features/caching#the-hash_funcs-parameter).
 
 **Notable Changes**

--- a/content/library/changelog.md
+++ b/content/library/changelog.md
@@ -17,13 +17,40 @@ pip install --upgrade streamlit
 
 </Tip>
 
+## **Version 1.24.0**
+
+_Release date: June 27, 2023_
+
+**Highlights**
+
+- 💬 Introducing `st.chat_message` and `st.chat_input` — two new [chat elements](/library/api-reference/chat) that let you build conversational apps. Learn how to use these features to build your own ChatGPT clone in our [tutorial](/knowledge-base/tutorials/build-conversational-apps).
+- 💾 Streamlit's caching decorators now allow you to override Streamlit's hashing mechanism of input parameters with the keyword-only argument [`hash_funcs`](/library/advanced-features/caching#the-hash_funcs-parameter).
+
+**Notable Changes**
+
+- 🐍 We've deprecated support for Python 3.7 in the core library and Streamlit Community Cloud ([#6868](https://github.com/streamlit/streamlit/pull/6868)).
+- 📅 `st.cache_data` and `st.cache_resource` can hash timezone-aware `datetime` objects ([#6812](https://github.com/streamlit/streamlit/pull/6812), [#6690](https://github.com/streamlit/streamlit/issues/6690), [#5110](https://github.com/streamlit/streamlit/issues/5110)).
+- 🏓 Streamlit commands such as `st.dataframe` that accept Pandas dataframes as input now support Ibis table expressions and other objects that have a `to_pandas()` method ([#6668](https://github.com/streamlit/streamlit/pull/6668), [#6467](https://github.com/streamlit/streamlit/issues/6467)). Thanks, [@cpcloud](https://github.com/cpcloud)!
+
+**Other Changes**
+
+- ✨ Visual design tweaks to Streamlit's input widgets ([#6817](https://github.com/streamlit/streamlit/pull/6817)).
+- 🐛 Bug fix: `st.write` pretty-prints dataclasses using `st.help` ([#6750](https://github.com/streamlit/streamlit/pull/6750)).
+- 🪲 Bug fix: `st.button`'s height is consistent with that of other widgets ([#6738](https://github.com/streamlit/streamlit/pull/6738)).
+- 🐜 Bug fix: Upgraded the `react-range` frontend dependency to fix the memory usage of sliders ([#6764](https://github.com/streamlit/streamlit/pull/6764), [#5436](https://github.com/streamlit/streamlit/issues/5436)). Thanks [@wolfd](https://github.com/wolfd)!
+- 🐝 Bug fix: Pydantic validators no longer result in exceptions on app reruns ([#6664](https://github.com/streamlit/streamlit/pull/6664), [#3218](https://github.com/streamlit/streamlit/issues/3218)).
+- 🐞 Bug fix: `streamlit config show` honors newlines ([#6758](https://github.com/streamlit/streamlit/pull/6758), [#2868](https://github.com/streamlit/streamlit/issues/2868)).
+- 🪰 Bug fix: Fixed a race condition to ensure Streamlit reruns the latest code when the file changes ([#6884](https://github.com/streamlit/streamlit/pull/6884)).
+- 🦋 Bug fix: Apps no longer rerun when users click anchor links ([#6834](https://github.com/streamlit/streamlit/pull/6834), [#6500](https://github.com/streamlit/streamlit/issues/6500)).
+- 🕸️ Bug fix: Added robust out-of-bounds checks for `min_value` and `max_value` in `st.number_input` ([#6847](https://github.com/streamlit/streamlit/pull/6847), [#6797](https://github.com/streamlit/streamlit/issues/6797)).
+
 ## **Version 1.23.0**
 
 _Release date: June 1, 2023_
 
 **Highlights**
 
-- ✂️ Announcing the general availability of [st.data_editor](/library/api-reference/data/st.data_editor), a widget that allows you to edit DataFrames and many other data structures in a table-like UI. **Breaking change:** the data editor’s representation used in `st.session_state` was altered. Find out more about the new format in [Access edited data](/library/advanced-features/dataframes#access-edited-data).
+- ✂️ Announcing the general availability of [st.data_editor](/library/api-reference/data/st.data_editor), a widget that allows you to edit DataFrames and many other data structures in a table-like UI. **Breaking change:** the data editor's representation used in `st.session_state` was altered. Find out more about the new format in [Access edited data](/library/advanced-features/dataframes#access-edited-data).
 - ⚙️ Introducing the [Column configuration API](/library/api-reference/data/st.column_config) with a suite of methods to configure the display and editing behavior of `st.dataframe` and `st.data_editor` columns (e.g. their title, visibility, type, or format). Keep an eye out for a detailed [blog post](https://blog.streamlit.io/) and in-depth [documentation](/library/advanced-features/dataframes#configuring-columns) upcoming in the next two weeks.
 - 🔌 Learn to use `st.experimental_connection` to create and manage data connections in your apps with the new [Connecting to data](/library/advanced-features/connecting-to-data) docs and [video tutorial](https://www.youtube.com/watch?v=xQwDfW7UHMo).
 
@@ -31,7 +58,7 @@ _Release date: June 1, 2023_
 
 - 📊 Streamlit now supports Protobuf 4 and Altair 5 ([#6215](https://github.com/streamlit/streamlit/issues/6215), [#6618](https://github.com/streamlit/streamlit/pull/6618), [#5626](https://github.com/streamlit/streamlit/issues/5626), [#6622](https://github.com/streamlit/streamlit/pull/6622)).
 - ☎️ st.dataframe and st.data_editor can hide index columns with `hide_index`, specify the display order of columns with `column_order`, and disable editing for individual columns with the `disabled` parameter.
-- ⏱️ The `ttl` parameter in [st.cache_data](/library/api-reference/performance/st.cache_data) and [st.cache_resource](/library/api-reference/performance/st.cache_resource) accepts formatted strings, so you can simply say `ttl="30d"`, `ttl="1h30m"` and any other combination of `w`, `d`, `h`, `m`, `s` supported by [Pandas’s Timedelta constructor](https://pandas.pydata.org/docs/reference/api/pandas.Timedelta.html) ([#6560](https://github.com/streamlit/streamlit/pull/6560)).
+- ⏱️ The `ttl` parameter in [st.cache_data](/library/api-reference/performance/st.cache_data) and [st.cache_resource](/library/api-reference/performance/st.cache_resource) accepts formatted strings, so you can simply say `ttl="30d"`, `ttl="1h30m"` and any other combination of `w`, `d`, `h`, `m`, `s` supported by [Pandas's Timedelta constructor](https://pandas.pydata.org/docs/reference/api/pandas.Timedelta.html) ([#6560](https://github.com/streamlit/streamlit/pull/6560)).
 - 📂 `st.file_uploader` now interprets the `type` parameter more accurately. For example, "jpg" or ".jpg" now accept both "jpg" and "jpeg" extensions. This functionality has also been extended to "mpeg/mpg", "tiff/tif", "html/htm", and "mpeg4/mp4".
 - 🤫 The new `global.disableWidgetStateDuplicationWarning` configuration option allows the silencing of warnings triggered by setting widget default values and keyed session state values concurrently ([#3605](https://github.com/streamlit/streamlit/issues/3605), [#6640](https://github.com/streamlit/streamlit/pull/6640)). Thanks, [@antonAce](https://github.com/antonAce)!
 
@@ -52,7 +79,7 @@ _Release date: June 1, 2023_
   - Fixed a display issue with index columns using category dtype ([#6680](https://github.com/streamlit/streamlit/issues/6680), [#6598](https://github.com/streamlit/streamlit/pull/6598)).
   - Fixed an issue that prevented a rerun when adding empty rows ([#6598](https://github.com/streamlit/streamlit/pull/6598)).
   - Unified the behavior between `st.data_editor` and `st.dataframe` related to auto-hiding the index column(s) based on the input data ([#6659](https://github.com/streamlit/streamlit/issues/6659), [#6598](https://github.com/streamlit/streamlit/pull/6598))
-- 🛡️ Streamlit’s [Security Policy](https://github.com/streamlit/streamlit/blob/develop/SECURITY.md) can be found in its GitHub repository ([#6666](https://github.com/streamlit/streamlit/pull/6666)).
+- 🛡️ Streamlit's [Security Policy](https://github.com/streamlit/streamlit/blob/develop/SECURITY.md) can be found in its GitHub repository ([#6666](https://github.com/streamlit/streamlit/pull/6666)).
 - 🤏 Documented the integer size limit for `st.number_input` and `st.slider` ([#6724](https://github.com/streamlit/streamlit/pull/6724)).
 - 🐍 The majority of Streamlit's Python dependencies have set a maximum allowable version, with the standard upper limit set to the next major version, but not inclusive of it ([#6691](https://github.com/streamlit/streamlit/pull/6691)).
 - 💅 UI design improvements to in-app modals ([#6688](https://github.com/streamlit/streamlit/pull/6688)).
@@ -100,7 +127,7 @@ _Release date: April 6, 2023_
 - 🪜 [st.time_input](/library/api-reference/widgets/st.time_input) supports adding a stepping interval with the keyword-only `step` parameter ([#6071](https://github.com/streamlit/streamlit/pull/6071)).
 - ❓ Most [text elements](/library/api-reference/text) can include tooltips with the `help` parameter ([#6043](https://github.com/streamlit/streamlit/pull/6043)).
 - ↔️ [st.pyplot](/library/api-reference/charts/st.pyplot) has a `use_container_width` parameter to set the chart to the container width (now all [chart elements](/library/api-reference/charts) support this parameter) ([#6067](https://github.com/streamlit/streamlit/pull/6067)).
-- 👩‍💻 [st.code](/library/api-reference/text/st.code) supports optionally displaying line numbers to the code block’s left with the boolean `line_numbers` parameter ([#5756](https://github.com/streamlit/streamlit/issues/5756), [#6042](https://github.com/streamlit/streamlit/pull/6042)).
+- 👩‍💻 [st.code](/library/api-reference/text/st.code) supports optionally displaying line numbers to the code block's left with the boolean `line_numbers` parameter ([#5756](https://github.com/streamlit/streamlit/issues/5756), [#6042](https://github.com/streamlit/streamlit/pull/6042)).
 - ⚓ Anchors in header elements can be turned off by setting `anchor=False` ([#6158](https://github.com/streamlit/streamlit/pull/6158)).
 
 **Other Changes**
@@ -109,11 +136,11 @@ _Release date: April 6, 2023_
 - 🕸️ Added `.webp` to the list of allowed static file extensions ([#6331](https://github.com/streamlit/streamlit/pull/6331))
 - 🐞 Bug fix: stop script execution on websocket close to immediately clear session information ([#6166](https://github.com/streamlit/streamlit/issues/6166), [#6204](https://github.com/streamlit/streamlit/pull/6204)).
 - 🐜 Bug fixes: updated allowed/disallowed label markdown behavior such that unsupported elements are unwrapped and only their children (text contents) render ([#5872](https://github.com/streamlit/streamlit/issues/5872), [#6036](https://github.com/streamlit/streamlit/issues/6036), [#6054](https://github.com/streamlit/streamlit/issues/6054), [#6163](https://github.com/streamlit/streamlit/pull/6163)).
-- 🪲 Bug fixes: don’t push browser history states on rerun, use HTTPS to load external resources in `streamlit hello`, and make the browser back button work for multipage apps ([#5292](https://github.com/streamlit/streamlit/issues/5292), [#6266](https://github.com/streamlit/streamlit/pull/6266), [#6232](https://github.com/streamlit/streamlit/pull/6232)). Thanks, [whitphx](https://github.com/whitphx)!
+- 🪲 Bug fixes: don't push browser history states on rerun, use HTTPS to load external resources in `streamlit hello`, and make the browser back button work for multipage apps ([#5292](https://github.com/streamlit/streamlit/issues/5292), [#6266](https://github.com/streamlit/streamlit/pull/6266), [#6232](https://github.com/streamlit/streamlit/pull/6232)). Thanks, [whitphx](https://github.com/whitphx)!
 - 🐝 Bug fix: avoid showing emoji on non-UTF-8 terminals. ([#2284](https://github.com/streamlit/streamlit/issues/2284), [#6088](https://github.com/streamlit/streamlit/pull/6088)). Thanks, [kcarnold](https://github.com/kcarnold)!
 - 📁 Bug fix: override default use of [File System Access API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API) for `react-dropzone` so that `st.file_uploader`'s File Selection Dialog only shows file types corresponding to those included in the `type` parameter ([#6176](https://github.com/streamlit/streamlit/issues/6176), [#6315](https://github.com/streamlit/streamlit/pull/6315)).
 - 💾 Bug fix: make the `.clear()` method on cache-decorated functions work ([#6310](https://github.com/streamlit/streamlit/issues/6310), [#6321](https://github.com/streamlit/streamlit/pull/6321)).
-- 🏃 Bug fix: `st.experimental_get_query_params` doesn’t need reruns to work ([#6347](https://github.com/streamlit/streamlit/issues/6347), [#6348](https://github.com/streamlit/streamlit/pull/6348)). Thanks, [PaleNeutron](https://github.com/PaleNeutron)!
+- 🏃 Bug fix: `st.experimental_get_query_params` doesn't need reruns to work ([#6347](https://github.com/streamlit/streamlit/issues/6347), [#6348](https://github.com/streamlit/streamlit/pull/6348)). Thanks, [PaleNeutron](https://github.com/PaleNeutron)!
 - 🐛 Bug fix: `CachedStFunctionWarning` mentions `experimental_allow_widgets` instead of the deprecated `suppress_st_warning` ([#6216](https://github.com/streamlit/streamlit/issues/6216), [#6217](https://github.com/streamlit/streamlit/pull/6217)).
 
 ## **Version 1.20.0**
@@ -147,7 +174,7 @@ _Release date: February 23, 2023_
 
 **Other Changes**
 
-- ✨ Streamlit’s GitHub README got a new look ([#6016](https://github.com/streamlit/streamlit/pull/6016)).
+- ✨ Streamlit's GitHub README got a new look ([#6016](https://github.com/streamlit/streamlit/pull/6016)).
 - 🌚 Improved readability of styled dataframe cells in dark mode ([#6060](https://github.com/streamlit/streamlit/issues/6060), [#6098](https://github.com/streamlit/streamlit/pull/6098)).
 - 🐛 Bug fix: make apps work again in the latest versions of Safari, and in Chrome with third-party cookies blocked ([#6092](https://github.com/streamlit/streamlit/issues/6092), [#6094](https://github.com/streamlit/streamlit/pull/6094), [#6087](https://github.com/streamlit/streamlit/issues/6087), [#6100](https://github.com/streamlit/streamlit/pull/6100)).
 - 🐞 Bug fix: refer to new cache primitives in the “Clear cache" dialog and error messages ([#6082](https://github.com/streamlit/streamlit/pull/6082), [#6128](https://github.com/streamlit/streamlit/pull/6128)).
@@ -169,7 +196,7 @@ _Release date: February 09, 2023_
 - ⏳ `st.progress` supports adding a message to display above the progress bar with the `text` keyword parameter.
 - ↔️ `st.button` has an optional `use_container_width` parameter to allow you to stretch buttons across the full container width.
 - 🐍 We formally added support for Python 3.11.
-- 🖨️ Save your app as a PDF via the “Print" option in your app’s hamburger menu.
+- 🖨️ Save your app as a PDF via the “Print" option in your app's hamburger menu.
 - 🛎️ Apps can serve small, static media files via the `enableStaticServing` config option. See our [documentation](/library/advanced-features/static-file-serving) on how to use this feature and our demo [app](https://static-file-serving.streamlit.app/) for an example.
 
 **Other Changes**
@@ -193,7 +220,7 @@ _Release date: January 12, 2023_
 **Notable Changes**
 
 - 🪄 [`@st.experimental_singleton`](/library/api-reference/performance/st.experimental_singleton#validating-the-cache) supports an optional `validate` parameter that accepts a validation function for cached data and is called each time the cached value is accessed.
-- 💾  [`@st.experimental_memo`](https://docs.streamlit.io/library/api-reference/performance/st.experimental_memo)’s `persist` parameter can also accept booleans.
+- 💾  [`@st.experimental_memo`](https://docs.streamlit.io/library/api-reference/performance/st.experimental_memo)'s `persist` parameter can also accept booleans.
 
 **Other Changes**
 
@@ -220,7 +247,7 @@ _Release date: December 14, 2022_
 **Other Changes**
 
 - 🗺️ `st.map` improvements: support for upper case columns and better exception messages ([#5679](https://github.com/streamlit/streamlit/pull/5679), [#5792](https://github.com/streamlit/streamlit/pull/5792)).
-- 🐞 Bug fix: `st.plotly_chart` respects the figure’s height attribute and the `use_container_width` parameter ([#5779](https://github.com/streamlit/streamlit/pull/5779)).
+- 🐞 Bug fix: `st.plotly_chart` respects the figure's height attribute and the `use_container_width` parameter ([#5779](https://github.com/streamlit/streamlit/pull/5779)).
 - 🪲 Bug fix: all commands with the `icon` parameter such as [st.error](/library/api-reference/status/st.error), [st.warning](/library/api-reference/status/st.warning), etc, can contain emojis with variant selectors ([#5583](https://github.com/streamlit/streamlit/pull/5583)).
 - 🐝 Bug fix: prevent `st.camera_input` from jittering when resizing the browser window ([#5661](https://github.com/streamlit/streamlit/pull/5711)).
 - 🐜 Bug fix: update exception layout to avoid overflow of stack traces ([#5700](https://github.com/streamlit/streamlit/pull/5700)).
@@ -240,7 +267,7 @@ _Release date: November 17, 2022_
 - 👩‍🎨 Design tweak to prevent jittering in sliders ([#5612](https://github.com/streamlit/streamlit/pull/5612)).
 - 🐛 Bug fix: links in headers are red, not blue ([#5609](https://github.com/streamlit/streamlit/pull/5609)).
 - 🐞 Bug fix: properly resize Plotly charts when exiting fullscreen ([#5645](https://github.com/streamlit/streamlit/pull/5645)).
-- 🐝: Bug fix: don’t accidentally trigger `st.balloons` and `st.snow` ([#5401](https://github.com/streamlit/streamlit/pull/5401)).
+- 🐝: Bug fix: don't accidentally trigger `st.balloons` and `st.snow` ([#5401](https://github.com/streamlit/streamlit/pull/5401)).
 
 ## **Version 1.14.0**
 
@@ -264,7 +291,7 @@ _Release date: October 27, 2022_
 - 📱 Design tweaks to the sidebar in multipage apps ([#5538](https://github.com/streamlit/streamlit/pull/5538), [#5445](https://github.com/streamlit/streamlit/pull/5445), [#5559](https://github.com/streamlit/streamlit/pull/5559)).
 - 📊 Improvements to the axis configuration for built-in charts ([#5412](https://github.com/streamlit/streamlit/pull/5412)).
 - 🔧 Memo and singleton improvements: support text values for `show_spinner`, use `datetime.timedelta` objects as `ttl` parameter value, properly hash PIL images and `Enum` classes, show better error messages when returning unevaluated dataframes ([#5447](https://github.com/streamlit/streamlit/pull/5447), [#5413](https://github.com/streamlit/streamlit/pull/5413), [#5504](https://github.com/streamlit/streamlit/pull/5504), [#5426](https://github.com/streamlit/streamlit/pull/5426), [#5515](https://github.com/streamlit/streamlit/pull/5515)).
-- 🔍 Zoom buttons in maps created with `st.map` and `st.pydeck_chart` use light or dark style based on the app’s theme ([#5479](https://github.com/streamlit/streamlit/pull/5479)).
+- 🔍 Zoom buttons in maps created with `st.map` and `st.pydeck_chart` use light or dark style based on the app's theme ([#5479](https://github.com/streamlit/streamlit/pull/5479)).
 - 🗜 Websocket headers from the current session's incoming WebSocket request can be obtained from a new "internal" (i.e.: subject to change without deprecation) API ([#5457](https://github.com/streamlit/streamlit/pull/5457)).
 - 📝 Improve the text that gets printed when you first install and use Streamlit ([#5473](https://github.com/streamlit/streamlit/pull/5473)).
 
@@ -312,8 +339,8 @@ _Release date: August 11, 2022_
 - 🧞‍♂️ `st.cache` properly handles JSON files now ([#5023](https://github.com/streamlit/streamlit/pull/5023)).
 - ⚓️ Headers render markdown now when the `anchor` parameter is set ([#5038](https://github.com/streamlit/streamlit/pull/5038)).
 - 🗻 `st.image` can now load SVGs from Inkscape ([#5040](https://github.com/streamlit/streamlit/pull/5040)).
-- 🗺️ `st.map` and `st.pydeck_chart` use light or dark style based on the app’s theme ([#5074](https://github.com/streamlit/streamlit/pull/5074), [#5108](https://github.com/streamlit/streamlit/pull/5108)).
-- 🎈 Clicks on elements below `st.balloons` and `st.snow` don’t get blocked anymore ([#5098](https://github.com/streamlit/streamlit/pull/5098)).
+- 🗺️ `st.map` and `st.pydeck_chart` use light or dark style based on the app's theme ([#5074](https://github.com/streamlit/streamlit/pull/5074), [#5108](https://github.com/streamlit/streamlit/pull/5108)).
+- 🎈 Clicks on elements below `st.balloons` and `st.snow` don't get blocked anymore ([#5098](https://github.com/streamlit/streamlit/pull/5098)).
 - 🔝 Embedded apps have lower top padding ([#5111](https://github.com/streamlit/streamlit/pull/5111)).
 - 💅 Adjusted padding and alignment for widgets, charts, and dataframes ([#4995](https://github.com/streamlit/streamlit/pull/4995), [#5061](https://github.com/streamlit/streamlit/pull/5061), [#5081](https://github.com/streamlit/streamlit/pull/5081)).
 - ✍️ More type hints! ([#4926](https://github.com/streamlit/streamlit/pull/4926), [#4932](https://github.com/streamlit/streamlit/pull/4932), [#4933](https://github.com/streamlit/streamlit/pull/4933))

--- a/pages/index.js
+++ b/pages/index.js
@@ -137,7 +137,51 @@ export default function Home({ window, menu, gdpr_data }) {
             <H2 className="no-b-m">What's new</H2>
 
             <TileContainer>
-              <RefCard size="third" href="/library/api-reference/connections">
+              <RefCard
+                size="third"
+                href="/knowledge-base/tutorials/build-conversational-apps"
+              >
+                <i className="material-icons-sharp">chat</i>
+                <h4>Chat elements</h4>
+                <p>
+                  Introducing <code>st.chat_message</code> and{" "}
+                  <code>st.chat_input</code> — two new chat elements that let
+                  you build conversational apps. Learn how to use these features
+                  in your LLM-powered chat apps in our tutorial.
+                </p>
+              </RefCard>
+              <RefCard
+                size="third"
+                href="/library/advanced-features/caching#the-hash_funcs-parameter"
+              >
+                <i className="material-icons-sharp">tag</i>
+                <h4>
+                  <code>hash_funcs</code>
+                </h4>
+                <p>
+                  Streamlit's caching decorators now allow you to customize
+                  Streamlit's hashing of input parameters with the keyword-only
+                  argument
+                  <code>hash_funcs</code>. Click to read the docs.
+                </p>
+              </RefCard>
+              <RefCard
+                size="third"
+                href="https://blog.streamlit.io/introducing-column-config/"
+              >
+                <i className="material-icons-sharp">settings_suggest</i>
+                <h4>Configure data editor columns!</h4>
+                <p>
+                  Introducing the Column configuration API with a suite of
+                  methods to configure the display and editing behavior of{" "}
+                  <code>st.dataframe</code>
+                  and <code>st.data_editor</code> columns.
+                </p>
+              </RefCard>
+              <RefCard
+                size="third"
+                href="/library/advanced-features/connecting-to-data"
+              >
                 <i className="material-icons-sharp">electrical_services</i>
                 <h4>st.experimental_connection</h4>
                 <p>
@@ -157,36 +201,6 @@ export default function Home({ window, menu, gdpr_data }) {
                   more, which is great for debugging!
                 </p>
               </RefCard>
-              <RefCard size="third" href="/library/api-reference/text">
-                <i className="material-icons-sharp">tips_and_updates</i>
-                <h4>Tooltips on text elements</h4>
-                <p>
-                  Most text elements can optionally include tooltips with the
-                  <code>help</code> parameter.
-                </p>
-              </RefCard>
-              <RefCard size="third" href="/library/api-reference/text/st.code">
-                <i className="material-icons-sharp">terminal</i>
-                <h4>Line numbers in st.code</h4>
-                <p>
-                  <code>st.code</code> supports optionally displaying line
-                  numbers to the code block's left with the boolean{" "}
-                  <code>line_numbers</code> parameter.
-                </p>
-              </RefCard>
-              <RefCard
-                size="third"
-                href="/library/advanced-features/secrets-management"
-              >
-                <i className="material-icons-sharp">lock</i>
-                <h4>Global secrets.toml file</h4>
-                <p>
-                  Streamlit now supports the use of a global{" "}
-                  <code>secrets.toml</code>
-                  file, in addition to a project-level file, to easily store and
-                  securely access your secrets. Click to read the docs.
-                </p>
-              </RefCard>
               <RefCard
                 size="third"
                 href="/library/advanced-features/dataframes"
@@ -194,10 +208,9 @@ export default function Home({ window, menu, gdpr_data }) {
                 <i className="material-icons-sharp">edit_note</i>
                 <h4>Editable dataframes!</h4>
                 <p>
-                  Display a data editor widget with{" "}
-                  <code>st.experimental_data_editor</code>
-                  to edit dataframes and many other data structures in a
-                  table-like UI.
+                  Announcing the general availability of{" "}
+                  <code>st.data_editor</code>, a widget that allows you to edit
+                  dataframes and many other data structures in a table-like UI.
                 </p>
               </RefCard>
               {/* <Tile


### PR DESCRIPTION
## 📚 Context

Streamlit released version 1.24.0 on June 27, 2023. This PR updates various pages in our docs to include the latest features.

## 🧠 Description of Changes

- Added the 1.24.0 release notes to changelog
- Bumped version to 1.24.0 in configuration and cheat sheet
- Added the new chat elements to cheat sheet
- Updated the `What's new` tiles on the homepage with the latest features.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
