### PR TITLE
Update `st.cache` migrating guide to remove lack of hash_funcs

### DIFF
--- a/content/library/advanced-features/caching.md
+++ b/content/library/advanced-features/caching.md
@@ -889,6 +889,5 @@ If your app is still using `st.cache`, don't despair! Here are a few notes on mi
 - Most parameters from `st.cache` are also present in the new commands, with a few exceptions:
   - `allow_output_mutation` does not exist anymore. You can safely delete it. Just make sure you use the right caching command for your use case.
   - `suppress_st_warning` does not exist anymore. You can safely delete it. Cached functions can now contain Streamlit commands and will replay them. If you want to use widgets inside cached functions, set `experimental_allow_widgets=True`. See [here](#using-streamlit-commands-in-cached-functions).
-  - `hash_funcs` does not exist anymore. You can exclude parameters from caching (and being hashed) by prepending them with an underscore: `_excluded_param`. See [here](#excluding-input-parameters).
 
 If you have any questions or issues during the migration process, please contact us on the [forum](https://discuss.streamlit.io/), and we will be happy to assist you. 🎈

--- a/content/library/advanced-features/caching.md
+++ b/content/library/advanced-features/caching.md
@@ -888,6 +888,6 @@ If your app is still using `st.cache`, don't despair! Here are a few notes on mi
 - Switching code to the new commands should be easy in most cases. To decide whether to use `st.cache_data` or `st.cache_resource`, read [Deciding which caching decorator to use](#deciding-which-caching-decorator-to-use). Streamlit will also recognize common use cases and show hints right in the deprecation warnings.
 - Most parameters from `st.cache` are also present in the new commands, with a few exceptions:
   - `allow_output_mutation` does not exist anymore. You can safely delete it. Just make sure you use the right caching command for your use case.
-  - `suppress_st_warning` does not exist anymore. You can safely delete it. Cached functions can now contain Streamlit commands and will replay them. If you want to use widgets inside cached functions, set `experimental_allow_widgets=True`. See [here](#using-streamlit-commands-in-cached-functions).
+  - `suppress_st_warning` does not exist anymore. You can safely delete it. Cached functions can now contain Streamlit commands and will replay them. If you want to use widgets inside cached functions, set `experimental_allow_widgets=True`. See [Input widgets](#input-widgets) for an example.
 
 If you have any questions or issues during the migration process, please contact us on the [forum](https://discuss.streamlit.io/), and we will be happy to assist you. 🎈

--- a/content/library/advanced-features/caching.md
+++ b/content/library/advanced-features/caching.md
@@ -883,7 +883,7 @@ We introduced the caching commands described above in Streamlit 1.18.0. Before t
 
 If your app is still using `st.cache`, don't despair! Here are a few notes on migrating:
 
-- `st.cache` is deprecated. • New versions of Streamlit will show a deprecation warning if your app uses it.
+- Streamlit will show a deprecation warning if your app uses `st.cache`.
 - We will not remove `st.cache` soon, so you don't need to worry about your 2-year-old app breaking. But we encourage you to try the new commands going forward – they will be way less annoying!
 - Switching code to the new commands should be easy in most cases. To decide whether to use `st.cache_data` or `st.cache_resource`, read [Deciding which caching decorator to use](#deciding-which-caching-decorator-to-use). Streamlit will also recognize common use cases and show hints right in the deprecation warnings.
 - Most parameters from `st.cache` are also present in the new commands, with a few exceptions:


### PR DESCRIPTION
## 📚 Context

<!-- Why do you want to make this change? What background should the reviewer know? -->

streamlit/streamlit#6502 reintroduced the parameter `hash_funcs` into the new caching functions which used to be available in `st.cache`. The migrating guide mentions that the parameter is no longer available, but as of  [1.24.0](https://github.com/streamlit/streamlit/releases/tag/1.24.0) that is not the case anymore.

## 🧠 Description of Changes

<!-- What was specifically changed? Which files, algorithms, links, media? -->
<!-- Please add them here as a bulleted list -->

- Removed bullet point which mentioned `hash_funcs` argument isn't available in the new caching functions

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [X] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
