### PR TITLE
Explaining widget behavior

### DIFF
--- a/content/library/advanced-features/advanced-widget-behavior.md
+++ b/content/library/advanced-features/advanced-widget-behavior.md
@@ -5,7 +5,7 @@ slug: /library/advanced-features/widget-behavior
 
 # Understanding widget behavior
 
-Widgets are magical and often work how you want. But they can have surprising behavior in some situations. Understanding the different parts of a widget and the precise order in which events occur helps you achieve your desired results.
+Widgets are at the heart of Streamlit apps. They are the interactive elements of Streamlit that pass information from your users into your Python code. Widgets are magical and often work how you want. But they can have surprising behavior in some situations. Understanding the different parts of a widget and the precise order in which events occur helps you achieve your desired results.
 
 <Collapse title="🎈 TL;DR" expanded={false}>
 

--- a/content/library/advanced-features/advanced-widget-behavior.md
+++ b/content/library/advanced-features/advanced-widget-behavior.md
@@ -7,6 +7,8 @@ slug: /library/advanced-features/widget-behavior
 
 Widgets are at the heart of Streamlit apps. They are the interactive elements of Streamlit that pass information from your users into your Python code. Widgets are magical and often work how you want. But they can have surprising behavior in some situations. Understanding the different parts of a widget and the precise order in which events occur helps you achieve your desired results.
 
+This guide covers advanced concepts about widgets. For most beginning users, these details won't be important to know right away. When you want to dynamically change widgets or preserve widget information between pages, these concepts will be important to understand.
+
 <Collapse title="🎈 TL;DR" expanded={false}>
 
 1. If you call a widget function before the widget state exists, the widget state defaults to a value. This value depends on the widget and its arguments.

--- a/content/library/advanced-features/advanced-widget-behavior.md
+++ b/content/library/advanced-features/advanced-widget-behavior.md
@@ -5,7 +5,19 @@ slug: /library/advanced-features/widget-behavior
 
 # Understanding widget behavior
 
-Widgets are magical and often work how you want. But they can have surprising behavior in some situations. Understanding the different parts of a widget and the precise order in which events occur helps achieve desired results.
+Widgets are magical and often work how you want. But they can have surprising behavior in some situations. Understanding the different parts of a widget and the precise order in which events occur helps you achieve your desired results.
+
+<Collapse title="🎈 TL;DR" expanded={false}>
+
+1. If you call a widget function before the widget state exists, the widget state defaults to a value. This value depends on the widget and its arguments.
+2. A widget function call returns the current widget state value. The return value is a simple Python type, and the exact type depends on the widget and its arguments.
+3. Widget states depend on a particular session (browser connection). The actions of one user do not affect the widgets of any other user.
+4. A widget's identity depends on the arguments passed to the widget function. If those change, the call will create a new widget (with a default value, per 1).
+5. If you don't call a widget function in a script run, we neither store the widget state nor render the widget. If you call a widget function with the same arguments later, Streamlit treats it as a new widget.
+
+4 and 5 are the most likely to be surprising and may pose a problem for some application designs. When you want to persist widget state for recreating a widget, use [Session State](/library/api-reference/session-state) to work around 5.
+
+</Collapse>
 
 ## Anatomy of a widget
 
@@ -203,6 +215,7 @@ When Streamlit gets to the end of a script run, it will delete the data for any 
 ## Additional examples
 
 As promised, let's address how to retain statefulness of widgets when changing pages or modifying their parameters. There are two ways to do this.
+
 1. Use dummy keys to duplicate widget values in `st.session_state` and protect the data from being deleted along with the widget.
 2. Interrupt the widget clean-up process.
 
