### PR TITLE
Prevent `Collapse` component closing on code block copy action

### DIFF
--- a/components/blocks/collapse.js
+++ b/components/blocks/collapse.js
@@ -7,8 +7,8 @@ const Collapse = ({ title, children, expanded = false }) => {
 
   return (
     <section className={styles.Container}>
-      <div className={styles.PanelHeading} onClick={() => setShow(!show)}>
-        <summary className={styles.PanelTitle}>
+      <div className={styles.PanelHeading}>
+        <summary className={styles.PanelTitle} onClick={() => setShow(!show)}>
           <span className={styles.Title}>{title}</span>
 
           <i


### PR DESCRIPTION
## 📚 Context

This PR fixes an issue whereby clicking the copy-to-clipboard button in code blocks within an expanded `<Collapse>` component lead to the component closing. Example:

````md
<Collapse title="View entire file" expanded={false} >

```python
import somepackage

print("yo")
```

</Collapse>
````

## 🧠 Description of Changes

- Moved the click event handler from the `div` with `className={styles.PanelHeading}` to the `summary` element. This ensures that the collapsing and expanding of the component only happens when you click the title or the icon, not when you click anywhere inside the Collapse component (including the "copy to clipboard" button in the code block).

### Examples for reviewers

https://deploy-preview-729--streamlit-docs.netlify.app/library/advanced-features/configuration#theme

https://deploy-preview-729--streamlit-docs.netlify.app/knowledge-base/tutorials/build-conversational-apps#build-a-simple-chatbot-gui-with-streaming

### Behavior

In the broken `Collapse` component, the `onClick` event handler was attached to the `div` element with `className={styles.PanelHeading}`. Meaning, clicking anywhere within that `div` (including its child elements) triggers the event handler and toggles the show state.

When a Prism code block is inside `Collapse` (as one of its children), the "copy to clipboard" button provided by Prism also becomes part of the `styles.PanelHeading` `div`. Therefore, clicking the "copy to clipboard" button bubbles up the click event to the `styles.PanelHeading` `div`, triggering the event handler and toggling the show state, causing `Collapse` to collapse.

By moving the `onClick` event handler to the summary element, we restrict the area that triggers the `Collapse` component's state change. Now, only a click on the title or the icon (which are part of the summary element) will toggle the show state. A click anywhere else within `Collapse` (including the "copy to clipboard" button in the Prism code block) will not affect the show state, thus preventing the Collapse component from unintentionally collapsing.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/snowflake-corp/Docs-bug-Prevent-Collapse-component-from-closing-on-code-block-copy-action-a954297da96941348f11ca47b9109e61)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
