### PR TITLE
Add st.experimental_data_editor (deprecated)

### DIFF
--- a/content/library/api/data/experimental_data_editor.md
+++ b/content/library/api/data/experimental_data_editor.md
@@ -1,0 +1,7 @@
+---
+title: st.experimental_data_editor
+slug: /library/api-reference/data/st.experimental_data_editor
+description: st.experimental_data_editor display a data editor widget that allows you to edit dataframes and many other data structures in a table-like UI.
+---
+
+<Autofunction function="streamlit.experimental_data_editor" deprecated={true} deprecatedText="<code>st.experimental_data_editor</code> was deprecated in version 1.23.0. Use <a href='/library/api-reference/data/st.data_editor'><code>st.data_editor</code></a> instead."/>

--- a/content/menu.md
+++ b/content/menu.md
@@ -120,6 +120,10 @@ site_menu:
   - category: Streamlit library / API reference / Data elements / st.json
     url: /library/api-reference/data/st.json
     isVersioned: true
+  - category: Streamlit library / API reference / Data elements / st.experimental_data_editor
+    url: /library/api-reference/data/st.experimental_data_editor
+    isVersioned: true
+    isDeprecated: true
   - category: Streamlit library / API reference / Chart elements
     url: /library/api-reference/charts
   - category: Streamlit library / API reference / Chart elements / st.area_chart


### PR DESCRIPTION
## 📚 Context
`st.experimental_data_editor` was deprecated and removed from documentation. Users of older versions (especially SiS users) often look for this deprecated widget.

## 🧠 Description of Changes
Re-added `st.experimental_data_editor` as a deprecated element. This is possibly a temporary measure pending robust IA rework.

Size:
- [X] Not small 

## 🌐 References
Notion task: [Re-add `st.experimental_data_editor`](https://www.notion.so/snowflake-corp/Re-add-st-experimental_data_editor-b7c6060291bd4d5db874460b175d98df?pvs=4)

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