@@ -216,7 +229,7 @@ To retain information for a widget with `key="my_key"`, just add this to the top
 st.session_state.my_key = st.session_state.my_key
 ```
 
-When you manually save data to a key in `st.session_state`, it will become detached from any widget as far as the clean-up process is concerned. If you navigate away from a widget with some key `"my_key"` and save data to `st.session_state.my_key` on the new page, you will interrupt the widget clean-up process and prevent the key-value pair from being deleted or overwritten if another widget with the same key exists. 
+When you manually save data to a key in `st.session_state`, it will become detached from any widget as far as the clean-up process is concerned. If you navigate away from a widget with some key `"my_key"` and save data to `st.session_state.my_key` on the new page, you will interrupt the widget clean-up process and prevent the key-value pair from being deleted or overwritten if another widget with the same key exists.
 
 ### Retain statefulness when changing a widget's parameters
 

--- a/content/library/advanced-features/advanced-widget-behavior.md
+++ b/content/library/advanced-features/advanced-widget-behavior.md
@@ -112,11 +112,11 @@ st.slider("With default, with key", minimum, maximum, value=5, key="b")
 
 #### Updating a slider with no default value
 
-For the first two sliders above, as soon as the min or max value is changed, the sliders reset to the min value. The changing of the min or max value makes it a "new" widget from Streamlit's perspective and so it is recreated from scratch when the app reruns with the changed parameter. Since no default value is defined, the widget will reset to its min value. This is the same with or without a key since it's seen as a new widget either way. There is a subtle point to understand about pre-existing keys connecting to widgets. This will be explained further down in [Widget life cycle](#widget-life-cycle).
+For the first two sliders above, as soon as the min or max value is changed, the sliders reset to the min value. The changing of the min or max value makes them "new" widgets from Streamlit's perspective and so they are recreated from scratch when the app reruns with the changed parameters. Since no default value is defined, each widget will reset to its min value. This is the same with or without a key since it's seen as a new widget either way. There is a subtle point to understand about pre-existing keys connecting to widgets. This will be explained further down in [Widget life cycle](#widget-life-cycle).
 
 #### Updating a slider with a default value
 
-For the last two sliders above, a change to the min or max value will result in the widget being seen as "new" and thus recreated like before. Since a default value of 5 is defined, the widget will reset to 5 whenever the min or max is changed. This is again the same (with or without a key).
+For the last two sliders above, a change to the min or max value will result in the widgets being seen as "new" and thus recreated like before. Since a default value of 5 is defined, each widget will reset to 5 whenever the min or max is changed. This is again the same (with or without a key).
 
 A solution to [Retain statefulness when changing a widget's parameters](#retain-statefulness-when-changing-a-widgets-parameters) is provided further on.
 

--- a/content/library/advanced-features/advanced-widget-behavior.md
+++ b/content/library/advanced-features/advanced-widget-behavior.md
@@ -13,9 +13,9 @@ This guide covers advanced concepts about widgets. Generally, it begins with sim
 
 1. The actions of one user do not affect the widgets of any other user.
 2. A widget function call returns the widget's current value, which is a simple Python type. (e.g. `st.button` returns a boolean value.)
-3. Widgets return default values on first call, before a user interacts with them.
+3. Widgets return their default values on their first call before a user interacts with them.
 4. A widget's identity depends on the arguments passed to the widget function. Changing a widget's label, min or max value, default value, placeholder text, help text, or key will cause it to reset.
-5. If you don't call a widget function in a script run, Streamlit will delete the widget's information&mdash;_including key-value pair in Session State_. If you call the same widget function later, Streamlit treats it as a new widget.
+5. If you don't call a widget function in a script run, Streamlit will delete the widget's information&mdash;_including its key-value pair in Session State_. If you call the same widget function later, Streamlit treats it as a new widget.
 
 The last two points (widget identity and widget deletion) are the most relevant when dynamically changing widgets or working with multi-page applications. This is covered in detail later in this guide: [Statefulness of widgets](#statefulness-of-widgets) and [Widget life cycle](#widget-life-cycle).
 
@@ -140,7 +140,7 @@ A solution to [Retain statefulness when changing a widget's parameters](#retain-
 
 ### Widgets do not persist when not continually rendered
 
-If a widget's function is not called during a script run, then none of its parts will be retained, including its value in `st.session_state`. If a widget has a key and you navigate away from that widget, its key and associated value in `st.session_state` will be deleted. Even temporarily hiding a widget will cause it to reset when it reappears; Streamlit will treat it like a new widget. You can either interrupt the [Widget cleanup process](#widget-cleanup-process) (described at the end of this page) or save the value to another key.
+If a widget's function is not called during a script run, then none of its parts will be retained, including its value in `st.session_state`. If a widget has a key and you navigate away from that widget, its key and associated value in `st.session_state` will be deleted. Even temporarily hiding a widget will cause it to reset when it reappears; Streamlit will treat it like a new widget. You can either interrupt the [Widget clean-up process](#widget-clean-up-process) (described at the end of this page) or save the value to another key.
 
 #### Save widget values in Session State to preserve them between pages
 
@@ -177,15 +177,15 @@ st.number_input("Number of filters", key="_my_key", on_change=save_value, args="
 
 When a widget function is called, Streamlit will check if it already has a widget with the same parameters. Streamlit will reconnect if it thinks the widget already exists. Otherwise, it will make a new one.
 
-As mentioned earlier, Streanlit determines a widget's ID is based on parameters such as label, min or max value, default value, placeholder text, help text, and key. The page name also factors in to a widget's ID. On the other hand, callback functions, callback args and kwargs, label visibility, and disabling a widget do not affect a widget's identity.
+As mentioned earlier, Streamlit determines a widget's ID based on parameters such as label, min or max value, default value, placeholder text, help text, and key. The page name also factors into a widget's ID. On the other hand, callback functions, callback args and kwargs, label visibility, and disabling a widget do not affect a widget's identity.
 
 ### Calling a widget function when the widget doesn't already exist
 
 If your script rerun calls a widget function with changed parameters or calls a widget function that wasn't used on the last script run:
 
 1. Streamlit will build the frontend and backend parts of the widget.
-2. If the widget has been assigned a key, Streamlit will check if that key already exists in session state.  
-   a. If it exists and is not currently associated to another widget, Streamlit will attach to that key and take on its value for the widget.  
+2. If the widget has been assigned a key, Streamlit will check if that key already exists in Session State.  
+   a. If it exists and is not currently associated with another widget, Streamlit will attach to that key and take on its value for the widget.  
    b. Otherwise, it will assign the default value to the key in `st.session_state` (creating a new key-value pair or overwriting an existing one).
 3. If there are args or kwargs for a callback function, they are computed and saved at this point in time.
 4. The default value is then returned by the function.
@@ -214,13 +214,13 @@ When rerunning a script without changing a widget's parameters:
 2. If the widget has a key that was deleted from `st.session_state`, then Streamlit will recreate the key using the current frontend value. (e.g Deleting a key will not revert the widget to a default value.)
 3. It will return the current value of the widget.
 
-### Widget cleanup process
+### Widget clean-up process
 
-When Streamlit gets to the end of a script run, it will delete the data for any widgets it has in memory that were not rendered on the screen. Most importantly, that means Streamlit will delete all key-value pairs in `st.session_state` associated to a widget not currently on screen.
+When Streamlit gets to the end of a script run, it will delete the data for any widgets it has in memory that were not rendered on the screen. Most importantly, that means Streamlit will delete all key-value pairs in `st.session_state` associated with a widget not currently on screen.
 
 ## Additional examples
 
-As promised, let's address how to retain statefulness of widgets when changing pages or modifying their parameters. There are two ways to do this.
+As promised, let's address how to retain the statefulness of widgets when changing pages or modifying their parameters. There are two ways to do this.
 
 1. Use dummy keys to duplicate widget values in `st.session_state` and protect the data from being deleted along with the widget.
 2. Interrupt the widget clean-up process.
@@ -266,4 +266,4 @@ st.slider("A", minimum, maximum, key="a")
 
 <Cloud src="https://doc-guide-widgets-change-parameters-solution.streamlit.app/?embed=true" height="250"/>
 
-The `update_value()` helper function is actually doing two things. On the surface, it's making sure there are no inconsistent changes to the parameters values as described. Importantly however, it's interrupting the widget clean-up process. When the min or max value of the widget changes, Streamlit sees it as a new widget on rerun. Without saving a value to `st.session_state.a`, the value would be thrown out and replaced by the "new" widget's default value.
+The `update_value()` helper function is actually doing two things. On the surface, it's making sure there are no inconsistent changes to the parameters values as described. Importantly, it's also interrupting the widget clean-up process. When the min or max value of the widget changes, Streamlit sees it as a new widget on rerun. Without saving a value to `st.session_state.a`, the value would be thrown out and replaced by the "new" widget's default value.

--- a/content/library/advanced-features/advanced-widget-behavior.md
+++ b/content/library/advanced-features/advanced-widget-behavior.md
@@ -89,7 +89,7 @@ with st.form(key="my_form"):
 
 ## Statefulness of widgets
 
-As long as the defining parameters of a widget remain the same and that widget is continuously rendered on the frontend, then it will be stateful.
+As long as the defining parameters of a widget remain the same and that widget is continuously rendered on the frontend, then it will be stateful and remember user input.
 
 ### Changing parameters of a widget will reset it
 
@@ -112,11 +112,11 @@ st.slider("With default, with key", minimum, maximum, value=5, key="b")
 
 #### Updating a slider with no default value
 
-As soon as the min or max value is changed, the slider will reset to the min value. The changing of the min or max value makes it a "new" widget from Streamlit's perspective and so it is recreated from scratch when the app reruns with the changed parameter. Since no default value is defined, the widget will reset to its min value. This is the same with or without a key since it's seen as a new widget either way. There is a subtle point to understand about pre-existing keys connecting to widgets. This will be explained further down in [Widget life cycle](#widget-life-cycle).
+For the first two sliders above, as soon as the min or max value is changed, the sliders reset to the min value. The changing of the min or max value makes it a "new" widget from Streamlit's perspective and so it is recreated from scratch when the app reruns with the changed parameter. Since no default value is defined, the widget will reset to its min value. This is the same with or without a key since it's seen as a new widget either way. There is a subtle point to understand about pre-existing keys connecting to widgets. This will be explained further down in [Widget life cycle](#widget-life-cycle).
 
 #### Updating a slider with a default value
 
-As with the previous case, a change to the min or max value will result in the widget being seen as "new" and thus recreated. Since a default value of 5 is defined, the widget will reset to 5 whenever the min or max is changed. This is again the same with or without a key and the same subtle point applies.
+For the last two sliders above, a change to the min or max value will result in the widget being seen as "new" and thus recreated like before. Since a default value of 5 is defined, the widget will reset to 5 whenever the min or max is changed. This is again the same (with or without a key).
 
 A solution to [Retain statefulness when changing a widget's parameters](#retain-statefulness-when-changing-a-widgets-parameters) is provided further on.
 
@@ -159,7 +159,7 @@ st.number_input("Number of filters", key="_my_key", on_change=save_value, args="
 
 When a widget function is called, Streamlit will check if it already has a widget with the same parameters. Streamlit will reconnect if it thinks the widget already exists. Otherwise, it will make a new one.
 
-As mentioned earlier, Streanlit determines a widget's ID is based on parameters such as label, min or max value, default value, placeholder text, help text, and key. The page name also factors in to a widget's ID. On the other hand, callback functions, callback args and kwargs, disabling options, and label visibility do not affect a widget's identity.
+As mentioned earlier, Streanlit determines a widget's ID is based on parameters such as label, min or max value, default value, placeholder text, help text, and key. The page name also factors in to a widget's ID. On the other hand, callback functions, callback args and kwargs, label visibility, and disabling a widget do not affect a widget's identity.
 
 ### Calling a widget function when the widget doesn't already exist
 
@@ -168,7 +168,7 @@ If your script rerun calls a widget function with changed parameters or calls a 
 1. Streamlit will build the frontend and backend parts of the widget.
 2. If the widget has been assigned a key, Streamlit will check if that key already exists in session state.  
    a. If it exists and is not currently associated to another widget, Streamlit will attach to that key and take on its value for the widget.  
-   b. Otherwise, it will assign the default value to the key in `st.session_state`.
+   b. Otherwise, it will assign the default value to the key in `st.session_state` (creating a new key-value pair or overwriting an existing one).
 3. If there are args or kwargs for a callback function, they are computed and saved at this point in time.
 4. The default value is then returned by the function.
 

--- a/content/library/advanced-features/advanced-widget-behavior.md
+++ b/content/library/advanced-features/advanced-widget-behavior.md
@@ -5,7 +5,7 @@ slug: /library/advanced-features/widget-behavior
 
 # Understanding widget behavior
 
-Widgets are at the heart of Streamlit apps. They are the interactive elements of Streamlit that pass information from your users into your Python code. Widgets are magical and often work how you want. But they can have surprising behavior in some situations. Understanding the different parts of a widget and the precise order in which events occur helps you achieve your desired results.
+Widgets are at the heart of Streamlit apps. They are the interactive elements of Streamlit that pass information from your users into your Python code. Widgets are magical and often work how you want, but they can have surprising behavior in some situations. Understanding the different parts of a widget and the precise order in which events occur helps you achieve your desired results.
 
 This guide covers advanced concepts about widgets. For most beginning users, these details won't be important to know right away. When you want to dynamically change widgets or preserve widget information between pages, these concepts will be important to understand.
 

--- a/content/library/advanced-features/advanced-widget-behavior.md
+++ b/content/library/advanced-features/advanced-widget-behavior.md
@@ -5,109 +5,47 @@ slug: /library/advanced-features/widget-behavior
 
 # Understanding widget behavior
 
-Widgets are magical and often work how you want. But they can have surprising behavior in some situations. Understanding the different parts of a widget and the precise order in which events occur is helpful for achieving desired results.
+Widgets are magical and often work how you want. But they can have surprising behavior in some situations. Understanding the different parts of a widget and the precise order in which events occur helps achieve desired results.
 
 ## Anatomy of a widget
 
-There are four parts to every widget:
+There are four parts to keep in mind when using widgets:
 
 1. The frontend component as seen by the user.
 2. The backend value or value as seen through `st.session_state`.
-3. The return value given by the widget's function.
-4. The key of the widget used to access its value via `st.session_state`.
+3. The key of the widget used to access its value via `st.session_state`.
+4. The return value given by the widget's function.
 
-### Session dependence
+### Widgets are session dependent
 
-These parts are dependent on a particular session (browser connection). The actions of one user do not affect the widgets of any other user. Furthermore, if a user opens up multiple tabs to access an app, then each tab will be a unique session. Hence, changing a widget in one tab will not affect the same widget in another tab.
+Widget states are dependent on a particular session (browser connection). The actions of one user do not affect the widgets of any other user. Furthermore, if a user opens up multiple tabs to access an app, each tab will be a unique session. Changing a widget in one tab will not affect the same widget in another tab.
 
-### Data types
+### Widgets return simple Python data types
 
-The backend value (as seen through `st.session_state`) and the return value of a widget are of simple Python types. For example, `st.button` returns a boolean value and will have the same boolean value saved in `st.session_state`.
+The value of a widget as seen through `st.session_state` and returned by the widget function are of simple Python types. For example, `st.button` returns a boolean value and will have the same boolean value saved in `st.session_state` if using a key.
 
-### Widget keys
+### Keys help distinguish widgets and access their values
 
 Widget keys serve two purposes:
 
 1. Distinguishing two otherwise identical widgets.
-2. Creating a means to access and manipulate the widget's value through
-   `st.session_state`.
+2. Creating a means to access and manipulate the widget's value through `st.session_state`.
 
-A widget's identity depends on the arguments passed to the widget function. If you have two widgets of the same type with the same arguments, you will get a `DuplicateWidgetID` error. In this case, you will need to assign unique keys to the two widgets.
+Whenever possible, Streamlit updates widgets incrementally on the frontend instead of rebuilding them with each rerun. This means Streamlit assigns an ID to each widget from the arguments passed to the widget function. A widget's ID is based on parameters such as label, min or max value, default value, placeholder text, help text, and key. The page where the widget appears also factors into a widget's ID. If you have two widgets of the same type with the same arguments on the same page, you will get a `DuplicateWidgetID` error. In this case, assign unique keys to the two widgets.
 
-### Persistence
-
-If a widget's function is not called during a script run, then none of its parts will be retained, including its value in `st.session_state`. If you have assigned a key to a widget and you navigate away from that widget, its key and associated value in `st.session_state` will be deleted. Even temporarily hiding a widget will cause it to reset when it reappears; Streamlit will treat it like a new widget.
-
-### Statefulness
-
-As long as the defining parameters of a widget remain the same and that widget is continuously rendered on the frontend, then it will be stateful. If any of the defining parameters of a widget change, Streamlit will see it as a new widget and it will reset. The use of manually assigned keys and default values is particularly important in this case.
-
-In this example, we have a slider with whose min and max values are changed. Try setting values on the slider and changing the min or max values to see how each behaves.
+#### Streamlit can't understand two identical widgets on the same page
 
 ```python
