### PR TITLE
Bug: Fix event listener cleanup in Search component

### DIFF
--- a/components/utilities/search.js
+++ b/components/utilities/search.js
@@ -132,13 +132,16 @@ const Search = () => {
         setHotkey("Ctrl-K");
       }
     }
+
+    document.addEventListener("keydown", handleKey);
+
     if (isModalOpen) {
-      document.addEventListener("keydown", handleKey);
-      return () => {
-        // clean up the listener when the modal is closed
-        document.removeEventListener("keydown", handleKey);
-      };
+      highlightResult();
     }
+
+    return () => {
+      document.removeEventListener("keydown", handleKey);
+    };
   }, [isModalOpen]); // add isModalOpen as a dependency, so the effect runs whenever isModalOpen changes
 
   const searchClient = algoliasearch(

--- a/components/utilities/search.js
+++ b/components/utilities/search.js
@@ -132,8 +132,14 @@ const Search = () => {
         setHotkey("Ctrl-K");
       }
     }
-    document.addEventListener("keydown", handleKey);
-  }, []);
+    if (isModalOpen) {
+      document.addEventListener("keydown", handleKey);
+      return () => {
+        // clean up the listener when the modal is closed
+        document.removeEventListener("keydown", handleKey);
+      };
+    }
+  }, [isModalOpen]); // add isModalOpen as a dependency, so the effect runs whenever isModalOpen changes
 
   const searchClient = algoliasearch(
     "XNXFGO6BQ1",


### PR DESCRIPTION
## 📚 Context

This PR fixes a bug in the `search.js` component's event handling.

Previously, the Search component attached a keydown event listener on every render, leading to multiple instances of the same event listener if the component was mounted and unmounted multiple times. This caused handleKey function to be invoked multiple times for each keydown event, leading to unexpected behavior.

In this PR, the keydown event listener attachment has been moved inside a useEffect hook and a cleanup function has been added to remove the event listener when the component unmounts or when the isModalOpen state changes.

This change ensures that only a single instance of the event listener is active at any given time, preventing any unintended behavior due to multiple listener instances. As a result, it eliminates the console warnings about potential memory leaks.

## For reviewers

To reproduce the console errors I was seeing, follow these steps:

1. From `main`, run `make up`.
2. Open the dev console
3. Navigate to any page with an image. Say http://localhost:3000/library/advanced-features/app-menu
4. Click an image to enlarge
5. Press `Esc`
6. Notice the errors in the console:

```
next-dev.js:32 Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
    at Search (webpack-internal:///./components/utilities/search.js:119:62)
    at WithRouterWrapper (webpack-internal:///./node_modules/next/dist/client/with-router.js:17:34)
    at section
    at nav
    at header
    at Header (webpack-internal:///./components/navigation/header.js:42:26)
    at main
    at Layout (webpack-internal:///./components/layouts/globalTemplate.js:16:26)
    at MDXProvider (webpack-internal:///./node_modules/@mdx-js/react/dist/esm.js:140:46)
    at Article (webpack-internal:///./pages/[...slug].js:139:22)
```

https://github.com/streamlit/docs/assets/20672874/25ae3bc5-68dc-452c-94f2-ef295cce0fa8

## Why does it occur?

The issue _seems_ to be that we're not cleaning up the event listener in the `useEffect` function. When the component is unmounted, the listener is still active and might be trying to set state on a component that no longer exists, hence the error.

But it's strange that it's triggered when enlarging and closing an image, even though it seems unrelated. My best guess is that it's likely because the image component is causing a rerender of some component which leads to the Search component unmounting for some reason. Not entirely sure... In the current implementation, the function uses an effect to set up a "keydown" event listener when the component mounts. This listener calls the handleKey function when a key is pressed. The problem is that when you click out of the modal, the event listener stays active, still responding to keyboard events even when the search modal is not open.

The solution in this PR sets up the event listener only when the modal is open, and cleans it up when the modal is closed.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
