### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ To preview your changes, refresh your browser tab and visit the edited page!
 
 ### Add a new docstring to the API Reference
 
-Any time a new version of Streamlit is released, the docstrings stored in `python/streamlit.json` have to be updated by running `make docstrings` . This will build the nesscary Docker image, and update the file with the documentation for the latest release on PyPi.
+Any time a new version of Streamlit is released, the docstrings stored in `python/streamlit.json` have to be updated by running `make docstrings` . This will build the necessary Docker image, and update the file with the documentation for the latest release on PyPi.
 
 If you need to regenerate all function signatures, across all versions, delete the content in `python/streamlit.json`, leaving the file in place, and run `make docstrings`. This will systematically install each version of streamlit, and generate the necessary function signatures in `streamlit.json`.
 


### PR DESCRIPTION
Fixed small typo: changed "nesscary" to "necessary"

## 📚 Context

Reading the documentation a small typo was detected, and has been corrected.

## 🧠 Description of Changes

- README.md: Fixed typo

**Revised:**

![image](https://github.com/streamlit/docs/assets/19372035/1504c6b3-a574-43de-b654-796f34aa5239)

**Current:**

![image](https://github.com/streamlit/docs/assets/19372035/0bd059c2-5964-46f2-97b5-16770cfc6dad)

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [X] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