-import streamlit as st
-
-cols = st.columns([2,1,2])
-minimum = cols[0].number_input('Minimum', 1, 5)
-maximum = cols[2].number_input('Maximum', 6, 10, 10)
-
-st.slider('No default, no key', minimum, maximum)
-
-st.slider('With default, no key', minimum, maximum, value=5)
-
-st.slider('No default, with key', minimum, maximum, key='a')
-
-st.slider('With default, with key', minimum, maximum, value=5, key='b')
+# This will cause a DuplicateWidgetID error.
+st.button("OK")
+st.button("OK")
 ```
 
-#### No default, no key
-
-As soon as the min or max value is changed, the slider will reset to the minimum value. The changing of the min or max value makes it a "new" widget from Streamlit's perspective and so it is recreated with the default value equal to the minimum value since it is not defined otherwise.
-
-#### With default, no key
-
-As with the previous case, a change to the min or max value will result in the widget being seen as "new" and thus recreated. Since a default value of 5 is defined, the widget will reset to 5 whenever the min or max is changed.
-
-#### No default, with key
-
-This is closer to expected behavior. Since the widget has a key, Streamlit has a way of reconnecting the state of the widget even with a change in min or max value that would otherwise make the widget be treated as "new." In this case, the change in min and max does cause the widget to be reconstructed, but the existence of the key in `st.session_state` with an assigned value causes the new widget's state to be overwritten from its otherwise default value. This example is not perfect though; try this:
-
-1. Set the slider to a value of 10.
-2. Reduce the max to 9.
-3. See the slider still appear to have a value of 10.
-4. Set the slider to a value less than 10.
-5. See the max of the slider update to 9.
-   The value of the slider in `st.session_state` can become invalid if the current selection becomes out-of-range through an update of min or max. A corrected example follows this one.
-
-#### With default, with key
-
-This is a tricky case. The default value and key are at odds.The default value trumps the value in `st.session_state` and the slider behaves the same as "With default, no key." As before, a change in min or max value results in a "new" widget. If you create a new widget with both a default value and a key, one of two things will happen:
-
-1. The key was associated to another widget from the previous script run and the new widget with load with the default value.
-2. The key was not associated to another widget from the previous script run and the new widget will load with the value assigned to the key (with a warning if it's different than the default value).
-
-#### Best practice
-
-Generally speaking, if you will be dynamically modifying a widget, stick to using a key and don't assign the default value through the optional parameter. Here is an exapanded example to handle this case:
+#### Use keys to distinguish otherwise identical widgets
 
 ```python
