### PR TITLE
Update list of widgets using callbacks

### DIFF
--- a/content/library/api/state/state.md
+++ b/content/library/api/state/state.md
@@ -110,6 +110,8 @@ Widgets which support the `on_change` event:
 - `st.checkbox`
 - `st.color_picker`
 - `st.date_input`
+- `st.data_editor`
+- `st.file_uploader`
 - `st.multiselect`
 - `st.number_input`
 - `st.radio`
@@ -119,7 +121,7 @@ Widgets which support the `on_change` event:
 - `st.text_area`
 - `st.text_input`
 - `st.time_input`
-- `st.file_uploader`
+- `st.toggle`
 
 Widgets which support the `on_click` event:
 


### PR DESCRIPTION
## 📚 Context
There is a list of widgets that use `on_change` and `on_click` callbacks. This PR adds two newer widgets to the lists.

## 💥 Impact
Size: Small 

## 🌐 References
Closes #841

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
