### PR TITLE
Update set_page_config snippet

### DIFF
--- a/content/library/api/utilities/utilities.md
+++ b/content/library/api/utilities/utilities.md
@@ -17,8 +17,8 @@ Configures the default settings of the page.
 
 ```python
 st.set_page_config(
-  title="My app",
-  favicon=":shark:",
+  page_title="My app",
+  page_icon=":shark:",
 )
 ```
 


### PR DESCRIPTION
Reflect most up-to-date usage.

## 📚 Context

The `st.set_page_config` function in the current version of streamlit uses `page_title` and `page_icon`, rather than `title` and `favicon`.

## 🧠 Description of Changes

Changed the argument names in the snippet to reflect usage as of `v1.25.0`.

**Revised:**

See commit.

**Current:**

See commit.

## 💥 Impact

Very small, but will save a quick error for some too lazy to read the dedicated reference for the function 😄 .

Size:

- [x ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

n/a

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
