### PR TITLE
Feature: Add Escape key functionality to close enlarged images

### DIFF
--- a/components/blocks/image.js
+++ b/components/blocks/image.js
@@ -1,10 +1,29 @@
-import React, { useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import classNames from "classnames";
 
 import styles from "./image.module.css";
 
 const Image = ({ caption, pure, src, alt, clean }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const isMounted = useRef(false);
+
+  useEffect(() => {
+    isMounted.current = true; // Set to true on mount
+
+    const handleEsc = (event) => {
+      if (isMounted.current && event.keyCode === 27) closeModal();
+      // Check if the component is still mounted before calling closeModal
+    };
+
+    if (isOpen) {
+      window.addEventListener("keydown", handleEsc);
+    }
+
+    return () => {
+      window.removeEventListener("keydown", handleEsc);
+      isMounted.current = false; // Set to false on unmount
+    };
+  }, [isOpen]);
 
   const openModal = () => {
     setIsOpen(true);

--- a/components/blocks/image.js
+++ b/components/blocks/image.js
@@ -1,29 +1,10 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState } from "react";
 import classNames from "classnames";
 
 import styles from "./image.module.css";
 
 const Image = ({ caption, pure, src, alt, clean }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const isMounted = useRef(false);
-
-  useEffect(() => {
-    isMounted.current = true; // Set to true on mount
-
-    const handleEsc = (event) => {
-      if (isMounted.current && event.keyCode === 27) closeModal();
-      // Check if the component is still mounted before calling closeModal
-    };
-
-    if (isOpen) {
-      window.addEventListener("keydown", handleEsc);
-    }
-
-    return () => {
-      window.removeEventListener("keydown", handleEsc);
-      isMounted.current = false; // Set to false on unmount
-    };
-  }, [isOpen]);
 
   const openModal = () => {
     setIsOpen(true);
@@ -32,6 +13,20 @@ const Image = ({ caption, pure, src, alt, clean }) => {
   const closeModal = () => {
     setIsOpen(false);
   };
+
+  useEffect(() => {
+    const handleEsc = (event) => {
+      if (event.keyCode === 27) closeModal();
+    };
+
+    if (isOpen) {
+      window.addEventListener("keydown", handleEsc);
+    }
+
+    return () => {
+      window.removeEventListener("keydown", handleEsc);
+    };
+  }, [isOpen]);
 
   let block;
   let customCaption;


### PR DESCRIPTION
## 📚 Context

It's slightly annoying UX that one cannot close the enlarged image modal by pressing the Escape key, but have to click the close button on the modal's top right corner or click on the image itself (although the mouseover icon does not appear when enlarged, so it's not obvious users need to click the image to close it).

## 🧠 Description of Changes

- In the `<Image>` component, implemented a keydown event listener to detect when the `Escape` key is pressed
- Utilized the `useState` and `useEffect` hooks to open and close the modal and manage the addition and removal of the event listener

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/snowflake-corp/Docs-feature-Add-Escape-key-functionality-to-close-Image-component-258c5ec6cd5c470886509121acd10706)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
