### PR TITLE
Add warnings about pickle and create security reminders page

### DIFF
--- a/content/library/advanced-features/caching.md
+++ b/content/library/advanced-features/caching.md
@@ -104,6 +104,12 @@ How does this work? Let's go through the behavior of `st.cache_data` step by ste
 
 This process of serializing and deserializing the cached object creates a copy of our original DataFrame. While this copying behavior may seem unnecessary, it's what we want when caching data objects since it effectively prevents mutation and concurrency issues. Read the section “[Mutation and concurrency issues](#mutation-and-concurrency-issues)" below to understand this in more detail.
 
+<Warning>
+
+`st.cache_data` implicitly uses the `pickle` module, which is known to be insecure. Anything your cached function returns is pickled and stored, then unpickled on retrieval. Ensure your cached functions return trusted values because it is possible to construct malicious pickle data that will execute arbitrary code during unpickling. Never load data that could have come from an untrusted source in an unsafe mode or that could have been tampered with. **Only load data you trust**.
+
+</Warning>
+
 #### Examples
 
 <br/>

--- a/content/library/advanced-features/security-reminders.md
+++ b/content/library/advanced-features/security-reminders.md
@@ -19,7 +19,7 @@ If you use any sensitive or private information during development, make sure th
 
 ## Pickle warning
 
-Streamlit uses the pickle module implicitly, which is known to be insecure. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling. Never load data that could have come from an untrusted source in an unsafe mode, or that could have been tampered with. Only load data you trust.
+Streamlit's [`st.cache_data`](/library/advanced-features/caching#stcache_data) and [`st.session_state`](/library/advanced-features/session-state#serializable-session-state) implicitly use the `pickle` module, which is known to be insecure. It is possible to construct malicious pickle data that will execute arbitrary code during unpickling. Never load data that could have come from an untrusted source in an unsafe mode or that could have been tampered with. **Only load data you trust**.
 