-import streamlit as st
-
-# Set default value
-if 'a' not in st.session_state:
-    st.session_state.a = 5
-
-cols = st.columns(2)
-minimum = cols[0].number_input('Min', 1, 5, key='min')
-maximum = cols[1].number_input('Max', 6, 10, 10, key='max')
-
-def update_value():
-    st.session_state.a = min(st.session_state.a, maximum)
-    st.session_state.a = max(st.session_state.a, minimum)
-
-# Validate the slider value before rendering
-update_value()
-st.slider('A', minimum, maximum, key='a')
+st.button("OK", key="privacy")
+st.button("OK", key="terms")
 ```
 
 ## Order of operations
@@ -116,9 +54,9 @@ When a user interacts with a widget, the order of logic is:
 
 1. Its value in `st.session_state` is updated.
 2. The callback function (if any) is executed.
-3. The page reruns, with the widget function returning its new value.
+3. The page reruns with the widget function returning its new value.
 
-If the callback function writes anything to the screen, that content will appear above the rest of the page. A callback function runs as a prefix to the page reloading. Consequently, that means anything written via a callback function will disappear as soon as the user performs their next action. Other widgets should generally not be created within a callback function.
+If the callback function writes anything to the screen, that content will appear above the rest of the page. A callback function runs as a _prefix_ to the script rerunning. Consequently, that means anything written via a callback function will disappear as soon as the user performs their next action. Other widgets should generally not be created within a callback function.
 
 <Note>
 
@@ -126,15 +64,106 @@ If a callback function is passed any args or kwargs, those arguments will be est
 
 </Note>
 
-[//]: # "TODO: simple example and form example"
+### Using callback functions with forms
 
-## Life cycle
+Using a callback function with a form requires consideration of this order of operations.
+
+```python
+import streamlit as st
+
+if "attendance" not in st.session_state:
+    st.session_state.attendance = set()
+
+
+def take_attendance():
+    if st.session_state.name in st.session_state.attendance:
+        st.info(f"{st.session_state.name} has already been counted.")
+    else:
+        st.session_state.attendance.add(st.session_state.name)
+
+
+with st.form(key="my_form"):
+    st.text_input("Name", key="name")
+    st.form_submit_button("I'm here!", on_click=take_attendance)
+```
+
+## Statefulness of widgets
+
+As long as the defining parameters of a widget remain the same and that widget is continuously rendered on the frontend, then it will be stateful.
+
+### Changing parameters of a widget will reset it
+
+If any of the defining parameters of a widget change, Streamlit will see it as a new widget and it will reset. The use of manually assigned keys and default values is particularly important in this case. _Note that callback functions, callback args and kwargs, label visibility, and disabling a widget do not affect a widget's identity._
+
+In this example, we have a slider whose min and max values are changed. Try interacting with each slider to change its value then change the min or max setting to see what happens.
+
+```python
+import streamlit as st
+
+cols = st.columns([2, 1, 2])
+minimum = cols[0].number_input("Minimum", 1, 5)
+maximum = cols[2].number_input("Maximum", 6, 10, 10)
+
+st.slider("No default, no key", minimum, maximum)
+st.slider("No default, with key", minimum, maximum, key="a")
+st.slider("With default, no key", minimum, maximum, value=5)
+st.slider("With default, with key", minimum, maximum, value=5, key="b")
+```
+
+#### Updating a slider with no default value
+
+As soon as the min or max value is changed, the slider will reset to the min value. The changing of the min or max value makes it a "new" widget from Streamlit's perspective and so it is recreated from scratch when the app reruns with the changed parameter. Since no default value is defined, the widget will reset to its min value. This is the same with or without a key since it's seen as a new widget either way. There is a subtle point to understand about pre-existing keys connecting to widgets. This will be explained further down in [Widget life cycle](#widget-life-cycle).
+
+#### Updating a slider with a default value
+
+As with the previous case, a change to the min or max value will result in the widget being seen as "new" and thus recreated. Since a default value of 5 is defined, the widget will reset to 5 whenever the min or max is changed. This is again the same with or without a key and the same subtle point applies.
+
+A solution to [Retain statefulness when changing a widget's parameters](#retain-statefulness-when-changing-a-widgets-parameters) is provided further on.
+
+### Widgets do not persist when not continually rendered
+
+If a widget's function is not called during a script run, then none of its parts will be retained, including its value in `st.session_state`. If a widget has a key and you navigate away from that widget, its key and associated value in `st.session_state` will be deleted. Even temporarily hiding a widget will cause it to reset when it reappears; Streamlit will treat it like a new widget. You can either interrupt the [widget cleanup process](#cleaning-up) (described at the end of this page) or save the value to another key.
+
+#### Save widget values in Session State to preserve them between pages
+
+If you want to navigate away from a widget and return to it while keeping its value, use a separate key in `st.session_state` to save the information independently from the widget. In this example, a temporary key is used with a widget. The temporary key uses an underscore prefix. Hence, `_my_key` is used as the widget key, but the data is copied to `my_key` to preserve it between pages.
+
+```python
+import streamlit as st
+
+def save_value():
+    # Copy the value to the permanent key
+    st.session_state["my_key"] = st.session_state["_my_key"]
+
+# Copy the saved value to the temporary key
+st.session_state["_my_key"] = st.session_state["my_key"]
+st.number_input("Number of filters", key="_my_key", on_change=save_value)
+```
+
+If this is functionalized to work with multiple widgets, it could look something like this:
+
+```python
+import streamlit as st
+
+def save_value(key):
+    st.session_state[key] = st.session_state["_"+key]
+def get_value(key):
+    st.session_state["_"+key] = st.session_state[key]
+
+get_value("my_key")
+st.number_input("Number of filters", key="_my_key", on_change=save_value, args="my_key")
+
+```
+
+## Widget life cycle
 
 When a widget function is called, Streamlit will check if it already has a widget with the same parameters. Streamlit will reconnect if it thinks the widget already exists. Otherwise, it will make a new one.
 
-Streamlit identifies widgets as "being the same" based on their construction parameters: labels, min or max values, default values, placeholder texts, help text, and keys are all used by Streamlit to identify a widget. On the other hand, callback functions, callback args and kwargs, disabling options, and label visibility do not affect a widget's identity.
+As mentioned earlier, Streanlit determines a widget's ID is based on parameters such as label, min or max value, default value, placeholder text, help text, and key. The page name also factors in to a widget's ID. On the other hand, callback functions, callback args and kwargs, disabling options, and label visibility do not affect a widget's identity.
 
 ### Calling a widget function when the widget doesn't already exist
+
+If your script rerun calls a widget function with changed parameters or calls a widget function that wasn't used on the last script run:
 
 1. Streamlit will build the frontend and backend parts of the widget.
 2. If the widget has been assigned a key, Streamlit will check if that key already exists in session state.  
@@ -146,35 +175,74 @@ Streamlit identifies widgets as "being the same" based on their construction par
 Step 2 can be tricky. If you have a widget:
 
 ```python
