### PR TITLE
Check for and show keyword-only arguments in Autofunction

### DIFF
--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -160,6 +160,7 @@ const Autofunction = ({
 
   const footers = [];
   const args = [];
+  const kwargs = [];
   const returns = [];
   const versionList = reverse(versions.slice());
   let functionObject;
@@ -305,39 +306,26 @@ const Autofunction = ({
   for (const index in functionObject.args) {
     const row = {};
     const param = functionObject.args[index];
-    const isDeprecated =
-      param.deprecated && param.deprecated.deprecated === true;
-    const deprecatedMarkup = isDeprecated
-      ? `
-      <div class="${styles.DeprecatedContent}">
-        <i class="material-icons-sharp">
-          delete
-        </i>
-        ${param.deprecated.deprecatedText}
-      </div>`
-      : "";
     const description = param.description
       ? param.description
       : `<p>No description</p> `;
 
     if (param.is_optional) {
       row["title"] = `
-          <p class="${isDeprecated ? "deprecated" : ""}">
+          <p>
             ${param.name}
             <span class='italic code'>(${param.type_name})</span>
           </p> `;
       row["body"] = `
-        ${deprecatedMarkup}
         ${description}
       `;
     } else {
       row["title"] = `
-          <p class="${isDeprecated ? "deprecated" : ""}">
+          <p>
             <span class='bold'>${param.name}</span>
             <span class='italic code'>(${param.type_name})</span>
           </p>`;
       row["body"] = `
-        ${deprecatedMarkup}
         ${description}
       `;
     }
@@ -346,6 +334,8 @@ const Autofunction = ({
     // individually parsed properties; using "Parameters" is a workaround.
     if (isClass) {
       propertiesRows.push(row);
+    } else if (param.is_kwarg_only) {
+      kwargs.push(row);
     } else {
       args.push(row);
     }
@@ -364,31 +354,15 @@ const Autofunction = ({
     const type_name = method.signature
       ? method.signature.match(/\((.*)\)/)[1]
       : "";
-    const isDeprecated =
-      method.deprecated && method.deprecated.deprecated === true;
-    const deprecatedMarkup = isDeprecated
-      ? `
-    <div class="${styles.DeprecatedContent}">
-      <i class="material-icons-sharp">
-        delete
-      </i>
-      ${method.deprecated.deprecatedText}
-    </div>`
-      : "";
     const description = method.description
       ? method.description
       : `<p>No description</p> `;
     // Add a link to the method by appending the method name to the current URL using slug.slice();
     row["title"] = `
-    <p class="${isDeprecated ? "deprecated" : ""}">
-      <a href="/${slicedSlug}#${hrefName}"><span class='bold'>${
-        method.name
-      }</span></a><span class='italic code'>(${type_name})</span>
+    <p>
+      <a href="/${slicedSlug}#${hrefName}"><span class='bold'>${method.name}</span></a><span class='italic code'>(${type_name})</span>
     </p>`;
-    row["body"] = `
-    ${deprecatedMarkup}
-    ${description}
-  `;
+    row["body"] = `${description}`;
 
     methodRows.push(row);
   }
@@ -401,31 +375,15 @@ const Autofunction = ({
       .toLowerCase()
       .replace("streamlit", "st")
       .replace(/[.,\/#!$%\^&\*;:{}=\-`~()]/g, "");
-    const isDeprecated =
-      property.deprecated && property.deprecated.deprecated === true;
-    const deprecatedMarkup = isDeprecated
-      ? `
-    <div class="${styles.DeprecatedContent}">
-      <i class="material-icons-sharp">
-        delete
-      </i>
-      ${property.deprecated.deprecatedText}
-    </div>`
-      : "";
     const description = property.description
       ? property.description
       : `<p>No description</p> `;
     // Add a link to the method by appending the method name to the current URL using slug.slice();
     row["title"] = `
-    <p class="${isDeprecated ? "deprecated" : ""}">
-      <a href="/${slicedSlug}#${hrefName}"><span class='bold'>${
-        property.name
-      }</span>
+    <p>
+      <a href="/${slicedSlug}#${hrefName}"><span class='bold'>${property.name}</span>
     </p>`;
-    row["body"] = `
-    ${deprecatedMarkup}
-    ${description}
-  `;
+    row["body"] = `${description}`;
     propertiesRows.push(row);
   }
 
@@ -467,11 +425,13 @@ const Autofunction = ({
       body={args.length ? { title: "Parameters" } : null}
       bodyRows={args.length ? args : null}
       foot={[
+        kwargs.length ? { title: "Keyword-only parameters" } : null,
         methods.length ? { title: "Methods" } : null,
         returns.length ? { title: "Returns" } : null,
         propertiesRows.length ? { title: "Attributes" } : null,
       ].filter((section) => section !== null)}
       footRows={[
+        kwargs.length ? kwargs : null,
         methods.length ? methodRows : null,
         returns.length ? returns : null,
         propertiesRows.length ? propertiesRows : null,

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -306,6 +306,17 @@ const Autofunction = ({
   for (const index in functionObject.args) {
     const row = {};
     const param = functionObject.args[index];
+    const isDeprecated =
+      param.deprecated && param.deprecated.deprecated === true;
+    const deprecatedMarkup = isDeprecated
+      ? `
+      <div class="${styles.DeprecatedContent}">
+        <i class="material-icons-sharp">
+          delete
+        </i>
+        ${param.deprecated.deprecatedText}
+      </div>`
+      : "";
     const description = param.description
       ? param.description
       : `<p>No description</p> `;
@@ -321,11 +332,12 @@ const Autofunction = ({
       `;
     } else {
       row["title"] = `
-          <p>
+          <pclass="${isDeprecated ? "deprecated" : ""}">
             <span class='bold'>${param.name}</span>
             <span class='italic code'>(${param.type_name})</span>
           </p>`;
       row["body"] = `
+        ${deprecatedMarkup}
         ${description}
       `;
     }
@@ -354,15 +366,31 @@ const Autofunction = ({
     const type_name = method.signature
       ? method.signature.match(/\((.*)\)/)[1]
       : "";
+    const isDeprecated =
+      method.deprecated && method.deprecated.deprecated === true;
+    const deprecatedMarkup = isDeprecated
+      ? `
+      <div class="${styles.DeprecatedContent}">
+        <i class="material-icons-sharp">
+          delete
+        </i>
+        ${method.deprecated.deprecatedText}
+      </div>`
+      : "";
     const description = method.description
       ? method.description
       : `<p>No description</p> `;
     // Add a link to the method by appending the method name to the current URL using slug.slice();
     row["title"] = `
-    <p>
-      <a href="/${slicedSlug}#${hrefName}"><span class='bold'>${method.name}</span></a><span class='italic code'>(${type_name})</span>
-    </p>`;
-    row["body"] = `${description}`;
+      <p class="${isDeprecated ? "deprecated" : ""}">
+        <a href="/${slicedSlug}#${hrefName}"><span class='bold'>${
+          method.name
+        }</span></a><span class='italic code'>(${type_name})</span>
+      </p>`;
+    row["body"] = `
+      ${deprecatedMarkup}
+      ${description}
+    `;
 
     methodRows.push(row);
   }
@@ -375,15 +403,31 @@ const Autofunction = ({
       .toLowerCase()
       .replace("streamlit", "st")
       .replace(/[.,\/#!$%\^&\*;:{}=\-`~()]/g, "");
+    const isDeprecated =
+      property.deprecated && property.deprecated.deprecated === true;
+    const deprecatedMarkup = isDeprecated
+      ? `
+    <div class="${styles.DeprecatedContent}">
+      <i class="material-icons-sharp">
+        delete
+      </i>
+      ${property.deprecated.deprecatedText}
+    </div>`
+      : "";
     const description = property.description
       ? property.description
       : `<p>No description</p> `;
     // Add a link to the method by appending the method name to the current URL using slug.slice();
     row["title"] = `
-    <p>
-      <a href="/${slicedSlug}#${hrefName}"><span class='bold'>${property.name}</span>
-    </p>`;
-    row["body"] = `${description}`;
+      <p class="${isDeprecated ? "deprecated" : ""}">
+        <a href="/${slicedSlug}#${hrefName}"><span class='bold'>${
+          property.name
+        }</span>
+      </p>`;
+    row["body"] = `
+      ${deprecatedMarkup}
+      ${description}
+    `;
     propertiesRows.push(row);
   }
 

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -160,7 +160,6 @@ const Autofunction = ({
 
   const footers = [];
   const args = [];
-  const kwargs = [];
   const returns = [];
   const versionList = reverse(versions.slice());
   let functionObject;
@@ -323,20 +322,26 @@ const Autofunction = ({
 
     if (param.is_optional) {
       row["title"] = `
-          <p class="${isDeprecated ? "deprecated" : ""}">
-            ${param.name}
-            <span class='italic code'>(${param.type_name})</span>
-          </p> `;
+        <p class="${isDeprecated ? "deprecated" : ""} ${
+          param.is_kwarg_only ? styles.Keyword : ""
+        }">
+          ${param.name}<br />
+          <span class='italic code'>(${param.type_name})</span>
+        </p> 
+      `;
       row["body"] = `
         ${description}
         ${deprecatedMarkup}
       `;
     } else {
       row["title"] = `
-          <p class="${isDeprecated ? "deprecated" : ""}">
-            <span class='bold'>${param.name}</span>
-            <span class='italic code'>(${param.type_name})</span>
-          </p>`;
+        <p class="${isDeprecated ? "deprecated" : ""} ${
+          param.is_kwarg_only ? styles.Keyword : ""
+        }">
+          <span class='bold'>${param.name}</span><br />
+          <span class='italic code'>(${param.type_name})</span>
+        </p>
+      `;
       row["body"] = `
         ${deprecatedMarkup}
         ${description}
@@ -347,8 +352,6 @@ const Autofunction = ({
     // individually parsed properties; using "Parameters" is a workaround.
     if (isClass) {
       propertiesRows.push(row);
-    } else if (param.is_kwarg_only) {
-      kwargs.push(row);
     } else {
       args.push(row);
     }
@@ -470,13 +473,11 @@ const Autofunction = ({
       body={args.length ? { title: "Parameters" } : null}
       bodyRows={args.length ? args : null}
       foot={[
-        kwargs.length ? { title: "Keyword-only parameters" } : null,
         methods.length ? { title: "Methods" } : null,
         returns.length ? { title: "Returns" } : null,
         propertiesRows.length ? { title: "Attributes" } : null,
       ].filter((section) => section !== null)}
       footRows={[
-        kwargs.length ? kwargs : null,
         methods.length ? methodRows : null,
         returns.length ? returns : null,
         propertiesRows.length ? propertiesRows : null,

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -323,7 +323,7 @@ const Autofunction = ({
 
     if (param.is_optional) {
       row["title"] = `
-          <p>
+          <p class="${isDeprecated ? "deprecated" : ""}">
             ${param.name}
             <span class='italic code'>(${param.type_name})</span>
           </p> `;
@@ -332,7 +332,7 @@ const Autofunction = ({
       `;
     } else {
       row["title"] = `
-          <pclass="${isDeprecated ? "deprecated" : ""}">
+          <p class="${isDeprecated ? "deprecated" : ""}">
             <span class='bold'>${param.name}</span>
             <span class='italic code'>(${param.type_name})</span>
           </p>`;

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -310,7 +310,7 @@ const Autofunction = ({
     const deprecatedMarkup = isDeprecated
       ? `
       <div class="${styles.DeprecatedContent}">
-        <i class="material-icons-sharp">
+        <i class="material-icons-sharp ${styles.DeprecatedIcon}">
           delete
         </i>
         ${param.deprecated.deprecatedText}
@@ -327,7 +327,6 @@ const Autofunction = ({
           ${param.is_kwarg_only ? styles.Keyword : ""}
         ">
           ${param.name}
-          <br />
           <span class='italic code'>(${param.type_name})</span>
         </p> 
       `;
@@ -342,7 +341,6 @@ const Autofunction = ({
           ${param.is_kwarg_only ? styles.Keyword : ""}
         ">
           <span class='bold'>${param.name}</span>
-          <br />
           <span class='italic code'>(${param.type_name})</span>
         </p>
       `;

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -322,23 +322,27 @@ const Autofunction = ({
 
     if (param.is_optional) {
       row["title"] = `
-        <p class="${isDeprecated ? "deprecated" : ""} ${
-          param.is_kwarg_only ? styles.Keyword : ""
-        }">
-          ${param.name}<br />
+        <p class="
+          ${isDeprecated ? "deprecated" : ""}
+          ${param.is_kwarg_only ? styles.Keyword : ""}
+        ">
+          ${param.name}
+          <br />
           <span class='italic code'>(${param.type_name})</span>
         </p> 
       `;
       row["body"] = `
-        ${description}
         ${deprecatedMarkup}
+        ${description}
       `;
     } else {
       row["title"] = `
-        <p class="${isDeprecated ? "deprecated" : ""} ${
-          param.is_kwarg_only ? styles.Keyword : ""
-        }">
-          <span class='bold'>${param.name}</span><br />
+        <p class="
+          ${isDeprecated ? "deprecated" : ""}
+          ${param.is_kwarg_only ? styles.Keyword : ""}
+        ">
+          <span class='bold'>${param.name}</span>
+          <br />
           <span class='italic code'>(${param.type_name})</span>
         </p>
       `;

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -329,6 +329,7 @@ const Autofunction = ({
           </p> `;
       row["body"] = `
         ${description}
+        ${deprecatedMarkup}
       `;
     } else {
       row["title"] = `

--- a/components/blocks/autofunction.module.css
+++ b/components/blocks/autofunction.module.css
@@ -168,7 +168,7 @@
 }
 
 .Keyword::after {
-  @apply block bg-gray-20 text-gray-70 text-opacity-100 text-2xs rounded-lg w-fit px-1 py-0;
+  @apply block bg-gray-20 text-gray-80 text-opacity-100 text-2xs rounded-lg w-fit px-2 py-0;
   content: "keyword-only";
 }
 

--- a/components/blocks/autofunction.module.css
+++ b/components/blocks/autofunction.module.css
@@ -158,3 +158,16 @@
 :global(.dark) .DeprecatedContent {
   @apply bg-orange-100/30;
 }
+
+td:has(> div > .Keyword) {
+  @apply relative;
+}
+
+td:has(> div > .Keyword)::after {
+  @apply text-gray-70 text-2xs leading-5 px-1 absolute top-0 right-0;
+  content: "keyword-only";
+}
+
+:global(.dark) td::after > div > .Keyword {
+  @apply text-gray-30;
+}

--- a/components/blocks/autofunction.module.css
+++ b/components/blocks/autofunction.module.css
@@ -144,30 +144,34 @@
 
 /* Styles for deprecation notice in param */
 .DeprecatedContent {
-  @apply bg-orange-20 text-gray-90 px-2 py-1 rounded-md text-sm mb-2 flex items-center;
+  @apply bg-orange-20 text-gray-90 px-2 py-1 rounded-md text-sm mb-2 flex items-center relative;
 }
 
 .DeprecatedContent i {
   @apply text-base text-orange-70 mr-2;
 }
 
+.DeprecatedContent p {
+  @apply ml-5;
+}
+
 .DeprecatedContent p tt {
   @apply text-sm;
+}
+
+.DeprecatedIcon {
+  @apply absolute top-0 left-2;
 }
 
 :global(.dark) .DeprecatedContent {
   @apply bg-orange-100/30;
 }
 
-td:has(> div > .Keyword) {
-  @apply relative;
-}
-
-td:has(> div > .Keyword)::after {
-  @apply text-gray-70 text-2xs leading-5 px-1 absolute top-0 right-0;
+.Keyword::after {
+  @apply block bg-gray-20 text-gray-70 text-opacity-100 text-2xs rounded-lg w-fit px-1 py-0;
   content: "keyword-only";
 }
 
-:global(.dark) td::after > div > .Keyword {
-  @apply text-gray-30;
+:global(.dark) .Keyword::after {
+  @apply bg-gray-80 text-gray-30;
 }

--- a/python/generate.py
+++ b/python/generate.py
@@ -369,8 +369,10 @@ def get_sig_string_without_annots(func):
                 args.append("/")
         # Insert "*" if this is the first keyword-only argument
         if param.kind is param.KEYWORD_ONLY:
-            if (prev is None) or (prev.kind is not param.KEYWORD_ONLY):
-                args.append("*")
+            if (prev is not None) and (prev.kind is prev.VAR_POSITIONAL):
+                pass
+            elif (prev is None) or (prev.kind is not prev.KEYWORD_ONLY):
+                    args.append("*")
 
         # If the parameter has a default value, format it accordingly
         if param.default != inspect._empty:

--- a/python/generate.py
+++ b/python/generate.py
@@ -364,10 +364,9 @@ def get_sig_string_without_annots(func):
             continue
 
         # Insert "/" if the previous param was the last positional-only param
-        if param.kind is param.POSITIONAL_OR_KEYWORD:
-            if (prev is not None) and (prev.kind is param.POSITIONAL_ONLY):
+        if (prev is not None) and (prev.kind is param.POSITIONAL_ONLY):
+            if param.kind is not param.POSITIONAL_ONLY:
                 args.append("/")
-                prev_was_positional_only = False
         # Insert "*" if this is the first keyword-only argument
         if param.kind is param.KEYWORD_ONLY:
             if (prev is None) or (prev.kind is not param.KEYWORD_ONLY):
@@ -398,6 +397,10 @@ def get_sig_string_without_annots(func):
 
         # Set the current parameter as the previous one for the next iteration
         prev = param
+    
+    # Edge case: append "/" if all parameters were positional-only
+    if (prev is not None) and (prev.kind is param.POSITIONAL_ONLY):
+        args.append("/")
 
     # Return the formatted argument string
     return ", ".join(args)

--- a/python/generate.py
+++ b/python/generate.py
@@ -73,20 +73,28 @@ def get_github_source(func):
         except AttributeError:
             source_file = inspect.getsourcefile(func.__call__)
 
-    try:
-        line = inspect.getsourcelines(func)[1]
-    except: #TypeError:
-        try:
-            line = inspect.getsourcelines(func.fget)[1]
-        except: #AttributeError:
-            try:
-                line = inspect.getsourcelines(func.__call__)[1]
-            except:
-                return ""
     # Get the relative path after the "streamlit" directory
     rel_path = os.path.relpath(
         source_file, start=os.path.join(streamlit.__path__[0], "..")
     )
+
+    # Exit if not in the Streamlit library
+    if ".." in rel_path:
+        return ""
+
+    try:
+        line = inspect.getsourcelines(func)[1]
+    except TypeError:
+        try:
+            line = inspect.getsourcelines(func.fget)[1]
+        except AttributeError:
+            try:
+                line = inspect.getsourcelines(func.__call__)[1]
+            except:
+                print(f"No line found for {func}")
+                return ""
+
+
 
     return "".join([repo_prefix, rel_path, f"#L{line}"])
 
@@ -258,6 +266,25 @@ def get_docstring_dict(
             arg_obj["name"] = param.arg_name  ## Store the argument name
             arg_obj["type_name"] = param.type_name  # Store the argument type
             arg_obj["is_optional"] = param.is_optional  # Store the optional flag
+            if (not is_class) and callable(obj):
+                if param.arg_name.startswith("**"):
+                    arg_obj["is_kwarg_only"] = True
+                elif param.arg_name == "*args":
+                    arg_obj["is_kwarg_only"] = False
+                else:
+                    try:
+                        # Check if the function is a bound method
+                        if isinstance(obj, types.MethodType):
+                            # Get the signature of the function object being bound
+                            sig = inspect.signature(obj.__func__)
+                        else:
+                            # Get the signature of the function
+                            sig = inspect.signature(obj)
+                        param_obj = sig.parameters[param.arg_name]
+                        arg_obj["is_kwarg_only"] = (param_obj.kind is param_obj.KEYWORD_ONLY)
+                    except:
+                        print(sig)
+                        print(f"Can't find {param.arg_name} as an argument for {obj}")
             arg_obj["description"] = (
                 parse_rst(param.description) if param.description else ""
             )  # Store the argument description (parsed from RST to HTML)
@@ -331,24 +358,19 @@ def get_sig_string_without_annots(func):
     for name, param in sig.parameters.items():
         # Skip the "self" parameter for class methods
         if name == "self":
-            prev = param
+            continue
+        # Skip private parameters that are for internal use
+        if name.startswith("_"):
             continue
 
-        # If there was a previous parameter, check for certain conditions
-        if prev:
-            # Insert "/" if going from positional_only to anything else
-            if (
-                prev.kind is prev.POSITIONAL_ONLY
-                and param.kind is not param.POSITIONAL_ONLY
-            ):
+        # Insert "/" if the previous param was the last positional-only param
+        if param.kind is param.POSITIONAL_OR_KEYWORD:
+            if (prev is not None) and (prev.kind is param.POSITIONAL_ONLY):
                 args.append("/")
                 prev_was_positional_only = False
-
-            # Insert "*" if going from something that's not *foo to keyword-only
-            if (
-                prev.kind not in (prev.VAR_POSITIONAL, prev.KEYWORD_ONLY)
-                and param.kind is param.KEYWORD_ONLY
-            ):
+        # Insert "*" if this is the first keyword-only argument
+        if param.kind is param.KEYWORD_ONLY:
+            if (prev is None) or (prev.kind is not param.KEYWORD_ONLY):
                 args.append("*")
 
         # If the parameter has a default value, format it accordingly

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -41,6 +41,7 @@ module.exports = {
 
     fontSize: {
       // Defaults are: https://tailwindcss.com/docs/font-size
+      "2xs": ["0.667rem", { lineHeight: "1.25rem", letterSpacing: "0.1em" }],
       xs: ["0.75rem", { lineHeight: "1.5rem", letterSpacing: "0.1em" }],
       sm: ["0.875rem", { lineHeight: "1.75rem", letterSpacing: "0.05em" }],
       base: ["1rem", { lineHeight: "2rem" }],


### PR DESCRIPTION
## 📚 Context
Keyword-only arguments have had inconsistent treatment. A previous PR removed the inconsistent message of "This argument can only be supplied by keyword" with the intention of programmatically flagging them to be consistent and complete.

## 🧠 Description of Changes
* `generate.py` included extra lines to flag arguments a keyword only by adding a `is_kwarg_only` field.
* Autofunction will bump arguments from "Parameters" section to a "Keyword-only parameters" section with `is_kwarg_only` is true.
* Autofunction has also been corrected to meaningfully ignore methods defined outside of the Streamlit library. (Previously, a bug was exploited in Python 3.11 to discard these. It's now functional in Python 3.9.)
* If `is_kwarg_only` isn't present (as with previous versions until `streamlit.json` is updated), docstrings will display unchanged. Historical versions can be updated independently to flag keyword-only arguments.
* Removed unused deprecation logic. We do not have arguments within functions marked as deprecated since we save different docstrings for each version. Deprecation is noted at the function level. (We can re-add if we start to utilize that functionality.)

**Revised:**
<table>
  <tr>
    <td><img width="1097" alt="image" src="https://github.com/streamlit/docs/assets/135349133/31981592-6b94-4ae9-886c-4f1cd4717c79"></td>
    <td><img width="856" alt="image" src="https://github.com/streamlit/docs/assets/135349133/8864968f-3bc4-43ea-8661-6da17bed38c6"></td>
  </tr>
</table>

**Current:**
<table>
  <tr>
    <td><img width="980" alt="image" src="https://github.com/streamlit/docs/assets/135349133/96ae760f-ddbe-4eff-a6f1-66ae7665cd2e"></td>
    <td><img width="747" alt="image" src="https://github.com/streamlit/docs/assets/135349133/a3f70f67-7134-49d4-a4ac-35ef6a476013"></td>
  </tr>
</table>


## 💥 Impact
Size:
- [X] Not small

## 🌐 References
Notion task: [Improve keyword-only parameters in docstrings](https://www.notion.so/snowflake-corp/Improve-keyword-only-parameters-in-docstrings-30e899de60b34c09a31711a423e00031?pvs=4)

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
