### PR TITLE
Add port 3000 issue in deployment docs

### DIFF
--- a/content/kb/deployments/remote-start.md
+++ b/content/kb/deployments/remote-start.md
@@ -91,6 +91,8 @@ improves performance. If you'd like to turn it back on, you'll need to find whic
 of your infrastructure is stripping the `Sec-WebSocket-Extensions` HTTP header and
 change that behavior.
 
+Additionally, a crucial note to remember: **Avoid running your application on port 3000**. Port 3000 serves as Streamlit's internal development port, exclusively reserved for internal usage. Using this port externally could lead to conflicts, potentially causing the "Please wait..." issue. While a workaround for this particular conflict might become available in the future, it's advisable to steer clear of using port 3000 for now to ensure smooth application functionality.
+
 ### Symptom #3: Unable to upload files when running in multiple replicas
 
 If the file uploader widget returns an error with status code 403, this is probably

--- a/content/kb/deployments/remote-start.md
+++ b/content/kb/deployments/remote-start.md
@@ -54,19 +54,25 @@ How to start a simple HTTP server:
 python -m http.server [port]
 ```
 
-### Symptom #2: The app says "Please wait..." forever
+### Symptom #2: The app says "Please wait..." or shows skeleton elements forever
 
-If when you try to load your app in a browser you see a blue box in the center
-of the page with the text "Please wait...", the underlying cause is likely one
-of the following:
+This symptom appears differently starting from version 1.29.0. For earlier
+versions of Streamlit, a loading app shows a blue box in the center of the page
+with a "Please wait..." message. Starting from version 1.29.0, a loading app
+shows skeleton elements. If this loading screen does not go away, the
+underlying cause is likely one of the following:
 
+- Using port 3000 which is reserved for internal development.
 - Misconfigured [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
   protection.
 - Server is stripping headers from the Websocket connection, thereby breaking
   compression.
 
-To diagnose the issue, try temporarily disabling CORS protection by running
-Streamlit with the `--server.enableCORS` flag set to `false`:
+To diagnose the issue, first make sure you are not using port 3000. If in doubt,
+try port 80 as described above.
+
+Next, try temporarily disabling CORS protection by running Streamlit with the
+`--server.enableCORS` flag set to `false`:
 
 ```bash
 streamlit run my_app.py --server.enableCORS=false
@@ -90,8 +96,6 @@ Compression is not required for Streamlit to work, but it's strongly recommended
 improves performance. If you'd like to turn it back on, you'll need to find which part
 of your infrastructure is stripping the `Sec-WebSocket-Extensions` HTTP header and
 change that behavior.
-
-Additionally, a crucial note to remember: **Avoid running your application on port 3000**. Port 3000 serves as Streamlit's internal development port, exclusively reserved for internal usage. Using this port externally could lead to conflicts, potentially causing the "Please wait..." issue. While a workaround for this particular conflict might become available in the future, it's advisable to steer clear of using port 3000 for now to ensure smooth application functionality.
 
 ### Symptom #3: Unable to upload files when running in multiple replicas
 


### PR DESCRIPTION
## 📚 Context

This pull request aims to enhance the documentation by providing additional guidance regarding the "Please wait..." issue encountered while running Streamlit apps. Specifically, it introduces crucial information related to the usage of port 3000 and its impact on the application's functionality.

## 🧠 Description of Changes

<!-- What was specifically changed? Which files, algorithms, links, media? -->
<!-- Please add them here as a bulleted list -->

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [Issue](https://github.com/streamlit/streamlit/issues/4921)
- [Discussion](https://discuss.streamlit.io/t/stcore-health-doesnt-change-port-when-running-on-different-port/43821/5)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
