### PR TITLE
Version selector persists when st.command doesn't exist in version

### DIFF
--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -96,9 +96,38 @@ const Autofunction = ({
     setIsHighlighted(true);
   };
 
+  const VersionSelector = ({
+    versionList,
+    currentVersion,
+    handleSelectVersion,
+  }) => {
+    const selectClass =
+      currentVersion !== versionList[0]
+        ? "version-select old-version"
+        : "version-select";
+
+    return (
+      <form className={classNames(selectClass, styles.Form)}>
+        <label>
+          <span className="sr-only">Streamlit Version</span>
+          <select
+            value={currentVersion}
+            onChange={handleSelectVersion}
+            className={styles.Select}
+          >
+            {versionList.map((version, index) => (
+              <option value={version} key={version}>
+                v{version}
+              </option>
+            ))}
+          </select>
+        </label>
+      </form>
+    );
+  };
+
   const handleSelectVersion = (event) => {
     const functionObject = streamlit[streamlitFunction];
-    const name = cleanHref(`st.${functionObject.name}`);
     const slicedSlug = slug.slice();
 
     if (event.target.value !== currentVersion) {
@@ -114,7 +143,12 @@ const Autofunction = ({
       }
     }
 
-    router.push(`/${slicedSlug.join("/")}#${name} `);
+    if (!functionObject) {
+      router.push(`/${slicedSlug.join("/")}`);
+    } else {
+      const name = cleanHref(`st.${functionObject.name}`);
+      router.push(`/${slicedSlug.join("/")}#${name} `);
+    }
   };
 
   const footers = [];
@@ -142,7 +176,7 @@ const Autofunction = ({
     return (
       <div className={styles.Container} ref={blockRef} key={slug}>
         <div className="code-header">
-          <H2>{streamlitFunction}</H2>
+          <H2>{streamlitFunction.replace("streamlit", "st")}</H2>
         </div>
         <Warning>
           <p>
@@ -150,6 +184,11 @@ const Autofunction = ({
             of Streamlit.
           </p>
         </Warning>
+        <VersionSelector
+          versionList={versionList}
+          currentVersion={currentVersion}
+          handleSelectVersion={handleSelectVersion}
+        />
       </div>
     );
   }
@@ -173,32 +212,15 @@ const Autofunction = ({
       String(functionObject.name).startsWith("iframe")
         ? `st.components.v1.${functionObject.name}`
         : functionName;
-    const selectClass =
-      currentVersion !== versionList[0]
-        ? "version-select old-version"
-        : "version-select";
     header = (
       <div className={styles.HeaderContainer}>
         <div className={styles.TitleContainer}>
           <H2 className={styles.Title}>{name}</H2>
-          <form className={classNames(selectClass, styles.Form)}>
-            <label>
-              <span className="sr-only">Streamlit Version</span>
-              <select
-                value={currentVersion}
-                onChange={handleSelectVersion}
-                className={styles.Select}
-              >
-                {versionList.map((version, index) => {
-                  return (
-                    <option value={version} key={version}>
-                      v{version}
-                    </option>
-                  );
-                })}
-              </select>
-            </label>
-          </form>
+          <VersionSelector
+            versionList={versionList}
+            currentVersion={currentVersion}
+            handleSelectVersion={handleSelectVersion}
+          />
         </div>
         {deprecated === true ? (
           <Deprecation>

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -174,9 +174,16 @@ const Autofunction = ({
     }
   } else {
     return (
-      <div className={styles.Container} ref={blockRef} key={slug}>
-        <div className="code-header">
-          <H2>{streamlitFunction.replace("streamlit", "st")}</H2>
+      <div className={styles.HeaderContainer}>
+        <div className={styles.TitleContainer} ref={blockRef} key={slug}>
+          <H2 className={styles.Title}>
+            {streamlitFunction.replace("streamlit", "st")}
+          </H2>
+          <VersionSelector
+            versionList={versionList}
+            currentVersion={currentVersion}
+            handleSelectVersion={handleSelectVersion}
+          />
         </div>
         <Warning>
           <p>
@@ -184,11 +191,6 @@ const Autofunction = ({
             of Streamlit.
           </p>
         </Warning>
-        <VersionSelector
-          versionList={versionList}
-          currentVersion={currentVersion}
-          handleSelectVersion={handleSelectVersion}
-        />
       </div>
     );
   }

--- a/components/blocks/autofunction.module.css
+++ b/components/blocks/autofunction.module.css
@@ -15,8 +15,7 @@
 }
 
 .Form {
-  @apply relative my-4 md:my-0 ml-0 md:ml-auto;
-  max-width: fit-content;
+  @apply relative my-4 md:my-0 ml-0 md:ml-auto max-w-fit;
 }
 
 .Form::after {

--- a/components/blocks/autofunction.module.css
+++ b/components/blocks/autofunction.module.css
@@ -16,6 +16,7 @@
 
 .Form {
   @apply relative my-4 md:my-0 ml-0 md:ml-auto;
+  max-width: fit-content;
 }
 
 .Form::after {


### PR DESCRIPTION
## 📚 Context

This PR makes the version selector in `st.command` API reference pages persist when the command didn't exist in that version. For example, if I go to an older version where the element didn't exist, the version selector disappears and I can't go back to the other versions.For example, for `st.experimental_connection`, if I navigate to [v1.21.0 or older](https://docs.streamlit.io/1.21.0/library/api-reference/connections/st.experimental_connection#stexperimental_connection), I'll see the warning that it didn't exist. But at this point, I could only use the back button of my browser to go back instead of continuing to use the version selector, which breaks the UX a little bit. 

The problem here is that when a command does not exist in a certain version, the component directly returns a `<Warning />` component without the version selector. To fix this issue, we now extract the version selector into a separate functional component and add it to both branches of our render.

## 🧠 Description of Changes

- Made the version selector independent of the existence of the `streamlitFunction` in `streamlit`. Even if the streamlitFunction does not exist, we show the version selector dropdown, allowing the user to select a different version where the `st.command` may exist. This is done by moving the version selector out of the header JSX, so it is rendered irrespective of whether `streamlitFunction` exists in `streamlit` or not.
- Replaced 'streamlit' Prefix in StreamlitFunction: When rendering the command name in the header when the command didn't exist in that version , 'streamlit' is replaced by 'st'. Currently for e.g., it says `streamlit.experimental_connection`.
- Added 'max-width: fit-content' to Form / dropdown style. @sfc-gh-jgarcia I could use your input here 😄 Without this change, here's what the form looked like:

![image](https://github.com/streamlit/docs/assets/20672874/80c6b8d3-0dd8-422f-a1af-56386173dc09)

I wasn't sure if there was a native tailwind equivalent to doing ` 'max-width: fit-content'`.


**Revised:**

![image](https://github.com/streamlit/docs/assets/20672874/7b7dec12-3a72-4add-bd03-cf1848b35959)

**Current:**

![image](https://github.com/streamlit/docs/assets/20672874/01d00153-4652-43df-8e39-be005998b0b7)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/snowflake-corp/Bug-version-selector-should-not-disappear-when-st-command-doesn-t-exit-in-that-version-3c16e8d0bd0a47929e5c06c38a4e3f51)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
