### PR TITLE
Fixed typo in additional-features.md

### DIFF
--- a/content/get-started/fundamentals/additional-features.md
+++ b/content/get-started/fundamentals/additional-features.md
@@ -105,7 +105,7 @@ Our documentation on [Multipage apps](/library/advanced-features/multipage-apps)
 
 ## Static file serving
 
-As you learned in Streamlit fundamentals, Streamlit runs a server that clients connect to. That means viewers of your app don't have direct access to the files which are local to your to your app. Most of the time, this doesn't matter because Streamlt commands handle that for you. When you use `st.image(<path-to-image>)` your Streamlit server will access the file and handle the necessary hosting so your app viewers can see it. However, if you want a direct URL to an image or file you'll need to host it. This requires setting the correct configuration and placing your hosted files in a directory named `static`. For example, your project could look like:
+As you learned in Streamlit fundamentals, Streamlit runs a server that clients connect to. That means viewers of your app don't have direct access to the files which are local to your app. Most of the time, this doesn't matter because Streamlt commands handle that for you. When you use `st.image(<path-to-image>)` your Streamlit server will access the file and handle the necessary hosting so your app viewers can see it. However, if you want a direct URL to an image or file you'll need to host it. This requires setting the correct configuration and placing your hosted files in a directory named `static`. For example, your project could look like:
 
 ```bash
 your-project/


### PR DESCRIPTION
Fixed a typo: In the Static file serving section, at the end of the second sentence it says "to your" twice.

## 📚 Context

Typo in tutorial documentation.

## 🧠 Description of Changes

In the **Static file serving** section, at the end of the second sentence it says "to your" twice.

**Revised:**

> As you learned in Streamlit fundamentals, Streamlit runs a server that clients connect to. That means viewers of your app don't have direct access to the files which are local to your ~to your~ app.

**Current:**

> As you learned in Streamlit fundamentals, Streamlit runs a server that clients connect to. That means viewers of your app don't have direct access to the files which are local **to your to your** app.

## 💥 Impact

Minimal


<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
