### PR TITLE
Add autoplay and loop support to YouTube component

### DIFF
--- a/components/blocks/youTube.js
+++ b/components/blocks/youTube.js
@@ -5,26 +5,8 @@ import styles from "./youtube.module.css";
 const YouTube = ({ caption, videoId, start, end }) => {
   let YouTubeBlock;
 
-  if (caption) {
-    YouTubeBlock = (
-      <section className={styles.Container}>
-        <section className={styles.IframeContainer}>
-          <iframe
-            src={`https://www.youtube-nocookie.com/embed/${videoId}?rel=0&start=${start}&end=${end}`}
-            className={styles.Iframe}
-            title="YouTube video player"
-            frameBorder="0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
-          ></iframe>
-        </section>
-        <section className={styles.CaptionContainer}>
-          <p className={styles.Caption}>{caption}</p>
-        </section>
-      </section>
-    );
-  } else {
-    YouTubeBlock = (
+  YouTubeBlock = (
+    <section className={styles.Container}>
       <section className={styles.IframeContainer}>
         <iframe
           src={`https://www.youtube-nocookie.com/embed/${videoId}?rel=0&start=${start}&end=${end}`}
@@ -35,8 +17,13 @@ const YouTube = ({ caption, videoId, start, end }) => {
           allowFullScreen
         ></iframe>
       </section>
-    );
-  }
+      {caption && (
+        <section className={styles.CaptionContainer}>
+          <p className={styles.Caption}>{caption}</p>
+        </section>
+      )}
+    </section>
+  );
   return YouTubeBlock;
 };
 

--- a/components/blocks/youTube.js
+++ b/components/blocks/youTube.js
@@ -11,7 +11,7 @@ const YouTube = ({ caption, videoId, start, end, autoplay, loop }) => {
   }
 
   YouTubeBlock = (
-    <section className={styles.Container}>
+    <div className={styles.Container}>
       <section className={styles.IframeContainer}>
         <iframe
           src={`https://www.youtube-nocookie.com/embed/${videoId}?playlist=${videoId}&rel=0&start=${start}&end=${end}&autoplay=${autoplay}&loop=${loop}&mute=${mute}`}
@@ -23,11 +23,11 @@ const YouTube = ({ caption, videoId, start, end, autoplay, loop }) => {
         ></iframe>
       </section>
       {caption && (
-        <section className={styles.CaptionContainer}>
+        <div className={styles.CaptionContainer}>
           <p className={styles.Caption}>{caption}</p>
-        </section>
+        </div>
       )}
-    </section>
+    </div>
   );
   return YouTubeBlock;
 };

--- a/components/blocks/youTube.js
+++ b/components/blocks/youTube.js
@@ -2,14 +2,19 @@ import React from "react";
 
 import styles from "./youtube.module.css";
 
-const YouTube = ({ caption, videoId, start, end }) => {
+const YouTube = ({ caption, videoId, start, end, autoplay, loop }) => {
   let YouTubeBlock;
+  let mute = 0;
+
+  if (autoplay || loop) {
+    mute = 1;
+  }
 
   YouTubeBlock = (
     <section className={styles.Container}>
       <section className={styles.IframeContainer}>
         <iframe
-          src={`https://www.youtube-nocookie.com/embed/${videoId}?rel=0&start=${start}&end=${end}`}
+          src={`https://www.youtube-nocookie.com/embed/${videoId}?playlist=${videoId}&rel=0&start=${start}&end=${end}&autoplay=${autoplay}&loop=${loop}&mute=${mute}`}
           className={styles.Iframe}
           title="YouTube video player"
           frameBorder="0"

--- a/content/library/advanced-features/connecting-to-data.md
+++ b/content/library/advanced-features/connecting-to-data.md
@@ -16,7 +16,7 @@ Most Streamlit apps need some kind of data or API access to be useful - either r
 
 For a comprehensive overview of this feature, check out this video tutorial by Joshua Carroll, Streamlit's Product Manager for Developer Experience. You'll learn about the feature's utility in creating and managing data connections within your apps by using real-world examples.
 
-<YouTube videoId="xQwDfW7UHMo" loop autoplay caption="Test caption" />
+<YouTube videoId="xQwDfW7UHMo" />
 
 ## Basic usage
 

--- a/content/library/advanced-features/connecting-to-data.md
+++ b/content/library/advanced-features/connecting-to-data.md
@@ -16,7 +16,7 @@ Most Streamlit apps need some kind of data or API access to be useful - either r
 
 For a comprehensive overview of this feature, check out this video tutorial by Joshua Carroll, Streamlit's Product Manager for Developer Experience. You'll learn about the feature's utility in creating and managing data connections within your apps by using real-world examples.
 
-<YouTube videoId="xQwDfW7UHMo" />
+<YouTube videoId="xQwDfW7UHMo" loop autoplay caption="Test caption" />
 
 ## Basic usage
 


### PR DESCRIPTION
## 📚 Context

The Docs team is trialing moving some GIFs over to YouTube. Those GIFs autoplayed in a loop. To preserve the same behavior when converted to YouTube videos, this PR lets authors optionally set the autoplay and looping behavior.

## 🧠 Description of Changes

- Refactor component to conditionally render captions
- Add autoplay and loop props to component
- Sets the video to muted when the video loops or autoplays (to avoid annoying users and avoid making them question if the video is supposed to have audio)

The changes of this PR can be pulled into #861 which includes a similar change.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
