### PR TITLE
Improve embed options descriptions

### DIFF
--- a/content/streamlit-cloud/get-started/embed-your-app.md
+++ b/content/streamlit-cloud/get-started/embed-your-app.md
@@ -86,43 +86,43 @@ The only noteworthy differences between the methods is that iframing allows you 
 
 When [Embedding with iframes](#embedding-with-iframes), Streamlit allows you to specify one or more instances of the `?embed_options` query parameter for granular control over the embedding behavior. The supported values for `?embed_options` are listed below:
 
-1. Show the toolbar at the top right of the app (menu, running man, ...)
+1. Show the toolbar at the top right of the app (menu, running man, ...).
 
    ```javascript
    /?embed=true&embed_options=show_toolbar
    ```
 
-2. Show padding at the top and bottom of the app
+2. Show padding at the top and bottom of the app.
 
    ```javascript
    /?embed=true&embed_options=show_padding
    ```
 
-3. Show the footer reading "Made with Streamlit"
+3. Show the footer reading "Made with Streamlit."
 
    ```javascript
    /?embed=true&embed_options=show_footer
    ```
 
-4. Show the colored line at the top of the app
+4. Show the colored line at the top of the app.
 
    ```javascript
    /?embed=true&embed_options=show_colored_line
    ```
 
-5. Disable scrolling
+5. Disable scrolling for the main body of the app. (The sidebar will still be scrollable.)
 
    ```javascript
    /?embed=true&embed_options=disable_scrolling
    ```
 
-6. Open with light theme
+6. Open the app with light theme.
 
    ```javascript
    /?embed=true&embed_options=light_theme
    ```
 
-7. Open with dark theme
+7. Open the app with dark theme.
 
    ```javascript
    /?embed=true&embed_options=dark_theme

--- a/content/streamlit-cloud/get-started/embed-your-app.md
+++ b/content/streamlit-cloud/get-started/embed-your-app.md
@@ -86,25 +86,25 @@ The only noteworthy differences between the methods is that iframing allows you 
 
 When [Embedding with iframes](#embedding-with-iframes), Streamlit allows you to specify one or more instances of the `?embed_options` query parameter for granular control over the embedding behavior. The supported values for `?embed_options` are listed below:
 
-1. Show toolbar
+1. Show the toolbar at the top right of the app (menu, running man, ...)
 
    ```javascript
    /?embed=true&embed_options=show_toolbar
    ```
 
-2. Show padding
+2. Show padding at the top and bottom of the app
 
    ```javascript
    /?embed=true&embed_options=show_padding
    ```
 
-3. Show footer
+3. Show the footer reading "Made with Streamlit"
 
    ```javascript
    /?embed=true&embed_options=show_footer
    ```
 
-4. Show colored line
+4. Show the colored line at the top of the app
 
    ```javascript
    /?embed=true&embed_options=show_colored_line


### PR DESCRIPTION
## 📚 Context

<!-- Why do you want to make this change? What background should the reviewer know? -->
Saw that the embed options where described in a very minimal way, which made them a bit confusing to read (e.g. it didn't explain which padding was meant by `?embed_options=show_padding`).

## 🧠 Description of Changes

<!-- What was specifically changed? Which files, algorithms, links, media? -->
<!-- Please add them here as a bulleted list -->
Improved the descriptions a tiny bit. Feel free to change wording!

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
