### PR TITLE
Cookie banner enhancements

### DIFF
--- a/components/navigation/footer.js
+++ b/components/navigation/footer.js
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 import styles from "./footer.module.css";
 
-const Footer = () => {
+const Footer = ({ setIsTelemetryModalVisible }) => {
   return (
     <footer className={styles.Container}>
       <section className={styles.InnerContainer}>
@@ -302,9 +302,17 @@ const Footer = () => {
             </i>
           </a>
         </section>
-        <p className={styles.Copyright}>
-          Copyright &copy; {new Date().getFullYear()}, Streamlit Inc.
-        </p>
+        <div className={styles.Copyright}>
+          <span>
+            Copyright &copy; {new Date().getFullYear()}, Streamlit Inc.
+          </span>
+          <button
+            className="hover:opacity-80 ml-2"
+            onClick={() => setIsTelemetryModalVisible(true)}
+          >
+            Cookie policy
+          </button>
+        </div>
       </section>
     </footer>
   );

--- a/components/utilities/breadCrumbs.js
+++ b/components/utilities/breadCrumbs.js
@@ -65,7 +65,7 @@ const BreadCrumbs = ({ slug, menu }) => {
   }
 
   // Then, we add a couple pages that don't need breadcrumbs, such as /menu, /index, etc.
-  filesToExclude.push("index", "gdpr-banner", "menu");
+  filesToExclude.push("index", "gdpr-banner", "menu", "cookie-settings");
 
   // Now, we throw the error if any page that's not on the filesToExclude array is missing in menu.md
   if (path.length === 0 && !filesToExclude.includes(slug[0])) {

--- a/components/utilities/cookieSettingsModal.js
+++ b/components/utilities/cookieSettingsModal.js
@@ -1,0 +1,73 @@
+import classNames from "classnames";
+import { MDXRemote } from "next-mdx-remote";
+
+import styles from "./cookieSettingsModal.module.css";
+
+export default function CookieSettingsModal({
+  setIsTelemetryModalVisible,
+  declineTelemetryAndCloseBanner,
+  allowTelemetryAndCloseBanner,
+  content,
+}) {
+  return (
+    <div className="fixed w-full h-full z-40 bg-gray-90 bg-opacity-90 top-0 flex items-center justify-center">
+      <div
+        className={classNames(
+          styles.Container,
+          "relative",
+          "bg-white rounded-xl",
+          "p-8 md:p-12",
+          "w-full max-w-4xl",
+          "overscroll-none overflow-y-auto",
+          "max-h-screen"
+        )}
+      >
+        <button
+          className="absolute right-4 top-4 md:right-11 md:top-11 fill-gray-70"
+          onClick={() => setIsTelemetryModalVisible(false)}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 -960 960 960"
+            className="mt-2 w-8 h-8 hover:bg-gray-30 rounded"
+          >
+            <path d="m253.897-229.795-24.102-24.102L455.897-480 229.795-706.103l24.102-24.102L480-504.103l226.103-226.102 24.102 24.102L504.103-480l226.102 226.103-24.102 24.102L480-455.897 253.897-229.795Z" />
+          </svg>
+        </button>
+        <MDXRemote {...content} />
+        <button
+          className={classNames(
+            "mt-4 md:mt-8",
+            "py-2 px-3",
+            "text-gray-90",
+            "border-gray-90 border",
+            "rounded",
+            "hover:bg-gray-90",
+            "hover:text-white",
+            "active:bg-gray-90",
+            "active:text-white"
+          )}
+          onClick={declineTelemetryAndCloseBanner}
+        >
+          Reject all
+        </button>
+        <button
+          className={classNames(
+            "mt-4 md:mt-8 ml-4",
+            "py-2 px-3",
+            "text-gray-90",
+            "border-gray-90 border",
+            "rounded",
+            "hover:bg-gray-90",
+            "hover:text-white",
+            "active:bg-gray-90",
+            "active:text-white"
+          )}
+          onClick={allowTelemetryAndCloseBanner}
+        >
+          Accept all
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/utilities/cookieSettingsModal.module.css
+++ b/components/utilities/cookieSettingsModal.module.css
@@ -1,0 +1,167 @@
+.Container > div {
+  @apply text-gray-90 grid grid-cols-1 gap-4 text-base leading-loose;
+}
+
+.Container h1,
+.Container h2,
+.Container h3,
+.Container h4,
+.Container h5,
+.Container h6 {
+  @apply scroll-mt-0 md:scroll-mt-32;
+}
+
+.Container h2,
+.Container h3,
+.Container h4,
+.Container h5 {
+  @apply mt-4 text-lg font-bold text-gray-90;
+}
+
+.Container h2 {
+  @apply text-xl;
+}
+
+.Container h3 {
+  @apply text-2xl;
+}
+
+.Container h2:first-child,
+.Container h3:first-child,
+.Container h4:first-child,
+.Container h5:first-child {
+  @apply mt-0;
+}
+
+.Container p {
+  @apply text-gray-90;
+}
+
+.Container a {
+  @apply underline;
+}
+
+.Container a:hover {
+  @apply opacity-80;
+}
+
+.Container ol {
+  @apply list-decimal pl-8 grid grid-cols-1 gap-4;
+}
+
+.Container section ol {
+  @apply list-none pl-0 gap-0 mb-5;
+}
+
+.Container ul {
+  @apply list-disc pl-8 grid grid-cols-1 gap-4;
+}
+
+.Container li {
+  @apply pl-2;
+}
+
+.Container blockquote {
+  @apply p-6 md:p-8 lg:p-16
+    -mx-6 md:-mx-8 lg:-mx-16
+    my-0 md:my-4 lg:my-12
+    grid grid-cols-1 gap-4
+    bg-lightBlue-10
+    text-gray-80
+    rounded-lg;
+}
+
+.PrivacyContainer blockquote ~ h4 {
+  @apply mt-12 md:mt-8 lg:mt-0 text-gray-90;
+}
+
+.PrivacyContainer blockquote h2 {
+  @apply hidden;
+}
+
+.Container blockquote h2 {
+  @apply text-gray-90 text-3xl;
+}
+
+.Container hr {
+  @apply border-gray-40 border-t-0 border-l-0 border-r-0 border-b my-8;
+}
+
+.Container address {
+  @apply whitespace-pre-line pl-4 border-l-2 border-gray-30 mt-4;
+}
+
+.Container pre {
+  @apply bg-gray-10 p-4 rounded-md overflow-x-auto text-gray-90;
+}
+
+.Container pre code {
+  @apply text-lg;
+}
+
+.Container figure {
+  @apply flex flex-col items-start;
+}
+
+.Container figure img {
+  @apply h-24 ml-2 mb-2;
+}
+
+.Container figure figcaption {
+  @apply text-sm text-gray-70;
+}
+
+/* For table in Privacy notice */
+.Container table {
+  @apply table-fixed my-8 w-full;
+}
+
+.Container table thead tr th {
+  @apply px-4 py-3 text-left bg-gray-20 bg-opacity-50 border border-gray-30 text-gray-90 font-semibold text-lg leading-normal align-top;
+}
+
+.Container table tbody tr td {
+  @apply px-4 py-3 border border-gray-30 text-gray-90 text-lg leading-normal align-top;
+}
+
+.DeploymentTerms ul,
+.DeploymentTerms ol {
+  @apply list-none;
+}
+
+/* Specific classes for colors */
+.Container:global(.red) a {
+  @apply text-red-70;
+}
+
+.Container:global(.orange) a {
+  @apply text-orange-70;
+}
+
+.Container:global(.yellow) a {
+  @apply text-yellow-90;
+}
+
+.Container:global(.green) a {
+  @apply text-green-70;
+}
+
+.Container:global(.acqua) a {
+  @apply text-acqua-70;
+}
+
+.Container:global(.lightBlue) a {
+  @apply text-lightBlue-70;
+}
+
+.Container:global(.darkBlue) a {
+  @apply text-darkBlue-70;
+}
+
+.Container:global(.indigo) a {
+  @apply text-indigo-70;
+}
+
+.Container:global(.gray) a {
+  @apply text-gray-70;
+}

--- a/components/utilities/gdpr.js
+++ b/components/utilities/gdpr.js
@@ -215,9 +215,9 @@ function insertTelemetry() {
           n.parentNode.insertBefore(t, n);
           analytics._loadOptions = e;
         };
-        analytics._writeKey = "5oR9PCgKBs3VqmQCMiiajboWKKBUa4dA";
+        analytics._writeKey = "pUoB6ihRTAFLDtLp2NWEuJvBNtiooQwE";
         analytics.SNIPPET_VERSION = "4.13.2";
-        analytics.load("5oR9PCgKBs3VqmQCMiiajboWKKBUa4dA");
+        analytics.load("pUoB6ihRTAFLDtLp2NWEuJvBNtiooQwE");
         analytics.page();
       }
   })();

--- a/components/utilities/gdpr.js
+++ b/components/utilities/gdpr.js
@@ -37,7 +37,6 @@ function getTelemetryPreference() {
 }
 
 export default function GDPRBanner({
-  title,
   content,
   isTelemetryModalVisible,
   setIsTelemetryModalVisible,
@@ -85,73 +84,66 @@ export default function GDPRBanner({
         <div
           className={classNames(
             isTelemetryBannerVisible === false ? "hidden" : "",
-            "z-30 w-full fixed border-t border-gray-40 p-4 bottom-0",
-            styles.Container
+            "z-30 fixed",
+            "bottom-2 inset-x-2 md:bottom-4 md:inset-x-4"
           )}
         >
           <div
             className={classNames(
-              "flex flex-col lg:flex-row lg:items-center pl-4 pr-4 sm:pl-8 sm:pr-8"
+              "flex flex-col lg:flex-row lg:items-end gap-4",
+              "pl-4 pr-4 sm:pl-8 sm:pr-8",
+              "rounded-lg border border-gray-30",
+              "shadow-lg",
+              "container mx-auto py-8",
+              styles.Container
             )}
           >
-            <div className="flex-1">
-              {title && (
-                <h6 className="font-bold text-gray-90 text-lg sm:text-2xl">
-                  {title}
-                </h6>
-              )}
+            <div className={classNames("flex-1", styles.Markdown)}>
               <MDXRemote {...content} />
             </div>
-            <button
-              className={classNames(
-                "mt-4 lg:mt-0",
-                "text-gray-90",
-                "hover:text-gray-70 hover:underline",
-                "order-last lg:order-none",
-                styles.Link
-              )}
-              onClick={() =>
-                setIsTelemetryModalVisible(!isTelemetryModalVisible)
-              }
-            >
-              Cookie settings
-            </button>
-            <button
-              className={classNames(
-                "mt-4 lg:mt-0",
-                "lg:ml-4",
-                "py-2 px-3",
-                "text-gray-90",
-                "border-gray-90 border",
-                "rounded",
-                "hover:bg-gray-90",
-                "hover:text-white",
-                "active:bg-gray-90",
-                "active:text-white",
-                styles.Button
-              )}
-              onClick={declineTelemetryAndCloseBanner}
-            >
-              Reject all
-            </button>
-            <button
-              className={classNames(
-                "mt-4 lg:mt-0",
-                "lg:ml-4",
-                "py-2 px-3",
-                "text-gray-90",
-                "border-gray-90 border",
-                "rounded",
-                "hover:bg-gray-90",
-                "hover:text-white",
-                "active:bg-gray-90",
-                "active:text-white",
-                styles.Button
-              )}
-              onClick={allowTelemetryAndCloseBanner}
-            >
-              Accept all
-            </button>
+            <div className="flex flex-col lg:flex-row lg:justify-end gap-2 lg:gap-4">
+              <button
+                className={classNames(
+                  "text-gray-90 hover:text-gray-70 hover:underline",
+                  "py-2",
+                  "order-last lg:order-none",
+                  styles.Button
+                )}
+                onClick={() =>
+                  setIsTelemetryModalVisible(!isTelemetryModalVisible)
+                }
+              >
+                Cookie settings
+              </button>
+              <button
+                className={classNames(
+                  "py-2 px-3",
+                  "text-gray-90",
+                  "border-gray-90 border",
+                  "rounded",
+                  "hover:bg-red-70 hover:border-red-70",
+                  "hover:text-white",
+                  styles.Button
+                )}
+                onClick={declineTelemetryAndCloseBanner}
+              >
+                Reject all
+              </button>
+              <button
+                className={classNames(
+                  "py-2 px-3",
+                  "rounded",
+                  "border",
+                  "text-white",
+                  "bg-gray-90 border-gray-90",
+                  "hover:bg-red-70 hover:border-red-70",
+                  styles.Button
+                )}
+                onClick={allowTelemetryAndCloseBanner}
+              >
+                Accept all
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/components/utilities/gdpr.module.css
+++ b/components/utilities/gdpr.module.css
@@ -1,63 +1,30 @@
 .Container {
-  @apply fixed bottom-0 md:bottom-4 md:right-4 w-full z-30 md:max-w-2xl;
-}
-
-.BannerBackground {
-  @apply border-t border-t-gray-50 bg-gray-20 md:border md:border-gray-30 p-2 md:p-6 md:rounded-md flex flex-col md:flex-row;
-}
-
-.Title {
-  @apply mt-0 mb-2 pt-2 md:pt-0 font-sans font-bold text-2xl tracking-tight leading-tight;
-  @apply text-gray-90;
-}
-
-.ImageContainer {
-  @apply hidden md:block mb-4 md:mb-0 md:mt-2 mr-4;
-}
-
-.CtasContainer {
-  @apply flex mt-4 md:mt-6;
-}
-
-.Button {
-  @apply rounded-md px-8 py-1 text-red-70 text-sm font-semibold tracking-normal block cursor-pointer mb-2 hover:opacity-90 hover:scale-105;
-}
-
-.DeclineButton {
-  @apply border border-solid bg-gray-20 border-gray-70 text-gray-90 mr-4 hover:opacity-80;
-}
-
-.AllowButton {
-  @apply bg-gray-90 text-white hover:opacity-80;
-}
-
-/* MDX styles */
-.Container div p,
-.Container div a {
-  @apply text-gray-90;
-}
-
-.Container div a {
-  @apply text-gray-70;
+  backdrop-filter: blur(10px);
+  background: #fffd;
 }
 
 .Container div p {
-  @apply m-0;
+  @apply text-gray-90 text-lg;
 }
 
-/* Dark mode modifiers */
-:global(.dark) .BannerBackground {
-  @apply bg-gray-90 border-t-gray-80 md:border-gray-80;
+.Container div p a {
+  @apply text-gray-90 underline hover:text-gray-70;
 }
 
-:global(.dark) .Container div p {
-  @apply text-white;
+:global(.dark) .Container {
+  @apply bg-gray-100 border-gray-90;
 }
 
-:global(.dark) .DeclineButton {
-  @apply bg-gray-90 text-white border-gray-80;
+:global(.dark) .Container div p,
+:global(.dark) .Container div p a {
+  @apply text-gray-20;
 }
 
-:global(.dark) .AllowButton {
-  @apply bg-white text-gray-90;
+:global(.dark) .Link,
+:global(.dark) .Button {
+  @apply text-gray-20;
+}
+
+:global(.dark) .Button {
+  @apply border-gray-80;
 }

--- a/components/utilities/gdpr.module.css
+++ b/components/utilities/gdpr.module.css
@@ -3,11 +3,19 @@
   background: #fffd;
 }
 
-.Container div p {
-  @apply text-gray-90 text-lg;
+.Markdown div {
+  @apply flex flex-col;
 }
 
-.Container div p a {
+.Markdown h1 {
+  @apply text-gray-90 text-lg sm:text-xl font-bold mb-1;
+}
+
+.Markdown p {
+  @apply text-gray-90 text-base mb-0;
+}
+
+.Markdown p a {
   @apply text-gray-90 underline hover:text-gray-70;
 }
 
@@ -15,8 +23,8 @@
   @apply bg-gray-100 border-gray-90;
 }
 
-:global(.dark) .Container div p,
-:global(.dark) .Container div p a {
+:global(.dark) .Markdown p,
+:global(.dark) .Markdown p a {
   @apply text-gray-20;
 }
 
@@ -27,4 +35,8 @@
 
 :global(.dark) .Button {
   @apply border-gray-80;
+}
+
+:global(.dark) .Markdown h1 {
+  @apply text-white;
 }

--- a/content/cookie-settings.md
+++ b/content/cookie-settings.md
@@ -1,4 +1,5 @@
 ---
+visible: false
 ---
 
 ### Cookie settings

--- a/content/cookie-settings.md
+++ b/content/cookie-settings.md
@@ -1,0 +1,20 @@
+---
+---
+
+### Cookie settings
+
+##### Strictly necessary cookies
+
+These cookies are necessary for the website to function and cannot be switched off. They are usually only set in response to actions made by you which amount to a request for services, such as setting your privacy preferences, logging in or filling in forms.
+
+##### Performance cookies
+
+These cookies allow us to count visits and traffic sources so we can measure and improve the performance of our site. They help us understand how visitors move around the site and which pages are most frequently visited.
+
+##### Functional cookies
+
+These cookies are used to record your choices and settings, maintain your preferences over time and recognize you when you return to our website. These cookies help us to personalize our content for you and remember your preferences.
+
+##### Targeting cookies
+
+These cookies may be deployed to our site by our advertising partners to build a profile of your interest and provide you with content that is relevant to you, including showing you relevant ads on other websites.

--- a/content/gdpr-banner.md
+++ b/content/gdpr-banner.md
@@ -1,8 +1,5 @@
 ---
-enabled: false
 title: We value your privacy.
 ---
 
-We would like to use cookies to help us understand how users interact with this website. This is used, for example, to find out which parts of this site should be further improved.
-
-More information can be found in our [Privacy Notice](https://www.streamlit.io/privacy-policy).
+We use cookies to help us understand how you interact with our website. By clicking “Accept all”, you consent to our use of cookies. For more information, please see our [privacy policy](www.streamlit.io/privacy-policy).

--- a/content/gdpr-banner.md
+++ b/content/gdpr-banner.md
@@ -1,5 +1,8 @@
 ---
-title: We value your privacy.
 ---
 
-We use cookies to help us understand how you interact with our website. By clicking “Accept all”, you consent to our use of cookies. For more information, please see our [privacy policy](www.streamlit.io/privacy-policy).
+# Hello there 👋
+
+Thanks for stopping by! We use cookies to help us understand how you interact with our website.
+
+By clicking “Accept all”, you consent to our use of cookies. For more information, please see our [privacy policy](www.streamlit.io/privacy-policy).

--- a/lib/api.js
+++ b/lib/api.js
@@ -104,3 +104,11 @@ export async function getGDPRBanner() {
   const markup = await serialize(data.content);
   return { data: data.data, content: markup, title: data.data.title };
 }
+
+export async function getCookieSettings() {
+  const fullPath = join(articleDirectory, `cookie-settings.md`);
+  const fileContents = fs.readFileSync(fullPath, "utf8");
+  const data = matter(fileContents);
+  const markup = await serialize(data.content);
+  return { content: markup };
+}

--- a/lib/api.js
+++ b/lib/api.js
@@ -102,7 +102,7 @@ export async function getGDPRBanner() {
   const fileContents = fs.readFileSync(fullPath, "utf8");
   const data = matter(fileContents);
   const markup = await serialize(data.content);
-  return { data: data.data, content: markup, title: data.data.title };
+  return { data: data.data, content: markup };
 }
 
 export async function getCookieSettings() {

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -80,7 +80,6 @@ export default function Article({
   nextMenuItem,
   versionFromStaticLoad,
   versions,
-  paths,
   gdpr_data,
   cookie_data,
   filename,
@@ -407,6 +406,7 @@ export async function getStaticProps(context) {
 
     props["menu"] = menu;
     props["gdpr_data"] = gdpr_data;
+    props["cookie_data"] = cookie_data;
     props["data"] = data;
     props["filename"] = filename;
     props["slug"] = context.params.slug;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useState, useCallback } from "react";
 import Head from "next/head";
+import { useRouter } from "next/router";
 
-import { getMenu, getGDPRBanner } from "../lib/api";
+import { getMenu, getGDPRBanner, getCookieSettings } from "../lib/api";
 
 import Layout from "../components/layouts/globalTemplate";
 import Footer from "../components/navigation/footer";
@@ -10,7 +11,10 @@ import SideBar from "../components/navigation/sideBar";
 import ArrowLinkContainer from "../components/navigation/arrowLinkContainer";
 import ArrowLink from "../components/navigation/arrowLink";
 
-import GDPRBanner from "../components/utilities/gdpr";
+import GDPRBanner, {
+  setTelemetryPreference,
+} from "../components/utilities/gdpr";
+import CookieSettingsModal from "../components/utilities/cookieSettingsModal";
 import SocialCallouts from "../components/utilities/socialCallout";
 import Spacer from "../components/utilities/spacer";
 
@@ -31,8 +35,32 @@ import { attributes } from "../content/index.md";
 
 import styles from "../components/layouts/container.module.css";
 
-export default function Home({ window, menu, gdpr_data }) {
+export default function Home({ window, menu, gdpr_data, cookie_data }) {
   let { description } = attributes;
+
+  const [isTelemetryModalVisible, setIsTelemetryModalVisible] = useState(false);
+  const [isTelemetryBannerVisible, setIsTelemetryBannerVisible] =
+    useState(false);
+  const [insertTelemetryCode, setInsertTelemetryCode] = useState(false);
+
+  const router = useRouter();
+
+  const allowTelemetryAndCloseBanner = useCallback(() => {
+    setIsTelemetryBannerVisible(false);
+    setIsTelemetryModalVisible(false);
+    setInsertTelemetryCode(true);
+    setTelemetryPreference(true);
+  }, [isTelemetryBannerVisible, insertTelemetryCode]);
+
+  const declineTelemetryAndCloseBanner = useCallback(() => {
+    setIsTelemetryBannerVisible(false);
+    setIsTelemetryModalVisible(false);
+    setInsertTelemetryCode(false);
+    setTelemetryPreference(false);
+
+    // If previous state was true, and now it's false, reload the page to remove telemetry JS
+    if (insertTelemetryCode) router.reload();
+  }, [isTelemetryBannerVisible, insertTelemetryCode]);
 
   return (
     <Layout window={window}>
@@ -66,7 +94,25 @@ export default function Home({ window, menu, gdpr_data }) {
           content={`https://${process.env.NEXT_PUBLIC_HOSTNAME}/sharing-image-twitter.jpg`}
         />
       </Head>
-      <GDPRBanner {...gdpr_data} />
+      {isTelemetryModalVisible && (
+        <CookieSettingsModal
+          {...cookie_data}
+          setIsTelemetryModalVisible={setIsTelemetryModalVisible}
+          allowTelemetryAndCloseBanner={allowTelemetryAndCloseBanner}
+          declineTelemetryAndCloseBanner={declineTelemetryAndCloseBanner}
+        />
+      )}
+      <GDPRBanner
+        {...gdpr_data}
+        isTelemetryModalVisible={isTelemetryModalVisible}
+        setIsTelemetryModalVisible={setIsTelemetryModalVisible}
+        isTelemetryBannerVisible={isTelemetryBannerVisible}
+        setIsTelemetryBannerVisible={setIsTelemetryBannerVisible}
+        insertTelemetryCode={insertTelemetryCode}
+        setInsertTelemetryCode={setInsertTelemetryCode}
+        allowTelemetryAndCloseBanner={allowTelemetryAndCloseBanner}
+        declineTelemetryAndCloseBanner={declineTelemetryAndCloseBanner}
+      />
       <section className={styles.Container}>
         <SideBar menu={menu} slug={[]} />
         <section className={styles.InnerContainer}>
@@ -261,7 +307,7 @@ export default function Home({ window, menu, gdpr_data }) {
             />
           </ArrowLinkContainer>
         </section>
-        <Footer />
+        <Footer setIsTelemetryModalVisible={setIsTelemetryModalVisible} />
       </section>
     </Layout>
   );
@@ -271,6 +317,7 @@ export async function getStaticProps(context) {
   const props = {};
   props["menu"] = getMenu();
   props["gdpr_data"] = await getGDPRBanner();
+  props["cookie_data"] = await getCookieSettings();
 
   return {
     props: props,


### PR DESCRIPTION
This PR implements a subset of the features listed [here](https://docs.google.com/document/d/19VQDI3qyhx34HVmH48MnolBtrQwaWzkeZP0mAj7Tzns/edit) to our cookie banner implementation, namely:
* Updates banner wording;
* Adds cookie type description in a modal window;
* Adds a CTA on the footer to open the cookie settings modal and update cookie preferences;
* Make consent expire after 6 months;

It also makes its style consistent with our other web properties, and fixes an issue reported by @snehankekre [here](https://www.notion.so/snowflake-corp/Cookie-banner-briefly-shows-up-on-every-reload-of-any-Docs-page-fd106b27ad724cd0b541e9a846a54110?pvs=4)

**Screenshots:**

<img width="1728" alt="Screenshot 2023-10-27 at 9 48 24 AM" src="https://github.com/streamlit/docs/assets/103376966/c9c5d792-fd7e-4e23-90b2-0ac6e590efa4">

<img width="1728" alt="Screenshot 2023-10-27 at 9 48 12 AM" src="https://github.com/streamlit/docs/assets/103376966/4fed8d2a-a475-4048-8ae7-4af7ba7a1ae8">

<img width="1728" alt="Screenshot 2023-10-20 at 12 14 49 PM" src="https://github.com/streamlit/docs/assets/103376966/1adb348d-6599-4aad-b701-cc99597bf144">

<img width="1330" alt="Screenshot 2023-10-20 at 12 58 44 PM" src="https://github.com/streamlit/docs/assets/103376966/f90841d6-929c-4b5c-a359-647a2e39e677">