### PR TITLE
Fix incorrect cache_data decorator in cache_resource docs

### DIFF
--- a/content/library/api/performance/cache-resource.md
+++ b/content/library/api/performance/cache-resource.md
@@ -73,7 +73,7 @@ def load_model():
 You can also use [interactive input widgets](/library/api-reference/widgets) like `st.slider` or `st.text_input` in cached functions. Widget replay is an experimental feature at the moment. To enable it, you need to set the `experimental_allow_widgets` parameter:
 
 ```python
-@st.cache_data(experimental_allow_widgets=True)  # 👈 Set the parameter
+@st.cache_resource(experimental_allow_widgets=True)  # 👈 Set the parameter
 def load_model():
     pretrained = st.checkbox("Use pre-trained model:")  # 👈 Add a checkbox
     model = torchvision.models.resnet50(weights=ResNet50_Weights.DEFAULT, pretrained=pretrained)


### PR DESCRIPTION
## 📚 Context

There is an incorrect code example which refers to `st.cache_data` instead `st.cache_resource`

## 🧠 Description of Changes

- Replace `@st.cache_data(...)` with `@st.cache_resource(...)`


## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->
