### PR TITLE
Fix mobile wrapping on function headers

### DIFF
--- a/components/utilities/headerLink.module.css
+++ b/components/utilities/headerLink.module.css
@@ -3,7 +3,7 @@
 }
 
 .HeaderContainer {
-  @apply flex items-center font-bold text-gray-90 leading-snug;
+  @apply flex items-center font-bold text-gray-90 leading-snug break-all md:break-normal;
 }
 
 .HeaderContainer strong {


### PR DESCRIPTION
## 📚 Context

This PR fixes an issue reported by @sfc-gh-dmatthews [here](https://www.notion.so/snowflake-corp/Papercut-Function-headers-in-docs-0645add4425d41cab765fc4028f63458?pvs=4) where long function headers won't break on mobile, causing horizontal scrolling. The word will likely be cut in odd places, but it's better than layout breaking imo.

**Before:**

![Untitled](https://github.com/streamlit/docs/assets/103376966/65420225-7214-416a-be3f-658c8de19a1d)

**After:**

![localhost_3000_library_api-reference_connections_st experimental_connection(iPhone SE)](https://github.com/streamlit/docs/assets/103376966/e9fd374a-4673-400d-b137-a35cc68d1e34)

## 🧠 Description of Changes

* Added `word-break: break-all;` on mobile for `headerLink` components

## 💥 Impact

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

- https://www.notion.so/snowflake-corp/Papercut-Function-headers-in-docs-0645add4425d41cab765fc4028f63458?pvs=4

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
