### PR TITLE
Autofunction: Prevent method signatures with nested parentheses from truncating

### DIFF
--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -339,7 +339,7 @@ const Autofunction = ({
       .replace("streamlit", "st")
       .replace(/[.,\/#!$%\^&\*;:{}=\-`~()]/g, "");
     const type_name = method.signature
-      ? method.signature.match(/\(([^)]*)\)/)[1]
+      ? method.signature.match(/\((.*)\)/)[1]
       : "";
     const isDeprecated =
       method.deprecated && method.deprecated.deprecated === true;


### PR DESCRIPTION
## 📚 Context
When a class method signature contains nested parentheses, Authofunction incorrectly truncates the string "(...(...)"

## 🧠 Description of Changes
The regular expression used to get the method arguments now identifies the first `(` and last `)` instead of the first `(` and first `)`.

A temporary fix which replaced the nested right parent with `&rpar;` is reverted.

**Revised:**
<img width="815" alt="image" src="https://github.com/streamlit/docs/assets/135349133/6557191b-378d-49e8-bc48-14e497bf30a4">

**Current:**
(Without temporary fix)
<img width="812" alt="image" src="https://github.com/streamlit/docs/assets/135349133/d8a2a9fb-4e6f-4ac6-aba2-992bc74d858d">


## 💥 Impact
- [X] Small

## 🌐 References
- Notion task: [Fix nested parentheses in method signatures](https://www.notion.so/snowflake-corp/Autofunction-Fix-nested-parentheses-in-method-signatures-4a09ee81615b4c079ce86e378f21679c?pvs=4)

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
