### PR TITLE
Link to Ploomber Cloud deployment guide in KB

### DIFF
--- a/content/kb/tutorials/deploy/index.md
+++ b/content/kb/tutorials/deploy/index.md
@@ -39,6 +39,6 @@ While we work on official Streamlit deployment guides for other hosting provider
 - [How to Deploy Streamlit to a Free Amazon EC2 instance](https://towardsdatascience.com/how-to-deploy-a-streamlit-app-using-an-amazon-free-ec2-instance-416a41f69dc3), by Rahul Agarwal
 - [Host Streamlit on Heroku](https://towardsdatascience.com/quickly-build-and-deploy-an-application-with-streamlit-988ca08c7e83), by Maarten Grootendorst
 - [Host Streamlit on Azure](https://towardsdatascience.com/deploying-a-streamlit-web-app-with-azure-app-service-1f09a2159743), by Richard Peterson
-- [Deploy Streamlit on Ploomber Cloud](https://docs.cloud.ploomber.io/en/latest/apps/streamlit.html), by Eduardo Blancas
+- [Deploy Streamlit on Ploomber Cloud](https://docs.cloud.ploomber.io/en/latest/apps/streamlit.html), by Ido Michael
 - [Host Streamlit on 21YunBox](https://www.21yunbox.com/docs/#/deploy-streamlit), by Toby Lei
 - [Community-supported deployment wiki](https://discuss.streamlit.io/t/streamlit-deployment-guide-wiki/5099).

--- a/content/kb/tutorials/deploy/index.md
+++ b/content/kb/tutorials/deploy/index.md
@@ -39,5 +39,6 @@ While we work on official Streamlit deployment guides for other hosting provider
 - [How to Deploy Streamlit to a Free Amazon EC2 instance](https://towardsdatascience.com/how-to-deploy-a-streamlit-app-using-an-amazon-free-ec2-instance-416a41f69dc3), by Rahul Agarwal
 - [Host Streamlit on Heroku](https://towardsdatascience.com/quickly-build-and-deploy-an-application-with-streamlit-988ca08c7e83), by Maarten Grootendorst
 - [Host Streamlit on Azure](https://towardsdatascience.com/deploying-a-streamlit-web-app-with-azure-app-service-1f09a2159743), by Richard Peterson
+- [Deploy Streamlit on Ploomber Cloud](https://docs.cloud.ploomber.io/en/latest/apps/streamlit.html), by Eduardo Blancas
 - [Host Streamlit on 21YunBox](https://www.21yunbox.com/docs/#/deploy-streamlit), by Toby Lei
 - [Community-supported deployment wiki](https://discuss.streamlit.io/t/streamlit-deployment-guide-wiki/5099).

--- a/content/kb/tutorials/deploy/index.md
+++ b/content/kb/tutorials/deploy/index.md
@@ -35,10 +35,10 @@ This sections contains step-by-step guides on how to deploy Streamlit apps to va
 
 While we work on official Streamlit deployment guides for other hosting providers, here are some user-submitted tutorials for different cloud services:
 
-- [How to deploy Streamlit apps to Google App Engine](https://dev.to/whitphx/how-to-deploy-streamlit-apps-to-google-app-engine-407o), by [Yuichiro Tachibana (Tsuchiya)](https://discuss.streamlit.io/u/whitphx/summary)
-- [How to Deploy Streamlit to a Free Amazon EC2 instance](https://towardsdatascience.com/how-to-deploy-a-streamlit-app-using-an-amazon-free-ec2-instance-416a41f69dc3), by Rahul Agarwal
-- [Host Streamlit on Heroku](https://towardsdatascience.com/quickly-build-and-deploy-an-application-with-streamlit-988ca08c7e83), by Maarten Grootendorst
-- [Host Streamlit on Azure](https://towardsdatascience.com/deploying-a-streamlit-web-app-with-azure-app-service-1f09a2159743), by Richard Peterson
-- [Deploy Streamlit on Ploomber Cloud](https://docs.cloud.ploomber.io/en/latest/apps/streamlit.html), by Ido Michael
-- [Host Streamlit on 21YunBox](https://www.21yunbox.com/docs/#/deploy-streamlit), by Toby Lei
+- [How to Deploy Streamlit to a Free **Amazon EC2** instance](https://towardsdatascience.com/how-to-deploy-a-streamlit-app-using-an-amazon-free-ec2-instance-416a41f69dc3), by Rahul Agarwal.
+- [Host Streamlit on **Azure**](https://towardsdatascience.com/deploying-a-streamlit-web-app-with-azure-app-service-1f09a2159743), by Richard Peterson.
+- [How to deploy Streamlit apps to **Google App Engine**](https://dev.to/whitphx/how-to-deploy-streamlit-apps-to-google-app-engine-407o), by [Yuichiro Tachibana (Tsuchiya)](https://discuss.streamlit.io/u/whitphx/summary).
+- [Host Streamlit on **Heroku**](https://towardsdatascience.com/quickly-build-and-deploy-an-application-with-streamlit-988ca08c7e83), by Maarten Grootendorst.
+- [Deploy Streamlit on **Ploomber Cloud**](https://docs.cloud.ploomber.io/en/latest/apps/streamlit.html), by Ido Michael.
+- [Host Streamlit on **21YunBox**](https://www.21yunbox.com/docs/#/deploy-streamlit), by Toby Lei.
 - [Community-supported deployment wiki](https://discuss.streamlit.io/t/streamlit-deployment-guide-wiki/5099).

--- a/content/menu.md
+++ b/content/menu.md
@@ -613,6 +613,20 @@ site_menu:
     url: /knowledge-base/tutorials/deploy/docker
   - category: Knowledge base / Tutorials / Deploy Streamlit apps / Kubernetes
     url: /knowledge-base/tutorials/deploy/kubernetes
+  - category: Knowledge base / Tutorials / Deploy Streamlit apps / Google App Engine
+    url: https://dev.to/whitphx/how-to-deploy-streamlit-apps-to-google-app-engine-407o
+  - category: Knowledge base / Tutorials / Deploy Streamlit apps / Amazon EC2
+    url: https://towardsdatascience.com/how-to-deploy-a-streamlit-app-using-an-amazon-free-ec2-instance-416a41f69dc3
+  - category: Knowledge base / Tutorials / Deploy Streamlit apps / Heroku
+    url: https://towardsdatascience.com/quickly-build-and-deploy-an-application-with-streamlit-988ca08c7e83
+  - category: Knowledge base / Tutorials / Deploy Streamlit apps / Azure
+    url: https://towardsdatascience.com/deploying-a-streamlit-web-app-with-azure-app-service-1f09a2159743
+  - category: Knowledge base / Tutorials / Deploy Streamlit apps / Ploomber Cloud
+    url: https://docs.cloud.ploomber.io/en/latest/apps/streamlit.html
+  - category: Knowledge base / Tutorials / Deploy Streamlit apps / 21YunBox
+    url: https://www.21yunbox.com/docs/#/deploy-streamlit
+  - category: Knowledge base / Tutorials / Deploy Streamlit apps / Community-built guides
+    url: https://discuss.streamlit.io/t/streamlit-deployment-guide-wiki/5099
   - category: Knowledge base / Tutorials / Build a basic LLM chat app
     url: /knowledge-base/tutorials/build-conversational-apps
   - category: Knowledge base / Tutorials / Build an LLM app using LangChain

--- a/content/menu.md
+++ b/content/menu.md
@@ -613,14 +613,14 @@ site_menu:
     url: /knowledge-base/tutorials/deploy/docker
   - category: Knowledge base / Tutorials / Deploy Streamlit apps / Kubernetes
     url: /knowledge-base/tutorials/deploy/kubernetes
-  - category: Knowledge base / Tutorials / Deploy Streamlit apps / Google App Engine
-    url: https://dev.to/whitphx/how-to-deploy-streamlit-apps-to-google-app-engine-407o
   - category: Knowledge base / Tutorials / Deploy Streamlit apps / Amazon EC2
     url: https://towardsdatascience.com/how-to-deploy-a-streamlit-app-using-an-amazon-free-ec2-instance-416a41f69dc3
-  - category: Knowledge base / Tutorials / Deploy Streamlit apps / Heroku
-    url: https://towardsdatascience.com/quickly-build-and-deploy-an-application-with-streamlit-988ca08c7e83
   - category: Knowledge base / Tutorials / Deploy Streamlit apps / Azure
     url: https://towardsdatascience.com/deploying-a-streamlit-web-app-with-azure-app-service-1f09a2159743
+  - category: Knowledge base / Tutorials / Deploy Streamlit apps / Google App Engine
+    url: https://dev.to/whitphx/how-to-deploy-streamlit-apps-to-google-app-engine-407o
+  - category: Knowledge base / Tutorials / Deploy Streamlit apps / Heroku
+    url: https://towardsdatascience.com/quickly-build-and-deploy-an-application-with-streamlit-988ca08c7e83
   - category: Knowledge base / Tutorials / Deploy Streamlit apps / Ploomber Cloud
     url: https://docs.cloud.ploomber.io/en/latest/apps/streamlit.html
   - category: Knowledge base / Tutorials / Deploy Streamlit apps / 21YunBox


### PR DESCRIPTION
## 📚 Context

[Ploomber](https://ploomber.io/) now supports [deploying Streamlit apps on Ploomber Cloud](https://docs.cloud.ploomber.io/en/latest/apps/streamlit.html) 🦦. Their deployment tutorial is [linked](https://discuss.streamlit.io/t/streamlit-deployment-guide-wiki/5099) in the Streamlit forum's community-supported deployment wiki.

The co-founder and CTO have contacted us, requesting that we link to their docs (as they do ours) on the KB page about deployment options.

## 🧠 Description of Changes

1. Links to Deploy Streamlit apps on Ploomber Cloud in the KB
2. Adds the featured community-supported deployment guides as external links in the menu.

2 is technically not necessary, but IMO a nice to have. So reviewers are free to request we solely do 1 if needed.

**Revised:**

![image](https://github.com/streamlit/docs/assets/20672874/6db819ca-f646-4787-aa04-fb90bffa6e9d)

**Current:**

![image](https://github.com/streamlit/docs/assets/20672874/d2cc9530-1ebe-4710-95f8-aa4961998fed)

## 💥 Impact

<!-- what is the scale of this change -->

Size:
- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
