### PR TITLE
Prevent inline code in headers from flexing

### DIFF
--- a/components/utilities/headerLink.module.css
+++ b/components/utilities/headerLink.module.css
@@ -11,10 +11,6 @@
   @apply font-bold;
 }
 
-.HeaderContainer code {
-  @apply mx-2;
-}
-
 h1.HeaderContainer {
   @apply leading-tight;
 }


### PR DESCRIPTION
## 📚 Context
Headers were in flex containers and this caused inline code to display as a block. This is apparent in mobile views. This PR removes `@apply flex` from header containers.

## 🧠 Description of Changes
* Removed flex from header containers
* Removed redundant padding from `code` within headers (a previous fix)

**Revised:**
<img width="500" alt="image" src="https://github.com/streamlit/docs/assets/135349133/a3f21f4f-d003-4d63-94b2-44c1c7c54c62">

**Current:**
<img width="500" alt="image" src="https://github.com/streamlit/docs/assets/135349133/3001324a-0949-47f2-9565-aa686dcc8eb0">

Closes #983 

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
