### PR TITLE
Supported Python versions in Community Cloud

### DIFF
--- a/content/streamlit-cloud/deploy-your-app/index.md
+++ b/content/streamlit-cloud/deploy-your-app/index.md
@@ -57,7 +57,7 @@ Although you can deploy multiple apps from the same repository, there can be onl
 
 <Note>
 
-Streamlit Community Cloud supports all released [versions of Python](https://devguide.python.org/versions/) that are still receiving security updates. Streamlit Community Cloud defaults to version 3.9. You can select a version of your choice from the "Python version" dropdown in the "Advanced settings" modal. If an app is running a version of Python that becomes unsupported, it will be forcibly upgraded to oldest, supported version of Python and may break.
+Streamlit Community Cloud supports all released [versions of Python that are still receiving security updates](https://devguide.python.org/versions/). Streamlit Community Cloud defaults to version 3.9. You can select a version of your choice from the "Python version" dropdown in the "Advanced settings" modal. If an app is running a version of Python that becomes unsupported, it will be forcibly upgraded to oldest, supported version of Python and may break.
 
 </Note>
 

--- a/content/streamlit-cloud/deploy-your-app/index.md
+++ b/content/streamlit-cloud/deploy-your-app/index.md
@@ -55,15 +55,15 @@ Although you can deploy multiple apps from the same repository, there can be onl
 
 ## Advanced settings for deployment
 
+<Note>
+
+Streamlit Community Cloud supports all released [versions of Python](https://devguide.python.org/versions/) that are still receiving security updates. Streamlit Community Cloud defaults to version 3.9. You can select a version of your choice from the "Python version" dropdown in the "Advanced settings" modal. If an app is running a version of Python that becomes unsupported, it will be forcibly upgraded to oldest, supported version of Python and may break.
+
+</Note>
+
 3. (Optional) If you are connecting to a data source or want to specify the Python version for your app, you can do that by clicking "**Advanced settings**" before you deploy the app. Learn more about [Secrets management](/streamlit-community-cloud/deploy-your-app/secrets-management).
 
    ![Advanced settings for deploying your app](/images/streamlit-community-cloud/deploy-an-app-advanced.png)
-
-<Tip>
-
-Streamlit Community Cloud supports Python 3.8 - Python 3.11, and defaults to version 3.9. You can select a version of your choice from the "Python version" dropdown in the "Advanced settings" modal.
-
-</Tip>
 
 ## Watch your app launch
 


### PR DESCRIPTION
## 📚 Context
Add clarification about what versions of Python are supported in Community Cloud.

## 🧠 Description of Changes
Explained that supported versions of Python were tied to security updates and that apps are forcibly upgraded if running on a version of Python that becomes unsupported.

## 💥 Impact
Size: Small

## 🌐 References
Notion task: [Update Community Cloud Python support](https://www.notion.so/snowflake-corp/Update-Community-Cloud-Python-support-8b7287a386374537ba26e67c103fb875?pvs=4)

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.