### PR TITLE
Fix scrollbars on MacOS

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -19,7 +19,6 @@ Router.events.on("routeChangeError", () => NProgress.done());
 
 function StreamlitDocs({ Component, pageProps }) {
   useEffect(() => {
-    console.log(navigator);
     if (navigator.platform.includes("Mac")) {
       document.body.classList.add("mac");
     }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -19,7 +19,8 @@ Router.events.on("routeChangeError", () => NProgress.done());
 
 function StreamlitDocs({ Component, pageProps }) {
   useEffect(() => {
-    if (navigator.platform.match("Mac") === null) {
+    console.log(navigator);
+    if (navigator.platform.includes("Mac")) {
       document.body.classList.add("mac");
     }
   }, []);

--- a/styles/scrollbars.scss
+++ b/styles/scrollbars.scss
@@ -1,5 +1,5 @@
 /* Improve scrollbars on Chrome + Windows/Linux. */
-:not(.mac) {
+body:not(.mac) {
   ::-webkit-scrollbar {
     height: 6px;
     width: 6px;


### PR DESCRIPTION
## 📚 Context

This PR fixes an issue reported by @sfc-gh-tteixeira where the Algolia popup would not have its right corners rounded.

<img width="878" alt="Screenshot 2023-08-17 at 11 43 00" src="https://github.com/streamlit/docs/assets/103376966/bdf4840f-6d68-4b64-b82f-38e89ed71a94">

## 🧠 Description of Changes

The main reason for this was that some styles we added for our scrollbars, which were meant to be applied on Windows machines, were also "leaking" on Mac computers as well. The reason for this was that our code was checking for platforms that were called `Mac`, but now that Apple also has `MacIntel` platforms, we need to ensure we accommodate for both scenarios. Changes made where:
* Updated `pages/_app.js` to check if the word `Mac` is present on the `navigator.platform` prop, instead of strictly checking for it to be `Mac` only;
* Added some specificity to the `scrollbars.scss` `:not(.mac)` selector

**Revised:**

https://github.com/streamlit/docs/assets/103376966/8b82a3ae-8a5f-4a3a-b6c6-3f76aee9ddbf

**Current:**

https://github.com/streamlit/docs/assets/103376966/0ddcde60-c1fc-4aaf-a716-960e0a369b2a

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

- https://www.notion.so/snowflake-corp/Corners-in-Algolia-popup-should-be-round-84b2096022004766a3b55ff61a465702?pvs=4

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
