### PR TITLE
Replace `removeAll` function with `replace` for compatibility

### DIFF
--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -19,12 +19,7 @@ import styles from "./autofunction.module.css";
 import { name } from "file-loader";
 
 const cleanHref = (name) => {
-  return String(name)
-    .replace(".", "")
-    .replace(".", "")
-    .replace(".", "")
-    .replace(".", "")
-    .replace(" ", "-");
+  return String(name).replace(/\./g, "").replace(" ", "-");
 };
 
 const Autofunction = ({

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -19,7 +19,7 @@ import styles from "./autofunction.module.css";
 import { name } from "file-loader";
 
 const cleanHref = (name) => {
-  return String(name).replace(/\./g, "").replace(" ", "-");
+  return String(name).replace(/\./g, "").replace(/\s+/g, "-");
 };
 
 const Autofunction = ({

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -19,7 +19,12 @@ import styles from "./autofunction.module.css";
 import { name } from "file-loader";
 
 const cleanHref = (name) => {
-  return String(name).replaceAll(".", "").replaceAll(" ", "-");
+  return String(name)
+    .replace(".", "")
+    .replace(".", "")
+    .replace(".", "")
+    .replace(".", "")
+    .replace(" ", "-");
 };
 
 const Autofunction = ({

--- a/components/blocks/headers.js
+++ b/components/blocks/headers.js
@@ -41,7 +41,7 @@ const getBody = (props) => {
 };
 
 export const cleanHref = (name) => {
-  const clean = String(name).replace(/\./g, "").replace(/ /g, "-");
+  const clean = String(name).replace(/\./g, "").replace(/\s+/g, "-");
   return clean;
 };
 

--- a/components/blocks/headers.js
+++ b/components/blocks/headers.js
@@ -41,7 +41,12 @@ const getBody = (props) => {
 };
 
 export const cleanHref = (name) => {
-  const clean = String(name).replaceAll(".", "").replaceAll(" ", "-");
+  const clean = String(name)
+    .replace(".", "")
+    .replace(".", "")
+    .replace(".", "")
+    .replace(".", "")
+    .replace(" ", "-");
   return clean;
 };
 

--- a/components/blocks/headers.js
+++ b/components/blocks/headers.js
@@ -41,12 +41,7 @@ const getBody = (props) => {
 };
 
 export const cleanHref = (name) => {
-  const clean = String(name)
-    .replace(".", "")
-    .replace(".", "")
-    .replace(".", "")
-    .replace(".", "")
-    .replace(" ", "-");
+  const clean = String(name).replace(/\./g, "").replace(/ /g, "-");
   return clean;
 };
 


### PR DESCRIPTION
## 📚 Context
`.replaceAll()` is not compatible with the current version of `algoliasearch`. Until that can be upgraded, this PR uses a regular expression and the global flag "g" to achieve the same behavior using `.replace()` within the process of creating header links.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.