### PR TITLE
Add st.experimental_user with SiS versioning

### DIFF
--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -296,6 +296,10 @@ const Autofunction = ({
     footers.push({ title: "Warning", body: functionObject.warning });
   }
 
+  // propertiesRows is initialized early to all "parameters" in class docstrings
+  // to be diverted to the properties section
+  let propertiesRows = [];
+
   for (const index in functionObject.args) {
     const row = {};
     const param = functionObject.args[index];
@@ -335,8 +339,14 @@ const Autofunction = ({
         ${description}
       `;
     }
-
-    args.push(row);
+    // When "Parameters" are included in a class docstring, they are actually
+    // "Properties." Using "Properties" in the docstring does not result in
+    // individually parsed properties; using "Parameters" is a workaround.
+    if (isClass) {
+      propertiesRows.push(row);
+    } else {
+      args.push(row);
+    }
   }
 
   let methodRows = [];
@@ -380,8 +390,6 @@ const Autofunction = ({
 
     methodRows.push(row);
   }
-
-  let propertiesRows = [];
 
   for (const index in properties) {
     const row = {};
@@ -433,24 +441,6 @@ const Autofunction = ({
     returns.push(row);
   }
 
-  const footTitles = [];
-  const footRowsContent = [];
-
-  if (methods.length) {
-    footTitles.push({ title: "Methods" });
-    footRowsContent.push(methodRows);
-  }
-
-  if (returns.length) {
-    footTitles.push({ title: "Returns" });
-    footRowsContent.push(returns);
-  }
-
-  if (properties.length) {
-    footTitles.push({ title: "Properties" });
-    footRowsContent.push(propertiesRows);
-  }
-
   body = (
     <Table
       head={{
@@ -477,12 +467,12 @@ const Autofunction = ({
       foot={[
         methods.length ? { title: "Methods" } : null,
         returns.length ? { title: "Returns" } : null,
-        properties.length ? { title: "Attributes" } : null,
+        propertiesRows.length ? { title: "Attributes" } : null,
       ].filter((section) => section !== null)}
       footRows={[
         methods.length ? methodRows : null,
         returns.length ? returns : null,
-        properties.length ? propertiesRows : null,
+        propertiesRows.length ? propertiesRows : null,
       ].filter((rows) => rows !== null)}
       additionalClass="full-width"
       footers={footers}

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -299,7 +299,7 @@ const Autofunction = ({
   // propertiesRows is initialized early to allow "Parameters" in any class
   // docstring to be diverted to the properties section. Docstring parsing
   // needs modification to first recognize "Attributes" or "Properites" then
-  // then parse their contents.
+  // parse their contents.
   let propertiesRows = [];
 
   for (const index in functionObject.args) {

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -296,8 +296,10 @@ const Autofunction = ({
     footers.push({ title: "Warning", body: functionObject.warning });
   }
 
-  // propertiesRows is initialized early to all "parameters" in class docstrings
-  // to be diverted to the properties section
+  // propertiesRows is initialized early to allow "Parameters" in any class
+  // docstring to be diverted to the properties section. Docstring parsing
+  // needs modification to first recognize "Attributes" or "Properites" then
+  // then parse their contents.
   let propertiesRows = [];
 
   for (const index in functionObject.args) {

--- a/content/library/api/personalization/experimental-user.md
+++ b/content/library/api/personalization/experimental-user.md
@@ -4,122 +4,13 @@ slug: /library/api-reference/personalization/st.experimental_user
 description: st.experimental_user returns information about the logged-in user of private apps on Streamlit Community Cloud.
 ---
 
-# st.experimental_user
-
 <Important>
 
 This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#experimental-features).
 
 </Important>
 
-`st.experimental_user` is a Streamlit command that returns information about the logged-in user on Streamlit Community Cloud. It allows developers to personalize apps for the user viewing the app. In a private Streamlit Community Cloud app, it returns a dictionary with the viewer's email. This value of this field is empty in a public Streamlit Community Cloud app to prevent leaking user emails to developers.
-
-The API closely resembles that of [`st.session_state`](/library/api-reference/session-state) and [`st.secrets`](/streamlit-community-cloud/deploy-your-app/secrets-management). It follows a field-based API, which is very similar to Python dictionaries.
-
-### Allowed fields
-
-The `st.experimental_user` command returns a dictionary with only one field: `email`.
-
-Display the allowed field by passing the command to `st.write`:
-
-```python
-# Display the contents of the dictionary
-st.write(st.experimental_user)
-```
-
-The above displays a dict with one field and value. The field is always `email`:
-
-```json
-{
-  "email": "value"
-}
-```
-
-You can check if a field exists in `st.experimental_user`:
-
-```python
-# Returns True if the field exists
-"email" in st.experimental_user
-
-# Returns False if the field does not exist
-"name" in st.experimental_user
-```
-
-### Read values
-
-Read the value of the `email` field and display it by passing to `st.write`:
-
-```python
-# Dictionary like API
-st.write(st.experimental_user['email'])
-
-# Attribute API
-st.write(st.experimental_user.email)
-```
-
-The above outputs either `None` or the logged-in user's email or test@example.com, depending on where the app is running. Read further to learn about `st.experimental_user`'s context-dependent behavior.
-
-### Updates and modifications
-
-Keys and values for `st.experimental_user` **cannot** be updated or modified. Streamlit throws a handy `StreamlitAPIException` exception if you try to update them:
-
-```python
-st.experimental_user.name = None
-# Throws an exception!
-
-st.experimental_user.email = "hello"
-# Throws an exception!
-```
-
-<Image src="/images/st-user-value-exception.png" />
-
-### Context-dependent behavior
-
-The value of `st.experimental_user.email` is context-dependent. It returns a value depending on where the app is running. The [private](#private-app-on-streamlit-cloud) or [public](#public-app-on-streamlit-cloud) app can be running on Streamlit Community Cloud, [locally](#local-development), or on a [3rd party cloud provider](#app-deployed-on-a-3rd-party-cloud-provider). Let's look at the different scenarios.
-
-#### **Private app on Streamlit Community Cloud**
-
-Users need to be logged in to Streamlit Community Cloud to view private apps. If a user is not logged, they see:
-
-<div style={{ maxWidth: '65%', marginBottom: '-1em', marginLeft: '8em' }}>
-    <Image src="/images/private-app-access.png" />
-</div>
-
-If a user is logged in, `st.experimental_user.email` returns the user's email. Suppose a user logged in to Streamlit Community Cloud using jane@email.com:
-
-```python
-st.experimental_user.email
-# Returns: jane@email.com
-```
-
-#### **Public app on Streamlit Community Cloud**
-
-Currently, `st.experimental_user.email` returns information about the logged-in user of _private apps_ on Streamlit Community Cloud. If used in a public app, it returns `None`. For example:
-
-```python
-st.experimental_user.email
-# Returns: None
-```
-
-This value of this field is empty in a public Streamlit Community Cloud app to prevent leaking user emails to developers.
-
-#### **Local development**
-
-When developing locally, `st.experimental_user.email` returns test@example.com. We don't return `None` to make it easier to locally test this functionality. For example:
-
-```python
-st.experimental_user.email
-# Returns: test@example.com
-```
-
-#### **App deployed on a 3rd party cloud provider**
-
-When deploying an app on a 3rd party cloud provider (e.g. Amazon EC2, Heroku, etc), `st.experimental_user.email` behaves the same as during local development. For example:
-
-```python
-st.experimental_user.email # On a 3rd party cloud provider
-# Returns: test@example.com
-```
+<Autofunction function="streamlit.experimental_user" />
 
 ### Examples
 
@@ -163,8 +54,4 @@ if st.experimental_user.email:
     st.write('Hello, %s!' % name)
 ```
 
-### Caveats and limitations
-
-- `st.experimental_user` is **read-only**. You cannot update or modify its value. Doing so will throw a `StreamlitAPIException`.
-- A valid email is returned only if the user is logged in to Streamlit Community Cloud and the app is private. Else, `None` or test@example.com is returned.
-- This is an experimental feature. Experimental features and their APIs may change or be removed at any time. To learn more, click [here](/library/advanced-features/prerelease#experimental-features).
+<Autofunction function="streamlit.experimental_user.to_dict" />

--- a/content/menu.md
+++ b/content/menu.md
@@ -376,7 +376,7 @@ site_menu:
     isVersioned: false
   - category: Streamlit library / API reference / Personalization / st.experimental_user
     url: /library/api-reference/personalization/st.experimental_user
-    isVersioned: false
+    isVersioned: true
   - category: Streamlit library / API reference / Connections and databases
     url: /library/api-reference/connections
   - category: Streamlit library / API reference / Connections and databases / st.connection

--- a/python/generate.py
+++ b/python/generate.py
@@ -82,7 +82,7 @@ def get_github_source(func):
             try:
                 line = inspect.getsourcelines(func.__call__)[1]
             except:
-                line=""
+                return ""
     # Get the relative path after the "streamlit" directory
     rel_path = os.path.relpath(
         source_file, start=os.path.join(streamlit.__path__[0], "..")
@@ -146,6 +146,8 @@ def get_docstring_dict(
                 f"{signature_prefix}.{method_name}",
                 is_class_method=True,
             )
+            if meth_obj["source"] == "":
+                continue
             description["methods"].append(meth_obj)
 
         # Get the class's properties
@@ -456,8 +458,10 @@ def get_obj_docstring_dict(obj, key_prefix, signature_prefix, only_include=None)
                 is_property,
             )
 
-        # Add the extracted metadata to obj_docstring_dict
-        obj_docstring_dict[fullname] = member_docstring_dict
+        # Add the extracted metadata to obj_docstring_dict if the object is
+        # local to streamlit (null source occurs when the object is inherited
+        if member_docstring_dict["source"]:
+            obj_docstring_dict[fullname] = member_docstring_dict
 
     return obj_docstring_dict
 
@@ -518,11 +522,25 @@ def get_streamlit_docstring_dict():
             "streamlit.testing.v1.element_tree",
             "st.testing.v1.element_tree",
         ],
+        streamlit.user_info.UserInfoProxy: ["streamlit.experimental_user", "st.experimental_user"],
+    }
+    proxy_obj_key = {
+        streamlit.user_info.UserInfoProxy: ["streamlit.experimental_user", "st.experimental_user"],
     }
 
     module_docstring_dict = {}
     for obj, key in obj_key.items():
         module_docstring_dict.update(get_obj_docstring_dict(obj, *key))
+    for obj, key in proxy_obj_key.items():
+        member_docstring_dict = get_docstring_dict(
+                obj, #member
+                key[0].split(".")[-1], #membername
+                "st", #signature_prefix
+                True, #isClass
+                False, #is_class_method
+                False, #is_property
+            )
+        module_docstring_dict.update({key[0]: member_docstring_dict})
 
     return module_docstring_dict
 


### PR DESCRIPTION
## 📚 Context
This PR is the final piece to publish a SiS version in the docs and includes the feature st.experimental_user which was previously not versioned.

## 🧠 Description of Changes
* st.experimental_user is now versioned
* All versioned function include an option to select Streamlit in Snowflake. This reflects excluded and modified functions.

## 💥 Impact
Not small

## 🌐 References
* Notion task: [Add SiS version to docs](https://www.notion.so/snowflake-corp/Add-SiS-version-to-doc-30330ce0884f4828bab10c83b8f15614?pvs=4)
* Notion task: [Docs for st.experimental_user for SiS](https://www.notion.so/snowflake-corp/Docs-for-st-experimental_user-for-SiS-54133328c46d47c494edf41a1f9cf2ad?pvs=4)

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
