### PR TITLE
Pagination updates

### DIFF
--- a/components/navigation/arrowLink.module.css
+++ b/components/navigation/arrowLink.module.css
@@ -1,5 +1,5 @@
 .Container {
-  @apply flex flex-wrap flex-col md:flex-row md:flex-nowrap items-center justify-between mt-20 gap-4;
+  @apply flex flex-wrap flex-col md:flex-row md:flex-nowrap items-center justify-between mt-16 py-8 border-t border-t-gray-30 gap-4;
 }
 
 .Link {
@@ -15,7 +15,7 @@
 }
 
 .NextLink {
-  @apply mt-8 sm:mt-0;
+  @apply mt-0 sm:mt-0;
 }
 
 .Icon {

--- a/components/navigation/arrowLink.module.css
+++ b/components/navigation/arrowLink.module.css
@@ -1,9 +1,9 @@
 .Container {
-  @apply flex flex-wrap flex-col md:flex-row md:flex-nowrap items-center justify-between mt-16 py-8 border-t border-t-gray-30 gap-4;
+  @apply flex flex-wrap flex-col md:flex-row md:flex-nowrap items-center justify-between mt-16 mb-8 gap-4;
 }
 
 .Link {
-  @apply overflow-hidden border-none text-base tracking-tight font-sans font-normal text-gray-90 leading-7 hover:opacity-70 flex items-center transition-all;
+  @apply overflow-hidden border-none text-base md:text-lg tracking-tight font-sans font-normal text-gray-90 leading-7 hover:opacity-70 flex items-center transition-all;
 }
 
 .Truncate {

--- a/components/utilities/helpful.module.css
+++ b/components/utilities/helpful.module.css
@@ -3,7 +3,7 @@
 }
 
 .Title {
-  @apply font-bold text-lg mb-0 tracking-tight;
+  @apply font-bold text-base mb-0 tracking-tight;
   @apply text-gray-90 !important;
 }
 
@@ -79,7 +79,7 @@
 }
 
 .FormContainer {
-  @apply flex flex-col md:flex-row items-start md:items-center mt-16;
+  @apply flex flex-col md:flex-row items-start md:items-center pt-8 mt-8 md:pt-12 md:mt-12 border-t border-t-gray-30;
 }
 
 .Form {

--- a/components/utilities/helpful.module.css
+++ b/components/utilities/helpful.module.css
@@ -7,13 +7,6 @@
   @apply text-gray-90 !important;
 }
 
-:global(.dark) .Title,
-:global(.dark) .ImproveTitle,
-:global(.dark) .ImproveText,
-:global(.dark) .Label {
-  @apply text-white !important;
-}
-
 .CtaContainer {
   @apply flex flex-row items-center pt-4 md:pt-0;
 }
@@ -27,18 +20,9 @@
   @apply ml-6;
 }
 
-:global(.dark) .Button {
-  @apply bg-gray-80;
-  @apply text-white !important;
-}
-
 .Icon {
   @apply text-base mr-2;
   @apply text-gray-50 !important;
-}
-
-:global(.dark) .Icon {
-  @apply text-gray-90;
 }
 
 /* How can we improve this page form step */
