### PR TITLE
DOC: small markdown fix in button behavior article

### DIFF
--- a/content/library/advanced-features/button-behavior-and-examples.md
+++ b/content/library/advanced-features/button-behavior-and-examples.md
@@ -118,12 +118,14 @@ st.slider('Select a value', disabled=st.session_state.button)
 
 ### Buttons to continue or control stages of a process
 
-Another alternative to nesting content inside a button is to use a value in `st.session_state` that designates the "step" or "stage" of a process. In this example, we have four stages in our script: 0. Before the user begins.
+Another alternative to nesting content inside a button is to use a value in `st.session_state` that designates the "step" or "stage" of a process. In this example, we have four stages in our script:
 
+0. Before the user begins.
 1. User enters their name.
 2. User chooses a color.
 3. User gets a thank-you message.
-   A button at the beginning advances the stage from 0 to 1. A button at the end resets the stage from 3 to 0. The other widgets used in stage 1 and 2 have callbacks to set the stage. If you have a process with dependant steps and want to keep previous stages visible, such a callback forces a user to retrace subsequent stages if they change an earlier widget.
+
+A button at the beginning advances the stage from 0 to 1. A button at the end resets the stage from 3 to 0. The other widgets used in stage 1 and 2 have callbacks to set the stage. If you have a process with dependant steps and want to keep previous stages visible, such a callback forces a user to retrace subsequent stages if they change an earlier widget.
 
 ```python
 import streamlit as st


### PR DESCRIPTION
Fix the display of a list. (Before this commit, the first list item was not part of the list but rather of the paragraph above. Furthermore, the following paragraph was not separate from the last list item.)

## 🧠 Description of Changes

Only white space to make a list appear correctly.

**Current:**

![image](https://github.com/streamlit/docs/assets/7026269/d3a701cc-486e-4c26-85db-460668af0354)

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