-- When using `st.cache_data`, anything returned by your function is pickled and stored, then unpickled on retrieval. Ensure your cached functions return trusted values. This also applies to `st.cache` (deprecated).
-- When `runner.enforceSerializableSessionState` set to true, ensure all data saved and retrieved from Session State is trusted.
+- When using `st.cache_data`, anything your function returns is pickled and stored, then unpickled on retrieval. Ensure your cached functions return trusted values. This warning also applies to [`st.cache`](/library/api-reference/performance/st.cache) (deprecated).
+- When the `runner.enforceSerializableSessionState` [configuration option](<(/library/advanced-features/configuration#runner)>) is set to `true`, ensure all data saved and retrieved from Session State is trusted.

--- a/content/library/advanced-features/security-reminders.md
+++ b/content/library/advanced-features/security-reminders.md
@@ -1,0 +1,25 @@
+---
+title: Security reminders
+slug: /library/advanced-features/security-reminders
+---
+
+# Security reminders
+
+## Protect your secrets
+
+Never save usernames, passwords, or security keys directly in your code or commit them to your repository.
+
+### Use environment variables
+
+Avoid putting sensitve information in your code by using environment variables. Be sure to check out [`st.secrets`](/library/advanced-features/secrets-management). Research any platform you use to follow their security best practices. If you use Streamlit Community Cloud, [Secrets management](/streamlit-community-cloud/deploy-your-app/secrets-management) allows you save environment variables and store secrets outside of your code.
+
+### Keep `.gitignore` updated
+
+If you use any sensitive or private information during development, make sure that information is saved in separate files from your code. Ensure `.gitginore` is properly configured to prevent saving private information to your repository.
+
+## Pickle warning
+
+Streamlit uses the pickle module implicitly, which is known to be insecure. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling. Never load data that could have come from an untrusted source in an unsafe mode, or that could have been tampered with. Only load data you trust.
+
+- When using `st.cache_data`, anything returned by your function is pickled and stored, then unpickled on retrieval. Ensure your cached functions return trusted values. This also applies to `st.cache` (deprecated).
+- When `runner.enforceSerializableSessionState` set to true, ensure all data saved and retrieved from Session State is trusted.

--- a/content/library/advanced-features/session-state.md
+++ b/content/library/advanced-features/session-state.md
@@ -276,7 +276,7 @@ Serialization refers to the process of converting an object or data structure in
 
 By default, Streamlit’s [Session State](/library/advanced-features/session-state) allows you to persist any Python object for the duration of the session, irrespective of the object’s pickle-serializability. This property lets you store Python primitives such as integers, floating-point numbers, complex numbers and booleans, dataframes, and even [lambdas](https://docs.python.org/3/reference/expressions.html#lambda) returned by functions. However, some execution environments may require serializing all data in Session State, so it may be useful to detect incompatibility during development, or when the execution environment will stop supporting it in the future.
 
-To that end, Streamlit provides a `runner.enforceSerializableSessionState` [configuration option](https://docs.streamlit.io/library/advanced-features/configuration) that, when set to `true`, only allows pickle-serializable objects in Session State. To enable the option, either create a global or project config file with the following or use it as a command-line flag:
+To that end, Streamlit provides a `runner.enforceSerializableSessionState` [configuration option](/library/advanced-features/configuration) that, when set to `true`, only allows pickle-serializable objects in Session State. To enable the option, either create a global or project config file with the following or use it as a command-line flag:
 
 ```toml
 # .streamlit/config.toml
@@ -297,6 +297,12 @@ st.session_state.unserializable = unserializable_data()
 ```
 
 <Image alt="UnserializableSessionStateError" src="/images/unserializable-session-state-error.png" clean />
+
+<Warning>
+
+When `runner.enforceSerializableSessionState` is set to `true`, Session State implicitly uses the `pickle` module, which is known to be insecure. Ensure all data saved and retrieved from Session State is trusted because it is possible to construct malicious pickle data that will execute arbitrary code during unpickling. Never load data that could have come from an untrusted source in an unsafe mode or that could have been tampered with. **Only load data you trust**.
+
+</Warning>
 
 ### Caveats and limitations
 

--- a/content/library/api/performance/cache-data.md
+++ b/content/library/api/performance/cache-data.md
@@ -11,6 +11,12 @@ This page only contains information on the `st.cache_data` API. For a deeper div
 
 <Autofunction function="streamlit.cache_data" />
 
+<Warning>
+
+`st.cache_data` implicitly uses the `pickle` module, which is known to be insecure. Anything your cached function returns is pickled and stored, then unpickled on retrieval. Ensure your cached functions return trusted values because it is possible to construct malicious pickle data that will execute arbitrary code during unpickling. Never load data that could have come from an untrusted source in an unsafe mode or that could have been tampered with. **Only load data you trust**.
+
+</Warning>
+
 ## Using Streamlit commands in cached functions
 
 ### Static elements

--- a/content/library/api/performance/cache.md
+++ b/content/library/api/performance/cache.md
@@ -28,3 +28,9 @@ For more information about the Streamlit cache, its configuration parameters,
 and its limitations, see [Caching](/library/advanced-features/caching).
 
 <Autofunction function="streamlit.cache" deprecated={true} deprecatedText="<code>st.cache</code> was deprecated in version 1.18.0. Use <a href='/library/api-reference/performance/st.cache_data'><code>st.cache_data</code></a> or <a href='/library/api-reference/performance/st.cache_resource'><code>st.cache_resource</code></a> instead. Learn more in <a href='/library/advanced-features/caching'>Caching</a>."/>
+
+<Warning>
+
+`st.cache` implicitly uses the `pickle` module, which is known to be insecure. Anything your cached function returns is pickled and stored, then unpickled on retrieval. Ensure your cached functions return trusted values because it is possible to construct malicious pickle data that will execute arbitrary code during unpickling. Never load data that could have come from an untrusted source in an unsafe mode or that could have been tampered with. **Only load data you trust**.
+
+</Warning>

--- a/content/library/api/state/state.md
+++ b/content/library/api/state/state.md
@@ -144,6 +144,40 @@ with st.form(key='my_form'):
     submit_button = st.form_submit_button(label='Submit', on_click=form_callback)
 ```
 
+### Serializable Session State
+
+Serialization refers to the process of converting an object or data structure into a format that can be persisted and shared, and allowing you to recover the data’s original structure. Python’s built-in [pickle](https://docs.python.org/3/library/pickle.html) module serializes Python objects to a byte stream ("pickling") and deserializes the stream into an object ("unpickling").
+
+By default, Streamlit’s [Session State](/library/advanced-features/session-state) allows you to persist any Python object for the duration of the session, irrespective of the object’s pickle-serializability. This property lets you store Python primitives such as integers, floating-point numbers, complex numbers and booleans, dataframes, and even [lambdas](https://docs.python.org/3/reference/expressions.html#lambda) returned by functions. However, some execution environments may require serializing all data in Session State, so it may be useful to detect incompatibility during development, or when the execution environment will stop supporting it in the future.
+
+To that end, Streamlit provides a `runner.enforceSerializableSessionState` [configuration option](/library/advanced-features/configuration) that, when set to `true`, only allows pickle-serializable objects in Session State. To enable the option, either create a global or project config file with the following or use it as a command-line flag:
+
+```toml
+# .streamlit/config.toml
+[runner]
+enforceSerializableSessionState = true
+```
+
+By "_pickle-serializable_", we mean calling `pickle.dumps(obj)` should not raise a [`PicklingError`](https://docs.python.org/3/library/pickle.html#pickle.PicklingError) exception. When the config option is enabled, adding unserializable data to session state should result in an exception. E.g.,
+
+```python
+import streamlit as st
+
+def unserializable_data():
+		return lambda x: x
+
+#👇 results in an exception when enforceSerializableSessionState is on
+st.session_state.unserializable = unserializable_data()
+```
+
+<Image alt="UnserializableSessionStateError" src="/images/unserializable-session-state-error.png" clean />
+
+<Warning>
+
+When `runner.enforceSerializableSessionState` is set to `true`, Session State implicitly uses the `pickle` module, which is known to be insecure. Ensure all data saved and retrieved from Session State is trusted because it is possible to construct malicious pickle data that will execute arbitrary code during unpickling. Never load data that could have come from an untrusted source in an unsafe mode or that could have been tampered with. **Only load data you trust**.
+
+</Warning>
+
 ### Caveats and limitations
 
 - Only the `st.form_submit_button` has a callback in forms. Other widgets inside a form are not allowed to have callbacks.

--- a/content/menu.md
+++ b/content/menu.md
@@ -421,6 +421,8 @@ site_menu:
     url: /library/advanced-features/https-support
   - category: Streamlit library / Advanced features/ Secrets management
     url: /library/advanced-features/secrets-management
+  - category: Streamlit library / Advanced features/ Security reminders
+    url: /library/advanced-features/security-reminders
   - category: Streamlit library / Components
     url: /library/components
   - category: Streamlit library / Components / Components API


### PR DESCRIPTION
## 📚 Context
Pickle is used for serialization and is known to be insecure. A warning was added to clarify proper practices.

## 💥 Impact
Size: Not small

## 🌐 References
Notion task: [Add pickle security warning](https://www.notion.so/snowflake-corp/Add-Pickle-security-warning-d41f9c922af1480084c1bfa90eda8fb6?pvs=4)

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
