### PR TITLE
Update components-api.md

### DIFF
--- a/content/library/components/components-api.md
+++ b/content/library/components/components-api.md
@@ -124,14 +124,14 @@ Clone the [component-template GitHub repo](https://github.com/streamlit/componen
    # React template
    cd template
    . venv/bin/activate # or similar to activate the venv/conda environment where Streamlit is installed
-   streamlit run my_component/__init__.py # run the example
+   streamlit run my_component/example.py # run the example
 
    # or
 
    # TypeScript-only template
    cd template-reactless
    . venv/bin/activate # or similar to activate the venv/conda environment where Streamlit is installed
-   streamlit run my_component/__init__.py # run the example
+   streamlit run my_component/example.py # run the example
    ```
 
 After running the steps above, you should see a Streamlit app in your browser that looks like this:


### PR DESCRIPTION
## 📚 Context

While working on e2e setup for component-template (https://github.com/streamlit/component-template/pull/68) we extract example to separate file, so command for run example component is now invalid.

## 🧠 Description of Changes

Change command to run example from: `streamlit run my_component/__init__.py` to `streamlit run my_component/example.py` in all places

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
