### PR TITLE
Add a section the SnowflakeConnection API Reference on configuration

### DIFF
--- a/content/library/api/connections/connections-snowflake.md
+++ b/content/library/api/connections/connections-snowflake.md
@@ -11,6 +11,42 @@ This page only contains the `st.connections.SnowflakeConnection` class. For a de
 
 <Autofunction function="streamlit.connections.SnowflakeConnection" />
 
+### Configuration
+
+<!---
+Internal note: This section is deep-linked from the library in 1.28.1, don't break or change this anchor!
+-->
+
+`st.connection("snowflake")` can be configured using `secrets.toml` or keyword args just like any other connection. It can also use existing Snowflake connection configuration when available.
+
+#### Using Streamlit secrets
+
+For example, if your Snowflake account supports SSO, you can set up a quick local connection for development using [browser-based SSO](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use#how-browser-based-sso-works) and `secrets.toml` as follows:
+
+```toml
+# .streamlit/secrets.toml
+
+[connections.snowflake]
+account = "<ACCOUNT ID>"
+user = "<USERNAME>"
+authenticator = "EXTERNALBROWSER"
+```
+
+You could also specify the full configuration and credentials in your secrets file, as in the [example here](/tutorials/databases/snowflake#add-connection-parameters-to-your-local-app-secrets)
+
+#### Using existing Snowflake configuration
+
+Snowflake's python driver also supports a [connection configuration file](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-example#connecting-using-the-connections-toml-file), which is well integrated with Streamlit `SnowflakeConnection`. If you already have one or more connections configured, all you need to do is pass Streamlit the name of the connection to use. This can be done in several ways:
+
+- Setting `connection_name` in your app code, such as `st.connnection("<name>", type="snowflake")`
+- Setting `connection_name = "<name>"` in the `[connections.snowflake]` section of your Streamlit secrets
+- Setting the environment variable `SNOWFLAKE_DEFAULT_CONNECTION_NAME=<name>`
+- [Set a default connection](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-example#setting-a-default-connection) in your Snowflake configuration.
+
+When available in [Streamlit in Snowflake](https://docs.snowflake.com/en/developer-guide/streamlit/about-streamlit), `st.connection("snowflake")` will connect automatically using the [app owner role](https://docs.snowflake.com/en/developer-guide/streamlit/owners-rights) and does not require any configuration.
+
+Learn more about setting up connections in the [Connecting Streamlit to Snowflake tutorial](/knowledge-base/tutorials/databases/snowflake) and [Connecting to data](/library/advanced-features/connecting-to-data).
+
 <Autofunction function="streamlit.connections.SnowflakeConnection.cursor" />
 
 <Autofunction function="streamlit.connections.SnowflakeConnection.query" />

--- a/content/library/api/connections/connections-snowflake.md
+++ b/content/library/api/connections/connections-snowflake.md
@@ -17,7 +17,7 @@ This page only contains the `st.connections.SnowflakeConnection` class. For a de
 Internal note: This section is deep-linked from the library in 1.28.1, don't break or change this anchor!
 -->
 
-`st.connection("snowflake")` can be configured using `secrets.toml` or keyword args just like any other connection. It can also use existing Snowflake connection configuration when available.
+`st.connection("snowflake")` can be configured using [Streamlit secrets](/library/advanced-features/secrets-management) or keyword args just like any other connection. It can also use existing Snowflake connection configuration when available.
 
 ### Using Streamlit secrets
 
@@ -32,7 +32,7 @@ user = "<USERNAME>"
 authenticator = "EXTERNALBROWSER"
 ```
 
-You could also specify the full configuration and credentials in your secrets file, as in the [example here](/knowledge-base/tutorials/databases/snowflake#add-connection-parameters-to-your-local-app-secrets).
+Learn more about [account indentifier here](https://docs.snowflake.com/en/user-guide/admin-account-identifier). You could also specify the full configuration and credentials in your secrets file, as in the [example here](/knowledge-base/tutorials/databases/snowflake#add-connection-parameters-to-your-local-app-secrets).
 
 ### Using existing Snowflake configuration
 

--- a/content/library/api/connections/connections-snowflake.md
+++ b/content/library/api/connections/connections-snowflake.md
@@ -38,10 +38,10 @@ Learn more about [account indentifier here](https://docs.snowflake.com/en/user-g
 
 Snowflake's python driver also supports a [connection configuration file](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-example#connecting-using-the-connections-toml-file), which is well integrated with Streamlit `SnowflakeConnection`. If you already have one or more connections configured, all you need to do is pass Streamlit the name of the connection to use. This can be done in several ways:
 
-- Setting `connection_name` in your app code, such as `st.connnection("<name>", type="snowflake")`
-- Setting `connection_name = "<name>"` in the `[connections.snowflake]` section of your Streamlit secrets
-- Setting the environment variable `SNOWFLAKE_DEFAULT_CONNECTION_NAME=<name>`
-- [Set a default connection](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-example#setting-a-default-connection) in your Snowflake configuration.
+- Set `connection_name` in your app code, such as `st.connnection("<name>", type="snowflake")`
+- Set `connection_name = "<name>"` in the `[connections.snowflake]` section of your Streamlit secrets
+- Set the environment variable `SNOWFLAKE_DEFAULT_CONNECTION_NAME=<name>`
+- [Set a default connection](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-example#setting-a-default-connection) in your Snowflake configuration
 
 When available in [Streamlit in Snowflake](https://docs.snowflake.com/en/developer-guide/streamlit/about-streamlit), `st.connection("snowflake")` will connect automatically using the [app owner role](https://docs.snowflake.com/en/developer-guide/streamlit/owners-rights) and does not require any configuration.
 

--- a/content/library/api/connections/connections-snowflake.md
+++ b/content/library/api/connections/connections-snowflake.md
@@ -11,15 +11,16 @@ This page only contains the `st.connections.SnowflakeConnection` class. For a de
 
 <Autofunction function="streamlit.connections.SnowflakeConnection" />
 
-## Configuration
+### Configuration
 
 <!---
-Internal note: This section is deep-linked from the library in 1.28.1, don't break or change this anchor!
+Internal note: This section is deep-linked from the library in 1.28.1 via /st.connections.snowflakeconnection-configuration through a redirect.
+Maintain the redirect if moved or modified.
 -->
 
 `st.connection("snowflake")` can be configured using [Streamlit secrets](/library/advanced-features/secrets-management) or keyword args just like any other connection. It can also use existing Snowflake connection configuration when available.
 
-### Using Streamlit secrets
+#### Using Streamlit secrets
 
 For example, if your Snowflake account supports SSO, you can set up a quick local connection for development using [browser-based SSO](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use#how-browser-based-sso-works) and `secrets.toml` as follows:
 
@@ -34,14 +35,14 @@ authenticator = "EXTERNALBROWSER"
 
 Learn more about [account indentifier here](https://docs.snowflake.com/en/user-guide/admin-account-identifier). You could also specify the full configuration and credentials in your secrets file, as in the [example here](/knowledge-base/tutorials/databases/snowflake#add-connection-parameters-to-your-local-app-secrets).
 
-### Using existing Snowflake configuration
+#### Using existing Snowflake configuration
 
 Snowflake's python driver also supports a [connection configuration file](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-example#connecting-using-the-connections-toml-file), which is well integrated with Streamlit `SnowflakeConnection`. If you already have one or more connections configured, all you need to do is pass Streamlit the name of the connection to use. This can be done in several ways:
 
-- Set `connection_name` in your app code, such as `st.connnection("<name>", type="snowflake")`
-- Set `connection_name = "<name>"` in the `[connections.snowflake]` section of your Streamlit secrets
-- Set the environment variable `SNOWFLAKE_DEFAULT_CONNECTION_NAME=<name>`
-- [Set a default connection](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-example#setting-a-default-connection) in your Snowflake configuration
+- Set `connection_name` in your app code, such as `st.connnection("<name>", type="snowflake")`.
+- Set `connection_name = "<name>"` in the `[connections.snowflake]` section of your Streamlit secrets.
+- Set the environment variable `SNOWFLAKE_DEFAULT_CONNECTION_NAME=<name>`.
+- [Set a default connection](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-example#setting-a-default-connection) in your Snowflake configuration.
 
 When available in [Streamlit in Snowflake](https://docs.snowflake.com/en/developer-guide/streamlit/about-streamlit), `st.connection("snowflake")` will connect automatically using the [app owner role](https://docs.snowflake.com/en/developer-guide/streamlit/owners-rights) and does not require any configuration.
 

--- a/content/library/api/connections/connections-snowflake.md
+++ b/content/library/api/connections/connections-snowflake.md
@@ -11,7 +11,7 @@ This page only contains the `st.connections.SnowflakeConnection` class. For a de
 
 <Autofunction function="streamlit.connections.SnowflakeConnection" />
 
-### Configuration
+## Configuration
 
 <!---
 Internal note: This section is deep-linked from the library in 1.28.1, don't break or change this anchor!
@@ -19,7 +19,7 @@ Internal note: This section is deep-linked from the library in 1.28.1, don't bre
 
 `st.connection("snowflake")` can be configured using `secrets.toml` or keyword args just like any other connection. It can also use existing Snowflake connection configuration when available.
 
-#### Using Streamlit secrets
+### Using Streamlit secrets
 
 For example, if your Snowflake account supports SSO, you can set up a quick local connection for development using [browser-based SSO](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use#how-browser-based-sso-works) and `secrets.toml` as follows:
 
@@ -32,9 +32,9 @@ user = "<USERNAME>"
 authenticator = "EXTERNALBROWSER"
 ```
 
-You could also specify the full configuration and credentials in your secrets file, as in the [example here](/tutorials/databases/snowflake#add-connection-parameters-to-your-local-app-secrets)
+You could also specify the full configuration and credentials in your secrets file, as in the [example here](/knowledge-base/tutorials/databases/snowflake#add-connection-parameters-to-your-local-app-secrets).
 
-#### Using existing Snowflake configuration
+### Using existing Snowflake configuration
 
 Snowflake's python driver also supports a [connection configuration file](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-example#connecting-using-the-connections-toml-file), which is well integrated with Streamlit `SnowflakeConnection`. If you already have one or more connections configured, all you need to do is pass Streamlit the name of the connection to use. This can be done in several ways:
 

--- a/public/_redirects
+++ b/public/_redirects
@@ -887,3 +887,4 @@
 /library/api-reference/performance/st.cache_resource.clear /library/api-reference/performance/st.cache_resource
 /library/api-reference/performance/st.experimental_memo.clear /library/api-reference/performance/st.experimental_memo
 /library/api-reference/performance/st.experimental_singleton.clear /library/api-reference/performance/st.experimental_singleton
+/st.connections.snowflakeconnection-configuration /library/api-reference/connections/st.connections.snowflakeconnection#configuration


### PR DESCRIPTION
## 📚 Context

Provide more dedicated and detailed documentation about configuring a SnowflakeConnection. Specifically, want to deep link this from an error in the library when a developer doesn't have any config available.

## 🧠 Description of Changes

Added the "Configuration" section to [SnowflakeConnection API Reference](https://docs.streamlit.io/library/api-reference/connections/st.connections.snowflakeconnection)

## 💥 Impact

Modest - new section with clearer documentation about options available and links to relevant Snowflake docs for more information.

**[Updated section in Deploy Preview](https://deploy-preview-873--streamlit-docs.netlify.app/library/api-reference/connections/st.connections.snowflakeconnection#configuration)**

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [x] Not small <!-- Everything else -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