-st.number_input('Alpha',key='A')
+st.number_input("Alpha",key="A")
 ```
 
 and you change it on a page rerun to:
 
 ```python
-st.number_input('Beta',key='A')
+st.number_input("Beta",key="A")
 ```
 
-Streamlit will see that as a new widget because of the label change. The key `'A'` will be considered part of the widget labeled `'Alpha'` and will not be attached as-is to the new widget labeled `'Beta'`. Streamlit will destroy `st.session_state.A` and recreate it with the default value.
+Streamlit will see that as a new widget because of the label change. The key `"A"` will be considered part of the widget labeled `"Alpha"` and will not be attached as-is to the new widget labeled `"Beta"`. Streamlit will destroy `st.session_state.A` and recreate it with the default value.
 
 If a widget attaches to a pre-existing key when created and is also manually assigned a default value, you will get a warning if there is a disparity. If you want to control a widget's value through `st.session_state`, initialize the widget's value through `st.session_state` and avoid the default value argument to prevent conflict.
 
-[//]: # "TODO: simple example and multipage example"
-
 ### Calling a widget function when the widget already exists
+
+When rerunning a script without changing a widget's parameters:
 
 1. Streamlit will connect to the existing frontend and backend parts.
 2. If the widget has a key that was deleted from `st.session_state`, then Streamlit will recreate the key using the current frontend value. (e.g Deleting a key will not revert the widget to a default value.)
 3. It will return the current value of the widget.
 
-[//]: # "TODO: Examples with the key copy workaround and pseudo key workflow"
-
 ### Cleaning up
 
-When Streamlit gets to the end of a page run, it will delete the data for any widgets it has in memory that were not rendered on the screen. Most importantly, that means Streamlit will delete all key-value pairs in `st.session_state` associated to a widget not currently on screen.
+When Streamlit gets to the end of a script run, it will delete the data for any widgets it has in memory that were not rendered on the screen. Most importantly, that means Streamlit will delete all key-value pairs in `st.session_state` associated to a widget not currently on screen.
 
-If you navigate away from a widget with some key `'my_key'` and save data to `st.session_state.my_key` on the new page, you will interrupt the widget cleanup process and prevent the key-value pair from being deleted. The rest of the widget will still be deleted and you will be left with an unassociated key-value in `st.session_state`. To preserve a widget's data, you can do something as trivial as resaving the key at the top of every page:
+## Additional examples
+
+As promised, let's address how to retain statefulness of widgets when changing pages or modifying their parameters. There are two ways to do this.
+1. Use dummy keys to duplicate widget values in `st.session_state` and protect the data from being deleted along with the widget.
+2. Interrupt the widget clean-up process.
+
+The first method was shown above in [Save widget values in Session State to preserve them between pages](#save-widget-values-in-session-state-to-preserve-them-between-pages)
+
+### Interrupting the widget clean-up process
+
+To retain information for a widget with `key="my_key"`, just add this to the top of every page:
 
 ```python
 st.session_state.my_key = st.session_state.my_key
 ```
+
+When you manually save data to a key in `st.session_state`, it will become detached from any widget as far as the clean-up process is concerned. If you navigate away from a widget with some key `"my_key"` and save data to `st.session_state.my_key` on the new page, you will interrupt the widget clean-up process and prevent the key-value pair from being deleted or overwritten if another widget with the same key exists. 
+
+### Retain statefulness when changing a widget's parameters
+
+Here is a solution to our earlier example of changing a slider's min and max values. This solution interrupts the clean-up process as described above.
+
+```python
+import streamlit as st
+
+# Set default value
+if "a" not in st.session_state:
+    st.session_state.a = 5
+
+cols = st.columns(2)
+minimum = cols[0].number_input("Min", 1, 5, key="min")
+maximum = cols[1].number_input("Max", 6, 10, 10, key="max")
+
+
+def update_value():
+    # Helper function to ensure consistency between widget parameters and value
+    st.session_state.a = min(st.session_state.a, maximum)
+    st.session_state.a = max(st.session_state.a, minimum)
+
+
+# Validate the slider value before rendering
+update_value()
+st.slider("A", minimum, maximum, key="a")
+```
+
+The `update_value()` helper function is actually doing two things. On the surface, it's making sure there are no inconsistent changes to the parameters values as described. Importantly however, it's interrupting the widget clean-up process. When the min or max value of the widget changes, Streamlit sees it as a new widget on rerun. Without saving a value to `st.session_state.a`, the value would be thrown out and replaced by the "new" widget's default value.

--- a/content/library/advanced-features/advanced-widget-behavior.md
+++ b/content/library/advanced-features/advanced-widget-behavior.md
@@ -99,6 +99,8 @@ with st.form(key="my_form"):
     st.form_submit_button("I'm here!", on_click=take_attendance)
 ```
 
