### PR TITLE
Fix inline code regression

### DIFF
--- a/styles/text.scss
+++ b/styles/text.scss
@@ -109,7 +109,7 @@ button:focus-visible {
 /* Inline code blocks */
 p > code,
 li > code {
-  @apply border border-gray-40 text-red-70 rounded-md px-1 mx-1 whitespace-nowrap;
+  @apply border border-gray-40 text-red-70 rounded-md px-1 mx-1 break-words;
 }
 
 p a code {


### PR DESCRIPTION
This PR fixes an issue reported by Adrien where large lines of inline code blocks would look off, especially on mobile resolutions 👇 

![image](https://github.com/streamlit/docs/assets/103376966/e2caac59-d8f2-4289-a419-65b511e69664)