### PR TITLE
Add left and right margins for code in headers

### DIFF
--- a/components/utilities/headerLink.module.css
+++ b/components/utilities/headerLink.module.css
@@ -11,6 +11,10 @@
   @apply font-bold;
 }
 
+.HeaderContainer code {
+  @apply ml-1 mr-1;
+}
+
 h1.HeaderContainer {
   @apply leading-tight;
 }

--- a/components/utilities/headerLink.module.css
+++ b/components/utilities/headerLink.module.css
@@ -12,7 +12,7 @@
 }
 
 .HeaderContainer code {
-  @apply ml-2 mr-2;
+  @apply mx-2;
 }
 
 h1.HeaderContainer {

--- a/components/utilities/headerLink.module.css
+++ b/components/utilities/headerLink.module.css
@@ -12,7 +12,7 @@
 }
 
 .HeaderContainer code {
-  @apply ml-1 mr-1;
+  @apply ml-2 mr-2;
 }
 
 h1.HeaderContainer {


### PR DESCRIPTION
## 📚 Context
When code text appears in headers, it does not have proper margins on the left and right. This PR adds the left and right margins.

## 🧠 Description of Changes
**Revised:**
<img width="857" alt="image" src="https://github.com/streamlit/docs/assets/135349133/44a7608d-dd0a-46da-bac7-ec71838302a2">

**Current:**
<img width="782" alt="image" src="https://github.com/streamlit/docs/assets/135349133/438c86a3-dc0e-4f53-81e2-f2b3f1e2a6a5">

## 💥 Impact
Size:
- [X] Small

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
