### PR TITLE
Fix buggy state initialization in app testing doc

### DIFF
--- a/content/library/advanced-features/app-testing/get-started.md
+++ b/content/library/advanced-features/app-testing/get-started.md
@@ -46,7 +46,8 @@ Main app file:
 import streamlit as st
 
 # Initialize st.session_state.beans
-beans = st.session_state.get("beans", 0)
+if "beans" not in st.session_state:
+    st.session_state.beans = 0
 
 st.title("Bean counter :paw_prints:")
 

--- a/content/library/advanced-features/app-testing/get-started.md
+++ b/content/library/advanced-features/app-testing/get-started.md
@@ -46,8 +46,7 @@ Main app file:
 import streamlit as st
 
 # Initialize st.session_state.beans
-if "beans" not in st.session_state:
-    st.session_state.beans = 0
+st.session_state.beans = st.session_state.get("beans", 0)
 
 st.title("Bean counter :paw_prints:")
 


### PR DESCRIPTION
## 📚 Context

Closes #880.

## 🧠 Description of Changes

- Properly initialized the `beans` session state variable

**Revised:**

![image](https://github.com/streamlit/docs/assets/20672874/e14b1515-d46d-4eeb-8c6f-9ab8d0dfaf28)

**Current:**

![image](https://github.com/streamlit/docs/assets/20672874/e9a60b45-c1cc-4623-80c1-240d6e3f969a)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
