### PR TITLE
Correct versioning error for column_config

### DIFF
--- a/content/menu.md
+++ b/content/menu.md
@@ -81,7 +81,6 @@ site_menu:
     isVersioned: true
   - category: Streamlit library / API reference / Data elements / st.column_config
     url: /library/api-reference/data/st.column_config
-    isVersioned: true
   - category: Streamlit library / API reference / Data elements / st.column_config / Column
     url: /library/api-reference/data/st.column_config/st.column_config.column
     isVersioned: true


### PR DESCRIPTION
## 📚 Context
/library/api-reference/data/st.column_config was marked versioned when it isn't. This broke the page when navigating to it for an older version selected. The versioning flag was removed.

## 💥 Impact
- [X] Small

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
