### PR TITLE
Fix light-mode scroll-based highlights

### DIFF
--- a/components/utilities/floatingNav.module.css
+++ b/components/utilities/floatingNav.module.css
@@ -26,17 +26,17 @@
 }
 
 /* Styles for the active item on the floating nav */
-:global(.dark) .activeLink {
-  @apply text-white !important;
+.Link {
+  @apply border-none inline-block pr-2 w-40 leading-4 hover:opacity-70 hover:no-underline;
+  @apply text-gray-70 !important;
 }
 
 .activeLink {
   @apply text-gray-90 !important;
 }
 
-.Link {
-  @apply border-none inline-block pr-2 w-40 leading-4 hover:opacity-70 hover:no-underline;
-  @apply text-gray-70 !important;
+:global(.dark) .activeLink {
+  @apply text-white !important;
 }
 
 /* Paddings for different title hierarchies */


### PR DESCRIPTION
## 📚 Context
Scroll-based highlighting was only visible in dark mode. This PR corrects a CSS ordering issue to make the existing scroll-based highlights show up in light mode within the floatingNav (table of contents) component.

## 🧠 Description of Changes
Reordered CSS to ensure light-mode highlights were rendered. No changes were made to the existing contrast.

**Revised:**
<table>
<tr>
<td>
<img width="278" alt="image" src="https://github.com/streamlit/docs/assets/135349133/f26584e3-45d0-44a0-9963-f27922f900c7">
</td>
<td>
<img width="279" alt="image" src="https://github.com/streamlit/docs/assets/135349133/66a4ffe9-cc7e-4e82-a2f4-b695ee4c5e34">
</td>
</tr>
</table>

**Current:**
<table>
<tr>
<td>
<img width="262" alt="image" src="https://github.com/streamlit/docs/assets/135349133/644f8b78-5c56-41e3-a0c8-983083211b03">
</td>
<td>
<img width="279" alt="image" src="https://github.com/streamlit/docs/assets/135349133/c2be4ec1-e4da-40d6-a7b5-1bd9f64f5fa8">
</td>
</tr>
</table>

## 💥 Impact
Size:
- [X] Small

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