+<Cloud src="https://doc-guide-widgets-form-callbacks.streamlit.app/?embed=true" height="250"/>
+
 ## Statefulness of widgets
 
 As long as the defining parameters of a widget remain the same and that widget is continuously rendered on the frontend, then it will be stateful and remember user input.
@@ -121,6 +123,8 @@ st.slider("No default, with key", minimum, maximum, key="a")
 st.slider("With default, no key", minimum, maximum, value=5)
 st.slider("With default, with key", minimum, maximum, value=5, key="b")
 ```
+
+<Cloud src="https://doc-guide-widgets-change-parameters.streamlit.app/?embed=true" height="550"/>
 
 #### Updating a slider with no default value
 
@@ -257,5 +261,7 @@ def update_value():
 update_value()
 st.slider("A", minimum, maximum, key="a")
 ```
+
+<Cloud src="https://doc-guide-widgets-change-parameters-solution.streamlit.app/?embed=true" height="250"/>
 
 The `update_value()` helper function is actually doing two things. On the surface, it's making sure there are no inconsistent changes to the parameters values as described. Importantly however, it's interrupting the widget clean-up process. When the min or max value of the widget changes, Streamlit sees it as a new widget on rerun. Without saving a value to `st.session_state.a`, the value would be thrown out and replaced by the "new" widget's default value.

--- a/content/library/advanced-features/advanced-widget-behavior.md
+++ b/content/library/advanced-features/advanced-widget-behavior.md
@@ -5,7 +5,7 @@ slug: /library/advanced-features/widget-behavior
 
 # Understanding widget behavior
 
