### PR TITLE
Note MPA behavior of `st.query_params`

### DIFF
--- a/content/library/api/utilities/query_params.md
+++ b/content/library/api/utilities/query_params.md
@@ -23,7 +23,7 @@ https://your_app.streamlit.app/?first_key=1&second_key=two&third_key=true
 
 ```
 
-A key-value pair prefixed with `?` is added to the end of your app's URL. Additional key-value pairs can be added. Each additional pair is prefixed with `&` instead of `?`. All keys and values will be set and returned as strings.
+A key-value pair prefixed with `?` is added to the end of your app's URL. Additional key-value pairs can be added. Each additional pair is prefixed with `&` instead of `?`. All keys and values will be set and returned as strings. Query parameters are cleared when navigating between pages in a multipage app.
 
 ### Repeated keys
 


### PR DESCRIPTION
## 📚 Context
Release of `st.query_params` came with a behavior change that was noted in the release notes. This PR adds a sentence to the description of `st.query_params` to make sure this is commented on the function's page, too.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
