### PR TITLE
Corrects a typo in app-menu.md

### DIFF
--- a/content/library/advanced-features/app-menu.md
+++ b/content/library/advanced-features/app-menu.md
@@ -131,7 +131,7 @@ If you are running an app locally from within a git repo, you can deploy your ap
 
 ## Customize the menu
 
-Using `client.toobarMode` in your app's [configuration](/library/advanced-features/configuration), you can make the app menu appear in the following ways:
+Using `client.toolbarMode` in your app's [configuration](/library/advanced-features/configuration), you can make the app menu appear in the following ways:
 
 - `"developer"` &mdash; Show the developer options to all viewers.
 - `"viewer"` &mdash; Hide the developer options from all viewers.


### PR DESCRIPTION
Corrects typo in the "Customize the menu" section. Attribute to set is `client.toolbarMode`.

## 📚 Context

There is a typo in the instructions.

## 🧠 Description of Changes

- Corrected typo from `client.toobarMode` to `client.toolbarMode` (missing the 'l').

**Revised:**

This is documentation.
<img width="1037" alt="image" src="https://github.com/streamlit/docs/assets/12780115/04ffcc8d-f7ff-44ca-a1d8-f6594d89eba2">


**Current:**

<img width="1029" alt="image" src="https://github.com/streamlit/docs/assets/12780115/7e787a90-f2e4-4069-b52b-e9baa5fbae98">

## 💥 Impact

Minor edit to instructions to correct a typo.

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

N/A

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