-Widgets are at the heart of Streamlit apps. They are the interactive elements of Streamlit that pass information from your users into your Python code. Widgets are magical and often work how you want, but they can have surprising behavior in some situations. Understanding the different parts of a widget and the precise order in which events occur helps you achieve your desired results.
+Widgets (like `st.button`, `st.selectbox`, and `st.text_input`) are at the heart of Streamlit apps. They are the interactive elements of Streamlit that pass information from your users into your Python code. Widgets are magical and often work how you want, but they can have surprising behavior in some situations. Understanding the different parts of a widget and the precise order in which events occur helps you achieve your desired results.
 
 This guide covers advanced concepts about widgets. For most beginning users, these details won't be important to know right away. When you want to dynamically change widgets or preserve widget information between pages, these concepts will be important to understand.
 

--- a/content/library/advanced-features/advanced-widget-behavior.md
+++ b/content/library/advanced-features/advanced-widget-behavior.md
@@ -1,16 +1,180 @@
 ---
-title: Widget semantics
-slug: /library/advanced-features/widget-semantics
+title: Widget behavior
+slug: /library/advanced-features/widget-behavior
 ---
 
-# Advanced notes on widget behavior
+# Understanding widget behavior
 
-Widgets are magical and often work how you want. But they can have surprising behavior in some situations. Here is a high-level, abstract description of widget behavior, including some common edge-cases:
+Widgets are magical and often work how you want. But they can have surprising behavior in some situations. Understanding the different parts of a widget and the precise order in which events occur is helpful for achieving desired results.
 
-1. If you call a widget function before the widget state exists, the widget state defaults to a value. This value depends on the widget and its arguments.
-2. A widget function call returns the current widget state value. The return value is a simple Python type, and the exact type depends on the widget and its arguments.
-3. Widget states depend on a particular session (browser connection). The actions of one user do not affect the widgets of any other user.
-4. A widget's identity depends on the arguments passed to the widget function. If those change, the call will create a new widget (with a default value, per 1).
-5. If you don't call a widget function in a script run, we neither store the widget state nor render the widget. If you call a widget function with the same arguments later, Streamlit treats it as a new widget.
+## Anatomy of a widget
 
