### PR TITLE
Prevent empty comments in page title in head

### DIFF
--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -257,7 +257,7 @@ export default function Article({
         <section className={styles.Container}>
           <SideBar slug={slug} menu={menu} />
           <Head>
-            <title>{data.title} - Streamlit Docs</title>
+            <title>{data.title + " - Streamlit Docs"}</title>
             <link rel="icon" href="/favicon.svg" />
             <link rel="alternate icon" href="/favicon32.ico" />
             <meta name="theme-color" content="#ffffff" />


### PR DESCRIPTION
## 📚 Context
Page titles had empty comments inserted which resulted in incorrect auto-text when pasting links (such as within the forum).

## 🧠 Description of Changes
Tweaked where the page title was filled in to concatenate the ` - Streamlit Docs` text _before_ inserting into `<title>`. 

**Revised:**
![image](https://github.com/streamlit/docs/assets/135349133/3463d1cb-d4a2-44c1-be53-f5f5819a79e0)


**Current:**
![image](https://github.com/streamlit/docs/assets/135349133/49d19696-b1fd-4609-afba-d59aeec7a1b5)

## 💥 Impact
Size:
- [X] Small

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