@@ -58,10 +42,6 @@
 
 .Input {
   @apply w-4 h-4 mr-2 checked:bg-gray-90 appearance-none border border-gray-90 rounded-sm outline-0 cursor-pointer;
-}
-
-:global(.dark) .Input {
-  @apply checked:bg-white border-white;
 }
 
 .Label {
@@ -84,4 +64,28 @@
 
 .Form {
   @apply flex-1;
+}
+
+:global(.dark) .Title,
+:global(.dark) .ImproveTitle,
+:global(.dark) .ImproveText,
+:global(.dark) .Label {
+  @apply text-white !important;
+}
+
+:global(.dark) .Button {
+  @apply bg-gray-80;
+  @apply text-white !important;
+}
+
+:global(.dark) .Icon {
+  @apply text-gray-90;
+}
+
+:global(.dark) .Input {
+  @apply checked:bg-white border-white;
+}
+
+:global(.dark) .FormContainer {
+  @apply border-gray-90;
 }

--- a/components/utilities/psa.module.css
+++ b/components/utilities/psa.module.css
@@ -1,5 +1,5 @@
 .Container {
-  @apply flex items-center flex-wrap py-8 mt-16 border-t border-b border-t-gray-30 border-b-gray-30;
+  @apply flex items-center flex-wrap;
 }
 
 :global(.dark) .Container {

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -334,6 +334,28 @@ export async function getStaticProps(context) {
 
     const { current, prev, next } = getPreviousNextFromMenu(menu, location);
 
+    // Determine which previous/next links we should be using, the override option coming from the markdown file (if it exists),
+    // or the one that gets generated automatically above by calling getPreviousNextFromMenu
+    let prevMenuItem;
+    if (data.previousLink && data.previousTitle) {
+      prevMenuItem = {
+        name: data.previousTitle,
+        url: data.previousLink,
+      };
+    } else {
+      prevMenuItem = prev;
+    }
+
+    let nextMenuItem;
+    if (data.nextLink && data.nextTitle) {
+      nextMenuItem = {
+        name: data.nextTitle,
+        url: data.nextLink,
+      };
+    } else {
+      nextMenuItem = next;
+    }
+
     props["menu"] = menu;
     props["gdpr_data"] = gdpr_data;
     props["data"] = data;
@@ -347,8 +369,8 @@ export async function getStaticProps(context) {
           isVersioned: !!current.isVersioned,
         }
       : null;
-    props["nextMenuItem"] = next ? { name: next.name, url: next.url } : null;
-    props["prevMenuItem"] = prev ? { name: prev.name, url: prev.url } : null;
+    props["prevMenuItem"] = prevMenuItem ? prevMenuItem : null;
+    props["nextMenuItem"] = nextMenuItem ? nextMenuItem : null;
   }
 
   return {

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -255,11 +255,11 @@ export default function Article({
               <FloatingNav slug={slug} menu={menu} version={version} />
               <div className={classNames("content", styles.ContentContainer)}>
                 <MDXRemote {...source} components={components} />
+                {arrowContainer}
+                <Psa />
                 <Helpful slug={slug} sourcefile={suggestEditURL} />
               </div>
             </article>
-            <Psa />
-            {arrowContainer}
           </section>
           <Footer />
         </section>


### PR DESCRIPTION
## 📚 Context

This PR addresses a few requests from @MathCatsAnd, namely:
1. Moves the pagination component a little higher in the page;
2. Allows to override the automatically generated previous and next links on a per-page basis.

## 🧠 Description of Changes

* Updated style of `arrowLink.module.css`, `helpful.module.css` and `psa.module.css` to better fit their new locations;
* Added a couple checks in `[...slug].js` to see whether there is a specific `previousLink`, `previousTitle`, `nextLink` and `nextTitle` being set at a page level, and use those instead of the automatically generated through `getPreviousNextFromMenu`

**Before:**

<img width="1713" alt="Untitled" src="https://github.com/streamlit/docs/assets/103376966/2e4ce80c-7c8a-43bc-9bef-cc646f8ba569">

**After:**

![Screenshot 2023-08-02 at 3 15 06 PM](https://github.com/streamlit/docs/assets/103376966/41f9613b-ceec-461e-8133-2414f019711c)

**How to set overrides for prev/next links:**

```md
---
title: Quickstart
slug: /streamlit-community-cloud/get-started/quickstart
nextLink: /streamlit-community-cloud/get-started/workspace
nextTitle: My nice next title
-—
```

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

## 🌐 References

* https://www.notion.so/snowflake-corp/Adjustments-to-docs-pagination-7fbb3b7a7e3d4051a44c65a1aa4f96cf?pvs=4

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
