### PR TITLE
Add components blurb to Get started

### DIFF
--- a/content/get-started/fundamentals/additional-features.md
+++ b/content/get-started/fundamentals/additional-features.md
@@ -103,6 +103,10 @@ Now run `streamlit run main_page.py` and view your shiny new multipage app!
 
 Our documentation on [Multipage apps](/library/advanced-features/multipage-apps) teaches you how to add pages to your app, including how to define pages, structure and run multipage apps, and navigate between pages. Once you understand the basics, [create your first multipage app](/get-started/tutorials/create-a-multipage-app)!
 
+## Custom components
+
+If you can't find the right component within the Streamlit library, try out custom components to extend Streamlit's built-in functionality. Explore and browse through popular, community-created components in the [Components gallery](https://streamlit.io/components). If you dabble in frontend development, you can build your own custom component with Streamlit's [components API](/library/components/components-api).
+
 ## Static file serving
 
 As you learned in Streamlit fundamentals, Streamlit runs a server that clients connect to. That means viewers of your app don't have direct access to the files which are local to your app. Most of the time, this doesn't matter because Streamlt commands handle that for you. When you use `st.image(<path-to-image>)` your Streamlit server will access the file and handle the necessary hosting so your app viewers can see it. However, if you want a direct URL to an image or file you'll need to host it. This requires setting the correct configuration and placing your hosted files in a directory named `static`. For example, your project could look like:


### PR DESCRIPTION
## 📚 Context
Custom components aren't currently introduced within Get started. They are worthy of a introductory blurb so the PR adds a short paragraph to get-started/fundamentals/additional-features.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
