### PR TITLE
Fix light theme styling on refcard code blocks

### DIFF
--- a/components/blocks/refCard.module.css
+++ b/components/blocks/refCard.module.css
@@ -66,7 +66,7 @@
   @apply text-white;
 }
 
-:global(.dark) .Container section div pre {
+:global(.dark) .Container section div {
   @apply bg-gray-90 text-white;
 }
 
@@ -147,45 +147,42 @@
 
 .Container section div {
   @apply flex flex-col flex-1;
-}
-
-.Container section div pre {
   @apply m-0 rounded-none p-4 h-full text-sm tracking-tight;
   @apply bg-gray-10;
   @apply text-gray-80;
 }
 
 /* Code block adjustments */
-.Container section div pre code :global(.operator) {
+.Container section div code :global(.operator) {
   @apply text-yellow-90;
 }
 
-.Container section div pre code :global(.decorator) {
+.Container section div code :global(.decorator) {
   @apply text-yellow-100;
 }
 
-.Container section div pre code :global(.keyword) {
+.Container section div code :global(.keyword) {
   @apply text-darkBlue-70;
 }
 
-.Container section div pre code :global(.builtin) {
+.Container section div code :global(.builtin) {
   @apply text-lightBlue-80;
 }
 
-.Container section div pre code :global(.string) {
+.Container section div code :global(.string) {
   @apply text-green-80;
 }
 
-.Container section div pre code :global(.number) {
+.Container section div code :global(.number) {
   @apply text-red-90;
 }
 
-.Container section div pre code :global(.function) {
+.Container section div code :global(.function) {
   @apply text-red-60;
 }
 
-.Container section div pre code :global(.comment),
-.Container section div pre code :global(.punctuation) {
+.Container section div code :global(.comment),
+.Container section div code :global(.punctuation) {
   @apply text-gray-60;
 }
 


### PR DESCRIPTION
## 📚 Context

Among other things, #914 "made \<Code\> component no longer wrap its children in a \<pre\>. ". As a result, the styling on code blocks within \<RefCard\> needs to be updated to remove the rule on \<pre\>. This styling issue was first reported by @sfc-gh-jrieke.

**Revised:**

![image](https://github.com/streamlit/docs/assets/20672874/2cf7a126-de94-4d70-befc-e5c1657e51b1)

**Current:**

![image](https://github.com/streamlit/docs/assets/20672874/9b628f3e-c24a-4c2e-bcee-17428b11a945)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [x] [Slack](https://snowflake.slack.com/archives/C039XQ62PB7/p1704921808177289)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