-4 and 5 are the most likely to be surprising and may pose a problem for some application designs. When you want to persist widget state for recreating a widget, use [Session State](/library/api-reference/session-state) to work around 5.
+There are four parts to every widget:
+
+1. The frontend component as seen by the user.
+2. The backend value or value as seen through `st.session_state`.
+3. The return value given by the widget's function.
+4. The key of the widget used to access its value via `st.session_state`.
+
+### Session dependence
+
+These parts are dependent on a particular session (browser connection). The actions of one user do not affect the widgets of any other user. Furthermore, if a user opens up multiple tabs to access an app, then each tab will be a unique session. Hence, changing a widget in one tab will not affect the same widget in another tab.
+
+### Data types
+
+The backend value (as seen through `st.session_state`) and the return value of a widget are of simple Python types. For example, `st.button` returns a boolean value and will have the same boolean value saved in `st.session_state`.
+
+### Widget keys
+
+Widget keys serve two purposes:
+
+1. Distinguishing two otherwise identical widgets.
+2. Creating a means to access and manipulate the widget's value through
+   `st.session_state`.
+
+A widget's identity depends on the arguments passed to the widget function. If you have two widgets of the same type with the same arguments, you will get a `DuplicateWidgetID` error. In this case, you will need to assign unique keys to the two widgets.
+
+### Persistence
+
+If a widget's function is not called during a script run, then none of its parts will be retained, including its value in `st.session_state`. If you have assigned a key to a widget and you navigate away from that widget, its key and associated value in `st.session_state` will be deleted. Even temporarily hiding a widget will cause it to reset when it reappears; Streamlit will treat it like a new widget.
+
+### Statefulness
+
+As long as the defining parameters of a widget remain the same and that widget is continuously rendered on the frontend, then it will be stateful. If any of the defining parameters of a widget change, Streamlit will see it as a new widget and it will reset. The use of manually assigned keys and default values is particularly important in this case.
+
+In this example, we have a slider with whose min and max values are changed. Try setting values on the slider and changing the min or max values to see how each behaves.
+
+```python
+import streamlit as st
+
+cols = st.columns([2,1,2])
+minimum = cols[0].number_input('Minimum', 1, 5)
+maximum = cols[2].number_input('Maximum', 6, 10, 10)
+
+st.slider('No default, no key', minimum, maximum)
+
+st.slider('With default, no key', minimum, maximum, value=5)
+
+st.slider('No default, with key', minimum, maximum, key='a')
+
+st.slider('With default, with key', minimum, maximum, value=5, key='b')
+```
+
+#### No default, no key
+
+As soon as the min or max value is changed, the slider will reset to the minimum value. The changing of the min or max value makes it a "new" widget from Streamlit's perspective and so it is recreated with the default value equal to the minimum value since it is not defined otherwise.
+
+#### With default, no key
+
+As with the previous case, a change to the min or max value will result in the widget being seen as "new" and thus recreated. Since a default value of 5 is defined, the widget will reset to 5 whenever the min or max is changed.
+
+#### No default, with key
+
+This is closer to expected behavior. Since the widget has a key, Streamlit has a way of reconnecting the state of the widget even with a change in min or max value that would otherwise make the widget be treated as "new." In this case, the change in min and max does cause the widget to be reconstructed, but the existence of the key in `st.session_state` with an assigned value causes the new widget's state to be overwritten from its otherwise default value. This example is not perfect though; try this:
+
+1. Set the slider to a value of 10.
+2. Reduce the max to 9.
+3. See the slider still appear to have a value of 10.
+4. Set the slider to a value less than 10.
+5. See the max of the slider update to 9.
+   The value of the slider in `st.session_state` can become invalid if the current selection becomes out-of-range through an update of min or max. A corrected example follows this one.
+
+#### With default, with key
+
+This is a tricky case. The default value and key are at odds.The default value trumps the value in `st.session_state` and the slider behaves the same as "With default, no key." As before, a change in min or max value results in a "new" widget. If you create a new widget with both a default value and a key, one of two things will happen:
+
+1. The key was associated to another widget from the previous script run and the new widget with load with the default value.
+2. The key was not associated to another widget from the previous script run and the new widget will load with the value assigned to the key (with a warning if it's different than the default value).
+
+#### Best practice
+
+Generally speaking, if you will be dynamically modifying a widget, stick to using a key and don't assign the default value through the optional parameter. Here is an exapanded example to handle this case:
+
+```python
+import streamlit as st
+
+# Set default value
+if 'a' not in st.session_state:
+    st.session_state.a = 5
+
+cols = st.columns(2)
+minimum = cols[0].number_input('Min', 1, 5, key='min')
+maximum = cols[1].number_input('Max', 6, 10, 10, key='max')
+
+def update_value():
+    st.session_state.a = min(st.session_state.a, maximum)
+    st.session_state.a = max(st.session_state.a, minimum)
+
+# Validate the slider value before rendering
+update_value()
+st.slider('A', minimum, maximum, key='a')
+```
+
+## Order of operations
+
+When a user interacts with a widget, the order of logic is:
+
+1. Its value in `st.session_state` is updated.
+2. The callback function (if any) is executed.
+3. The page reruns, with the widget function returning its new value.
+
+If the callback function writes anything to the screen, that content will appear above the rest of the page. A callback function runs as a prefix to the page reloading. Consequently, that means anything written via a callback function will disappear as soon as the user performs their next action. Other widgets should generally not be created within a callback function.
+
+<Note>
+
+If a callback function is passed any args or kwargs, those arguments will be established when the widget is rendered. In particular, if you want to use a widget's new value in its own callback function, you cannot pass that value to the callback function via the `args` parameter; you will have to assign a key to the widget and look up its new value using a call to `st.session_state` _within the callback function_.
+
+</Note>
+
+[//]: # "TODO: simple example and form example"
+
+## Life cycle
+
+When a widget function is called, Streamlit will check if it already has a widget with the same parameters. Streamlit will reconnect if it thinks the widget already exists. Otherwise, it will make a new one.
+
+Streamlit identifies widgets as "being the same" based on their construction parameters: labels, min or max values, default values, placeholder texts, help text, and keys are all used by Streamlit to identify a widget. On the other hand, callback functions, callback args and kwargs, disabling options, and label visibility do not affect a widget's identity.
+
+### Calling a widget function when the widget doesn't already exist
+
+1. Streamlit will build the frontend and backend parts of the widget.
+2. If the widget has been assigned a key, Streamlit will check if that key already exists in session state.  
+   a. If it exists and is not currently associated to another widget, Streamlit will attach to that key and take on its value for the widget.  
+   b. Otherwise, it will assign the default value to the key in `st.session_state`.
+3. If there are args or kwargs for a callback function, they are computed and saved at this point in time.
+4. The default value is then returned by the function.
+
+Step 2 can be tricky. If you have a widget:
+
+```python
+st.number_input('Alpha',key='A')
+```
+
+and you change it on a page rerun to:
+
+```python
+st.number_input('Beta',key='A')
+```
+
+Streamlit will see that as a new widget because of the label change. The key `'A'` will be considered part of the widget labeled `'Alpha'` and will not be attached as-is to the new widget labeled `'Beta'`. Streamlit will destroy `st.session_state.A` and recreate it with the default value.
+
+If a widget attaches to a pre-existing key when created and is also manually assigned a default value, you will get a warning if there is a disparity. If you want to control a widget's value through `st.session_state`, initialize the widget's value through `st.session_state` and avoid the default value argument to prevent conflict.
+
+[//]: # "TODO: simple example and multipage example"
+
+### Calling a widget function when the widget already exists
+
+1. Streamlit will connect to the existing frontend and backend parts.
+2. If the widget has a key that was deleted from `st.session_state`, then Streamlit will recreate the key using the current frontend value. (e.g Deleting a key will not revert the widget to a default value.)
+3. It will return the current value of the widget.
+
+[//]: # "TODO: Examples with the key copy workaround and pseudo key workflow"
+
+### Cleaning up
+
+When Streamlit gets to the end of a page run, it will delete the data for any widgets it has in memory that were not rendered on the screen. Most importantly, that means Streamlit will delete all key-value pairs in `st.session_state` associated to a widget not currently on screen.
+
+If you navigate away from a widget with some key `'my_key'` and save data to `st.session_state.my_key` on the new page, you will interrupt the widget cleanup process and prevent the key-value pair from being deleted. The rest of the widget will still be deleted and you will be left with an unassociated key-value in `st.session_state`. To preserve a widget's data, you can do something as trivial as resaving the key at the top of every page:
+
+```python
+st.session_state.my_key = st.session_state.my_key
+```

--- a/content/menu.md
+++ b/content/menu.md
@@ -409,8 +409,8 @@ site_menu:
     visible: false
   - category: Streamlit library / Advanced features/ Add statefulness to apps
     url: /library/advanced-features/session-state
-  - category: Streamlit library / Advanced features/ Widget semantics
-    url: /library/advanced-features/widget-semantics
+  - category: Streamlit library / Advanced features/ Widget behavior
+    url: /library/advanced-features/widget-behavior
   - category: Streamlit library / Advanced features/ Pre-release features
     url: /library/advanced-features/prerelease
   - category: Streamlit library / Advanced features/ Working with timezones

--- a/public/_redirects
+++ b/public/_redirects
@@ -882,3 +882,4 @@
 /streamlit-community-cloud/get-started/share-your-app/share-previews /streamlit-community-cloud/share-your-app/share-previews
 /streamlit-community-cloud/get-started/manage-your-app /streamlit-community-cloud/manage-your-app
 /streamlit-community-cloud/trust-and-security /streamlit-community-cloud/get-started/trust-and-security
+/library/advanced-features/widget-semantics /library/advanced-features/widget-behavior


### PR DESCRIPTION
## 📚 Context
The finer details of widget behavior often lead to confusion, especially when dynamically changing a widget or trying to carrying widget state between pages.

## 🧠 Description of Changes
Changed Widget semantics page to Widget behavior and added a more comprehensive description of widget anatomy and behavior.

## 💥 Impact

Size: Not small 

## 🌐 References

Closes #449 

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
