### PR TITLE
Change suggestEdits text to 'Edit this page on GitHub'

### DIFF
--- a/components/utilities/suggestEdits.js
+++ b/components/utilities/suggestEdits.js
@@ -11,7 +11,7 @@ const SuggestEdits = ({ sourcefile }) => {
           target="_blank"
           rel="noopener noreferrer"
         >
-          Suggest edits
+          Edit this page on GitHub
         </a>
       </section>
     </section>


### PR DESCRIPTION
## 📚 Context

To make the purpose of the "Suggest edits" feature clearer, this PR changes the link text to "Edit this page on GitHub". The current "Suggest edits" form could be interpreted as asking users to submit feature requests, while the latter implicitly assumes the user knows what specific change to make and wants to make the change themselves (on GitHub).

Tailwind [docs](https://tailwindcss.com/docs/editor-setup#jet-brains-ides) do the same.

## 🧠 Description of Changes

- Edited the link text in `suggestEdits.js` from `Suggest edits` to `Edit this page on GitHub`.

**Revised:**

![image](https://github.com/streamlit/docs/assets/20672874/9d501c66-1fe7-4a4e-b95d-5ab4cd7d411c)

**Current:**

![image](https://github.com/streamlit/docs/assets/20672874/f3933959-578a-4d08-ac36-ec4206a19ca1)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Notion](https://www.notion.so/snowflake-corp/Docs-Suggest-edits-feature-32659feedf5d447ca6ab89dc46da4025)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
