### PR TITLE
Update to show SnowflakeConnection requires snowflake-snowpark-python

### DIFF
--- a/content/kb/tutorials/databases/snowflake.md
+++ b/content/kb/tutorials/databases/snowflake.md
@@ -7,7 +7,7 @@ slug: /knowledge-base/tutorials/databases/snowflake
 
 ## Introduction
 
-This guide explains how to securely access a Snowflake database from Streamlit. It uses [st.connection](/library/api-reference/connections/st.connection), the [Snowflake Python Connector](https://docs.snowflake.com/en/developer-guide/snowpark/python/index) library and Streamlit's [Secrets management](/library/advanced-features/secrets-management). The below example code **will only work on Streamlit version >= 1.28**, when `st.connection` was added.
+This guide explains how to securely access a Snowflake database from Streamlit. It uses [st.connection](/library/api-reference/connections/st.connection), the [Snowpark library](https://docs.snowflake.com/en/developer-guide/snowpark/python/index) and Streamlit's [Secrets management](/library/advanced-features/secrets-management). The below example code **will only work on Streamlit version >= 1.28**, when `st.connection` was added.
 
 ## Create a Snowflake database
 
@@ -56,12 +56,12 @@ Once you have executed the queries, you should see a preview of the table in the
 
 Make sure to note down the name of your warehouse, database, and schema. ☝️
 
-## Install snowflake-connector-python
+## Install snowflake-snowpark-python
 
-You can find the instructions and prerequisites for installing `snowflake-connector-python` in the [Snowflake Developer Guide](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-install).
+You can find the instructions and prerequisites for installing `snowflake-snowpark-python` in the [Snowflake Developer Guide](https://docs.snowflake.com/en/developer-guide/snowpark/python/setup#installation-instructions).
 
 ```bash
-pip install "snowflake-connector-python"
+pip install snowflake-snowpark-python
 ```
 
 ## Add connection parameters to your local app secrets
@@ -118,7 +118,7 @@ If everything worked out (and you used the example table we created above), your
 
 ### Using a Snowpark Session
 
-The same [SnowflakeConnection](/library/api-reference/connections/st.connections.snowflakeconnection) used above also provides access to the [Snowpark Session](https://docs.snowflake.com/en/developer-guide/snowpark/reference/python/session.html) for DataFrame-style operations that run natively inside Snowflake. The [Snowpark Python library](https://docs.snowflake.com/en/developer-guide/snowpark/python/index) is a dependency for this, so be sure to `pip install snowflake-snowpark-python` first. Using this approach, you can rewrite the app above as follows:
+The same [SnowflakeConnection](/library/api-reference/connections/st.connections.snowflakeconnection) used above also provides access to the [Snowpark Session](https://docs.snowflake.com/en/developer-guide/snowpark/reference/python/session.html) for DataFrame-style operations that run natively inside Snowflake. Using this approach, you can rewrite the app above as follows:
 
 ```python
 # streamlit_app.py
@@ -147,5 +147,5 @@ If everything worked out (and you used the example table we created above), your
 
 This tutorial assumes a local Streamlit app, however you can also connect to Snowflake from apps hosted in Community Cloud. The main additional steps are:
 
-- [Include information about dependencies](/streamlit-community-cloud/deploy-your-app/app-dependencies) using a `requirements.txt` file with `snowflake-connector-python` and any other dependencies.
+- [Include information about dependencies](/streamlit-community-cloud/deploy-your-app/app-dependencies) using a `requirements.txt` file with `snowflake-snowpark-python` and any other dependencies.
 - [Add your secrets](/streamlit-community-cloud/deploy-your-app/secrets-management#deploy-an-app-and-set-up-secrets) to your Community Cloud app.

--- a/content/library/api/connections/connections-snowflake.md
+++ b/content/library/api/connections/connections-snowflake.md
@@ -20,6 +20,8 @@ Maintain the redirect if moved or modified.
 
 `st.connection("snowflake")` can be configured using [Streamlit secrets](/library/advanced-features/secrets-management) or keyword args just like any other connection. It can also use existing Snowflake connection configuration when available.
 
+Note that [snowflake-snowpark-python](https://pypi.org/project/snowflake-snowpark-python/) must be installed to use this connection.
+
 #### Using Streamlit secrets
 
 For example, if your Snowflake account supports SSO, you can set up a quick local connection for development using [browser-based SSO](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use#how-browser-based-sso-works) and `secrets.toml` as follows:

--- a/content/library/api/connections/connections-sql.md
+++ b/content/library/api/connections/connections-sql.md
@@ -13,6 +13,8 @@ This page only contains the `st.connections.SQLConnection` class. For a deeper d
 
 ### Basic usage:
 
+[SQLAlchemy](https://pypi.org/project/SQLAlchemy/) and any required drivers must be installed to use this connection.
+
 ```python
 import streamlit as st
 


### PR DESCRIPTION
## 📚 Context

I discovered there's a bug in SnowflakeConnection where it actually requires `snowflake-snowpark-python` to be installed for any usage. Hoping we can fix this bug soon but in the meantime want the docs to be accurate.

Will happily submit a PR to reverse this once fixed, if needed.

## 🧠 Description of Changes

- Updated references from the Snowflake Connector to Snowpark library in tutorial and API docs for SnowflakeConnection
- Added an explicit statement that SQLAlchemy must be installed to use the SQLConnection for completeness

## 💥 Impact

Not much!

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
