### PR TITLE
Bug: Pass unique key prop to each `NewsEntry` list in `NewsFeed` component

### DIFF
--- a/components/blocks/newsFeed.js
+++ b/components/blocks/newsFeed.js
@@ -28,6 +28,7 @@ function NewsFeed() {
       <div id="result">
         {posts.map((post) => (
           <NewsEntry
+            key={post.id}
             date={post.published_at}
             title={post.title}
             text={post.excerpt}


### PR DESCRIPTION
## 📚 Context

When you run `make up` and look at the browser console, you'll see the following warning:

```
next-dev.js:32 Warning: Each child in a list should have a unique "key" prop.

Check the render method of `NewsFeed`. See https://reactjs.org/link/warning-keys for more information.
    at NewsEntry (webpack-internal:///./components/blocks/newsEntry.js:21:23)
    at NewsFeed (webpack-internal:///./components/blocks/newsFeed.js:21:62)
    at section
    at NewsContainer (webpack-internal:///./components/layouts/newsContainer.js:10:26)
    at article
    at section
    at section
    at div
    at main
    at Layout (webpack-internal:///./components/layouts/globalTemplate.js:16:26)
    at Home (webpack-internal:///./pages/index.js:88:24)
    at AppContextProvider (webpack-internal:///./context/AppContext.js:15:26)
    at StreamlitDocs (webpack-internal:///./pages/_app.js:71:27)
    at ErrorBoundary (webpack-internal:///./node_modules/next/dist/compiled/@next/react-dev-overlay/client.js:8:20584)
    at ReactDevOverlay (webpack-internal:///./node_modules/next/dist/compiled/@next/react-dev-overlay/client.js:8:23125)
    at Container (webpack-internal:///./node_modules/next/dist/client/index.js:357:9)
    at AppContainer (webpack-internal:///./node_modules/next/dist/client/index.js:791:26)
    at Root (webpack-internal:///./node_modules/next/dist/client/index.js:915:27)
```

This error is a result of not passing a unique "key" prop to each `<NewsEntry>` list in the `NewsFeed` component. This PR passes the blog post id as a unique identifier to the key prop to eliminate the warning.

## 🧠 Description of Changes

- Set `key={post.id}` for each `<NewsEntry>` list in the `NewsFeed` component. 

**Revised:**

```js
<div id="result">
        {posts.map((post) => (
          <NewsEntry
            key={post.id}
            date={post.published_at}
            title={post.title}
            text={post.excerpt}
            link={post.url}
            image={post.feature_image}
            target="_blank"
          />
        ))}
      </div>
```

**Current:**

```js
<div id="result">
        {posts.map((post) => (
          <NewsEntry
            date={post.published_at}
            title={post.title}
            text={post.excerpt}
            link={post.url}
            image={post.feature_image}
            target="_blank"
          />
        ))}
      </div>
```

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/snowflake-corp/Bug-fix-pass-unique-key-prop-to-NewsEntry-to-get-rid-of-console-warning-7a3f8b6bbaec4e2195821245acebf094)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
