### PR TITLE
Use `overflow-wrap: anywhere` for headers

### DIFF
--- a/components/utilities/headerLink.module.css
+++ b/components/utilities/headerLink.module.css
@@ -3,7 +3,8 @@
 }
 
 .HeaderContainer {
-  @apply flex items-center font-bold text-gray-90 leading-snug break-all md:break-normal;
+  @apply flex items-center font-bold text-gray-90 leading-snug;
+  overflow-wrap: anywhere;
 }
 
 .HeaderContainer strong {


### PR DESCRIPTION
Allow headers to soft wrap if possible and only break words if an otherwise unbreakable string overflows on a line by itself.

## 📚 Context
Long function signatures were causing unintended overflow on mobile view. This was fixed by introducing `overflow-wrap: break-word`, but this will prefer breaking a word over an available soft wrap. `overflow-wrap: anywhere` will utilize soft wrap when possible. [It is well-supported.](https://caniuse.com/mdn-css_properties_overflow-wrap_anywhere)


**Revised:**
![image](https://github.com/streamlit/docs/assets/98661771/2fc390d8-fff0-44bd-a4c9-290e1b795af6)

**Current:**
![image](https://github.com/streamlit/docs/assets/98661771/17bd5e03-9906-4ec4-ae57-7a9004bd92a5)

Words that are too long to fit on one line remain the same:
![image](https://github.com/streamlit/docs/assets/98661771/a9b86a84-94a4-4bde-99a0-97eaf1f75039)

## 💥 Impact
Size: Small

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
