### PR TITLE
Dont truncate sidenav titles

### DIFF
--- a/components/utilities/floatingNav.module.css
+++ b/components/utilities/floatingNav.module.css
@@ -35,7 +35,7 @@
 }
 
 .Link {
-  @apply border-none inline-block w-40 leading-4 hover:opacity-70 hover:no-underline;
+  @apply border-none inline-block pr-2 w-40 leading-4 hover:opacity-70 hover:no-underline;
   @apply text-gray-70 !important;
 }
 

--- a/components/utilities/floatingNav.module.css
+++ b/components/utilities/floatingNav.module.css
@@ -35,7 +35,7 @@
 }
 
 .Link {
-  @apply border-none inline-block truncate w-40 leading-4 hover:opacity-70 hover:no-underline;
+  @apply border-none inline-block w-40 leading-4 hover:opacity-70 hover:no-underline;
   @apply text-gray-70 !important;
 }
 


### PR DESCRIPTION
## 📚 Context

This PR fixes an issue reported by @MathCatsAnd, where right navigation titles would truncate, something we don't want them to do.

## 🧠 Description of Changes

* Removed the `truncate` Tailwind directive from `floatingNav.module.css`;
* Added a bit of padding right to ensure content does not overflow.

**Revised:**

![Screenshot 2023-08-08 at 1 27 09 PM](https://github.com/streamlit/docs/assets/103376966/bced3086-9387-4a6f-829a-dac6d6d06928)

**Current:**

![Untitled](https://github.com/streamlit/docs/assets/103376966/7a1f60cc-d8c6-4b4a-9fc0-998eea6e56c8)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- https://www.notion.so/snowflake-corp/Don-t-truncate-titles-on-right-navigation-aa67c75b61ba4205a39d13b2ae3f9c89?pvs=4

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
