### PR TITLE
Fix versioning for `st.write`

### DIFF
--- a/content/menu.md
+++ b/content/menu.md
@@ -41,6 +41,7 @@ site_menu:
     url: /library/api-reference/write-magic
   - category: Streamlit library / API reference / Write and magic / st.write
     url: /library/api-reference/write-magic/st.write
+    isVersioned: true
   - category: Streamlit library / API reference / Write and magic / st.write_stream
     url: /library/api-reference/write-magic/st.write_stream
     isVersioned: true


### PR DESCRIPTION
## 📚 Context
The API reference page for `st.write` was missing its `isVersioned` indicator. This PR fixes that so that the version selector works correctly on that page.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
