### PR TITLE
Visual fixes to inline code and images

### DIFF
--- a/components/blocks/image.module.css
+++ b/components/blocks/image.module.css
@@ -35,7 +35,7 @@
 }
 
 .ModalImage {
-  @apply h-full object-contain;
+  @apply h-screen object-contain py-4;
 }
 
 .CloseButton {

--- a/styles/text.scss
+++ b/styles/text.scss
@@ -109,7 +109,7 @@ button:focus-visible {
 /* Inline code blocks */
 p > code,
 li > code {
-  @apply border border-gray-40 text-red-70 rounded-md px-1 mx-1 break-words;
+  @apply border border-gray-40 text-red-70 rounded-md px-1 mx-1 whitespace-nowrap;
 }
 
 p a code {


### PR DESCRIPTION
## 📚 Context

This PR fixes a couple of visual issues reported by @MathCatsAnd, namely:

- Ensures inline code doesn't break in two words;
- Ensures tall images look good when enlarged.

## 🧠 Description of Changes

* Added `whitespace-nowrap` to `p > code` tags;
* Added `h-screen` to `.ModalImage` styles.

**Revised:**

<img width="1728" alt="Screenshot 2023-07-17 at 12 54 57 PM" src="https://github.com/streamlit/docs/assets/103376966/23249257-c48e-4a96-a11c-e3076b3e7492">

<img width="816" alt="Screenshot 2023-07-17 at 12 51 32 PM" src="https://github.com/streamlit/docs/assets/103376966/d63f873a-98df-4aa1-8be0-5cd020c5659a">

**Current:**

![Untitled (1)](https://github.com/streamlit/docs/assets/103376966/58568407-0a6c-4e19-b091-0945411eed66)

![Untitled](https://github.com/streamlit/docs/assets/103376966/5635a694-2a1b-4959-9662-580dee92a323)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

- https://www.notion.so/snowflake-corp/Docs-site-inline-code-line-breaks-a5177a9790e5470291fd8e248c85f101
- https://www.notion.so/snowflake-corp/Docs-Site-Tall-images-don-t-scale-correctly-on-click-for-close-up-440238120dfe4eb69a45665496b58caf

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
