### PR TITLE
Feature: Add scroll-based highlighting to floating TOC

### DIFF
--- a/components/utilities/floatingNav.js
+++ b/components/utilities/floatingNav.js
@@ -86,7 +86,7 @@ const useIntersectionObserver = (slug) => {
     // Create an intersection observer, to track when the links enter/leave.
     const observer = new IntersectionObserver(callback, {
       threshold: 1.0,
-      rootMargin: "0px 0px -200px 0px",
+      rootMargin: "0px 0px -90% 0px",
     });
 
     headingLinks.forEach((element) => observer.observe(element));

--- a/components/utilities/floatingNav.module.css
+++ b/components/utilities/floatingNav.module.css
@@ -15,10 +15,6 @@
   @apply absolute h-6 w-full bg-gradient-to-b from-white z-10;
 }
 
-:global(.dark) .TopGradient {
-  @apply from-gray-100;
-}
-
 /* Contents Title */
 .ListTitle {
   @apply pt-6 uppercase font-semibold tracking-widest;
@@ -26,10 +22,6 @@
 }
 
 /* Styles for the active item on the floating nav */
-:global(.dark) .activeLink {
-  @apply text-white !important;
-}
-
 .activeLink {
   @apply relative text-gray-90 font-bold transform scale-105 !important;
 }
@@ -49,15 +41,6 @@
   @apply relative border-none inline-block pr-2 w-40 leading-4 hover:opacity-70;
   @apply text-gray-70 !important;
 }
-
-/* .ListItem:first-child .Link {
-  @apply relative text-gray-90 font-bold transform scale-105 !important;
-}
-
-.ListItem:first-child .Link::before {
-  @apply absolute -left-4 top-1/4 transform scale-95 bg-gray-70 w-2 h-2 rounded-full;
-  content: '';
-} */
 
 /* Paddings for different title hierarchies */
 .List li[data-hierarchy="0"] {
@@ -86,4 +69,22 @@
 
 .List li[data-hierarchy="6"] {
   @apply pl-20;
+}
+
+/* Dark mode adjustments */
+:global(.dark) .TopGradient {
+  @apply from-gray-100;
+}
+
+:global(.dark) .ListItem .Link {
+  @apply text-gray-40 !important;
+}
+
+:global(.dark) .ListTitle,
+:global(.dark) .ListItem > .activeLink {
+  @apply text-white !important;
+}
+
+:global(.dark) .ListItem > .activeLink::before {
+  @apply bg-white;
 }

--- a/components/utilities/floatingNav.module.css
+++ b/components/utilities/floatingNav.module.css
@@ -31,13 +31,33 @@
 }
 
 .activeLink {
-  @apply text-gray-90 !important;
+  @apply relative text-gray-90 font-bold transform scale-105 !important;
+}
+
+.ListItem > .activeLink::before {
+  @apply absolute -left-4 top-1/4 transform scale-95 bg-gray-70 w-2 h-2 rounded-full;
+  content: "";
 }
 
 .Link {
-  @apply border-none inline-block pr-2 w-40 leading-4 hover:opacity-70 hover:no-underline;
+  @apply inline-block pr-2 w-40 leading-4 hover:opacity-70 hover:no-underline;
   @apply text-gray-70 !important;
 }
+
+.ListItem .Link {
+  @apply no-underline;
+  @apply relative border-none inline-block pr-2 w-40 leading-4 hover:opacity-70;
+  @apply text-gray-70 !important;
+}
+
+/* .ListItem:first-child .Link {
+  @apply relative text-gray-90 font-bold transform scale-105 !important;
+}
+
+.ListItem:first-child .Link::before {
+  @apply absolute -left-4 top-1/4 transform scale-95 bg-gray-70 w-2 h-2 rounded-full;
+  content: '';
+} */
 
 /* Paddings for different title hierarchies */
 .List li[data-hierarchy="0"] {


### PR DESCRIPTION
## 📚 Context

Improving the user experience is paramount. With many  pages having a long list of content, it's often helpful for users to have a visual cue on their progress through the content. This enhancement is designed to provide a dynamic highlight in the floatingNav on the right as users scroll through the page.

## 🧠 Description of Changes

- Adjusted the intersection observer's root margin to better detect when headings are at the viewport's center in `floatingNav.js.`
- Modified CSS styling for `.activeLink` to give a prominent visual cue. This involves text bolding, a subtle scaling effect, and an accompanying circle to highlight the active link.

https://github.com/streamlit/docs/assets/20672874/03eac5e7-eeba-4ea6-938a-42c8a1bd57ba

**Revised:**

![image](https://github.com/streamlit/docs/assets/20672874/57381b34-4b8e-4ed9-9c86-96e292ca00f0)

**Current:**

![image](https://github.com/streamlit/docs/assets/20672874/6c2ff3b0-09a5-4a24-837f-84dad060881a)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
