### PR TITLE
Shouldn't `onClick` event for close button be set to call `closeModal`, not `openModal`?

### DIFF
--- a/components/blocks/image.js
+++ b/components/blocks/image.js
@@ -37,7 +37,7 @@ const Image = ({ caption, pure, src, alt, clean }) => {
           {customCaption}
         </section>
         <section className={styles.LightBox} onClick={closeModal}>
-          <button className={styles.CloseButton} onClick={openModal}>
+          <button className={styles.CloseButton} onClick={closeModal}>
             close
           </button>
           <section className={styles.ImageContainer}>


### PR DESCRIPTION
## 📚 Context

When I was working on #749, I noticed in the `Image` component that the `onClick` handler for `CloseButton` calls the `openModal` function instead of `closeModal`. Shouldn't it be the opposite?

## 🧠 Description of Changes

- Sets the `onClick` event on the close button to call `closeModal` function which sets `isOpen` to `false`, hiding the modal.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
