### PR TITLE
Embed 'Introducing Streamlit Chat Elements' video in API and tutorial

### DIFF
--- a/content/kb/tutorials/chat.md
+++ b/content/kb/tutorials/chat.md
@@ -35,6 +35,10 @@ Streamlit offers several commands to help you build conversational apps. These c
 
 [`st.chat_message`](/library/api-reference/chat/st.chat_message) lets you insert a chat message container into the app so you can display messages from the user or the app. Chat containers can contain other Streamlit elements, including charts, tables, text, and more. [`st.chat_input`](/library/api-reference/chat/st.chat_input) lets you display a chat input widget so the user can type in a message.
 
+For an overview of the API, check out this video tutorial by Chanin Nantasenamat ([@dataprofessor](https://www.youtube.com/dataprofessor)), a Senior Developer Advocate at Streamlit.
+
+<YouTube videoId="4sPnOqeUDmk" />
+
 ### st.chat_message
 
 `st.chat_message` lets you insert a multi-element chat message container into your app. The returned container can contain any Streamlit element, including charts, tables, text, and more. To add elements to the returned container, you can use `with` notation.

--- a/content/library/api/chat/chat-input.md
+++ b/content/library/api/chat/chat-input.md
@@ -11,3 +11,7 @@ Read the [Build conversational apps](/knowledge-base/tutorials/build-conversatio
 </Tip>
 
 <Autofunction function="streamlit.chat_input" />
+
+For an overview of the `st.chat_input` and `st.chat_message` API, check out this video tutorial by Chanin Nantasenamat ([@dataprofessor](https://www.youtube.com/dataprofessor)), a Senior Developer Advocate at Streamlit.
+
+<YouTube videoId="4sPnOqeUDmk" />

--- a/content/library/api/chat/chat-message.md
+++ b/content/library/api/chat/chat-message.md
@@ -11,3 +11,7 @@ Read the [Build conversational apps](/knowledge-base/tutorials/build-conversatio
 </Tip>
 
 <Autofunction function="streamlit.chat_message" />
+
+For an overview of the `st.chat_message` and `st.chat_input` API, check out this video tutorial by Chanin Nantasenamat ([@dataprofessor](https://www.youtube.com/dataprofessor)), a Senior Developer Advocate at Streamlit.
+
+<YouTube videoId="4sPnOqeUDmk" />


### PR DESCRIPTION
## 📚 Context

We just released a new [Introducing Streamlit Chat Elements](https://www.youtube.com/watch?v=4sPnOqeUDmk) video on YouTube that quickly walks through the `st.chat_input` and `st.chat_message` API. It would be great to embed it in the API and the tutorial for the visual persona of users.

## 🧠 Description of Changes

Embeds the video in:
- `/library/api-reference/chat/st.chat_input`
- `/library/api-reference/chat/st.chat_message` and
- `/knowledge-base/tutorials/build-conversational-apps#chat-elements`

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
