### PR TITLE
Fix Invalid DOM property warning on svg path in socialCallout.js

### DIFF
--- a/components/utilities/socialCallout.js
+++ b/components/utilities/socialCallout.js
@@ -267,9 +267,9 @@ const SocialCallout = () => {
                 <path
                   d="M21.75 6.75v10.5a1.5 1.5 0 0 1-1.5 1.5H3.75a1.5 1.5 0 0 1-1.5-1.5V6.75m19.5 0a1.5 1.5 0 0 0-1.5-1.5H3.75a1.5 1.5 0 0 0-1.5 1.5m19.5 0-8.896 6.159a1.5 1.5 0 0 1-1.708 0L2.25 6.75"
                   stroke="#FFFFFF"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
+                  strokeWidth={1.5}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
                 />
               </svg>
             </div>


### PR DESCRIPTION
## 📚 Context

Opening the docs landing page from `main` leads to multiple console warnings like:

```
Warning: Invalid DOM property `stroke-linejoin`. Did you mean `strokeLinejoin`?
    at path
    at svg
    at div
    at a
    at li
    at ul
    at section
    at SocialCallout
    at section
    at section
    at div
    at main
    at Layout (webpack-internal:///./components/layouts/globalTemplate.js:16:26)
    at Home (webpack-internal:///./pages/index.js:88:24)
    at AppContextProvider (webpack-internal:///./context/AppContext.js:15:26)
    at StreamlitDocs (webpack-internal:///./pages/_app.js:71:27)
    at ErrorBoundary (webpack-internal:///./node_modules/next/dist/compiled/@next/react-dev-overlay/client.js:8:20584)
    at ReactDevOverlay (webpack-internal:///./node_modules/next/dist/compiled/@next/react-dev-overlay/client.js:8:23125)
    at Container (webpack-internal:///./node_modules/next/dist/client/index.js:357:9)
    at AppContainer (webpack-internal:///./node_modules/next/dist/client/index.js:791:26)
    at Root (webpack-internal:///./node_modules/next/dist/client/index.js:915:27)
```

## 🧠 Description of Changes

- Uses the right svg path property names in `socialCallout.js` to get rid of `Invalid DOM property warning`s in the console. 

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
