### PR TITLE
fix run.sh in kubernetes deploy tutorial

### DIFF
--- a/content/kb/tutorials/deploy/kubernetes.md
+++ b/content/kb/tutorials/deploy/kubernetes.md
@@ -76,9 +76,9 @@ trap stopRunningProcess EXIT TERM
 source ${VIRTUAL_ENV}/bin/activate
 
 streamlit run ${HOME}/app/streamlit_app.py &
-APP_ID=${!}
+APP_PID=${!}
 
-wait ${APP_ID}
+wait ${APP_PID}
 ```
 
 ### Create a Dockerfile


### PR DESCRIPTION
There was an inconsistent variable name.

## 📚 Context

<!-- Why do you want to make this change? What background should the reviewer know? -->

## 🧠 Description of Changes
There was an inconsistent variable name. `stopRunningProcess()` was looking at `APP_PID` variable while `APP_ID` was defined at application run.

**Revised:**
```bash
streamlit run ${HOME}/app/streamlit_app.py &
APP_PID=${!}

wait ${APP_PID}
```

**Current:**
```bash
streamlit run ${HOME}/app/streamlit_app.py &
APP_ID=${!}

wait ${APP_ID}
```

## 💥 Impact
Small typo fix.

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->



**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
