### PR TITLE
Use nightly to utilize patch

### DIFF
--- a/python/api-examples-source/requirements.txt
+++ b/python/api-examples-source/requirements.txt
@@ -10,4 +10,4 @@ altair==4.2.0
 pydeck==0.8.0
 Faker==19.1.0
 openai==0.27.8
-streamlit==1.28.0
+streamlit-nightly==1.28.1.dev20231026


### PR DESCRIPTION
## 📚 Context
A last-minute patch did not make it into 1.28.0. This PR switches the embedded apps at the root of api-examples-source to use nightly. This ensures dataframes have enough padding to show the toolbar when they appear as the first element in an embedded app.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
