### PR TITLE
Clarification: Port 3000 limitation and XSRF protection troubleshooting

### DIFF
--- a/content/kb/deployments/remote-start.md
+++ b/content/kb/deployments/remote-start.md
@@ -79,8 +79,7 @@ streamlit run my_app.py --server.enableCORS=false
 ```
 
 If this fixes your issue, **you should re-enable CORS protection** and then set
-`browser.serverPort` and `browser.serverAddress` to the URL and port of your
-Streamlit app.
+`browser.serverAddress` to the URL of your Streamlit app.
 
 If the issue persists, try disabling websocket compression by running Streamlit with the
 `--server.enableWebsocketCompression` flag set to `false`
@@ -110,6 +109,10 @@ with the `--server.enableXsrfProtection` flag set to `false`:
 streamlit run my_app.py --server.enableXsrfProtection=false
 ```
 
-If this fixes your issue, **you should re-enable XSRF protection** and then
-configure your app to use the same secret across every replica by setting the
-`server.cookieSecret` config option to the same hard-to-guess string everywhere.
+If this fixes your issue, **you should re-enable XSRF protection** and try one
+or both of the following:
+
+- Set `browser.serverAddress` and `browser.serverPort` to the URL and port of
+  your Streamlit app.
+- Configure your app to use the same secret across every replica by setting the
+  `server.cookieSecret` config option to the same hard-to-guess string everywhere.

--- a/content/library/advanced-features/configuration.md
+++ b/content/library/advanced-features/configuration.md
@@ -271,6 +271,7 @@ runOnSave = false
 address =
 
 # The port where the server will listen for browser connections.
+# Don't use port 3000 which is reserved for internal development.
 # Default: 8501
 port = 8501
 
@@ -350,9 +351,12 @@ gatherUsageStats = true
 # Port where users should point their browsers in order to connect to the
 # app.
 # This is used to:
-# - Set the correct URL for CORS and XSRF protection purposes.
-# - Show the URL on the terminal
-# - Open the browser
+# - Set the correct URL for XSRF protection purposes.
+# - Show the URL on the terminal (part of `streamlit run`).
+# - Open the browser automatically (part of `streamlit run`).
+# This option is for advanced use cases. To change the port of your app, use
+# `server.Port` instead. Don't use port 3000 which is reserved for internal
+# development.
 # Default: whatever value is set in server.port.
 serverPort = 8501
 ```


### PR DESCRIPTION
## 📚 Context
The PR adds clarification around not using port 3000 and how to properly troubleshoot CORS and XSRF protection problems.

## 🧠 Description of Changes
Updated configuration guide and remote start KB article.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
