### PR TITLE
Add Autofunction option to show experimental precursor

### DIFF
--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -31,7 +31,7 @@ const Autofunction = ({
   hideHeader,
   deprecated,
   deprecatedText,
-  ancestorFunction,
+  oldStreamlitFunction,
 }) => {
   const blockRef = useRef();
   const router = useRouter();
@@ -135,7 +135,7 @@ const Autofunction = ({
 
   const handleSelectVersion = (event) => {
     const functionObject =
-      streamlit[streamlitFunction] ?? streamlit[ancestorFunction];
+      streamlit[streamlitFunction] ?? streamlit[oldStreamlitFunction];
     const slicedSlug = slug.slice();
 
     if (event.target.value !== currentVersion) {
@@ -172,9 +172,9 @@ const Autofunction = ({
   let methods = [];
   let properties = [];
 
-  if (streamlitFunction in streamlit || ancestorFunction in streamlit) {
+  if (streamlitFunction in streamlit || oldStreamlitFunction in streamlit) {
     functionObject =
-      streamlit[streamlitFunction] ?? streamlit[ancestorFunction];
+      streamlit[streamlitFunction] ?? streamlit[oldStreamlitFunction];
     isClass = functionObject.is_class;
     if (
       functionObject.description !== undefined &&

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -134,9 +134,8 @@ const Autofunction = ({
   };
 
   const handleSelectVersion = (event) => {
-    const functionObject = streamlit[streamlitFunction]
-      ? streamlit[streamlitFunction]
-      : streamlit[ancestorFunction];
+    const functionObject =
+      streamlit[streamlitFunction] ?? streamlit[ancestorFunction];
     const slicedSlug = slug.slice();
 
     if (event.target.value !== currentVersion) {
@@ -174,9 +173,8 @@ const Autofunction = ({
   let properties = [];
 
   if (streamlitFunction in streamlit || ancestorFunction in streamlit) {
-    functionObject = streamlit[streamlitFunction]
-      ? streamlit[streamlitFunction]
-      : streamlit[ancestorFunction];
+    functionObject =
+      streamlit[streamlitFunction] ?? streamlit[ancestorFunction];
     isClass = functionObject.is_class;
     if (
       functionObject.description !== undefined &&

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -31,6 +31,7 @@ const Autofunction = ({
   hideHeader,
   deprecated,
   deprecatedText,
+  ancestorFunction,
 }) => {
   const blockRef = useRef();
   const router = useRouter();
@@ -133,7 +134,9 @@ const Autofunction = ({
   };
 
   const handleSelectVersion = (event) => {
-    const functionObject = streamlit[streamlitFunction];
+    const functionObject = streamlit[streamlitFunction]
+      ? streamlit[streamlitFunction]
+      : streamlit[ancestorFunction];
     const slicedSlug = slug.slice();
 
     if (event.target.value !== currentVersion) {
@@ -170,8 +173,10 @@ const Autofunction = ({
   let methods = [];
   let properties = [];
 
-  if (streamlitFunction in streamlit) {
-    functionObject = streamlit[streamlitFunction];
+  if (streamlitFunction in streamlit || ancestorFunction in streamlit) {
+    functionObject = streamlit[streamlitFunction]
+      ? streamlit[streamlitFunction]
+      : streamlit[ancestorFunction];
     isClass = functionObject.is_class;
     if (
       functionObject.description !== undefined &&

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -155,7 +155,7 @@ export default function Article({
         version={version}
         versions={versions}
         slug={slug}
-        ancestorFunction={props.ancestor ? props.ancestor : ""}
+        ancestorFunction={props.ancestor ?? ""}
       />
     ),
     pre: (props) => <Code {...props} />,

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -155,7 +155,7 @@ export default function Article({
         version={version}
         versions={versions}
         slug={slug}
-        ancestorFunction={props.ancestor ?? ""}
+        oldStreamlitFunction={props.oldName ?? ""}
       />
     ),
     pre: (props) => <Code {...props} />,

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -155,6 +155,7 @@ export default function Article({
         version={version}
         versions={versions}
         slug={slug}
+        ancestorFunction={props.ancestor ? props.ancestor : ""}
       />
     ),
     pre: (props) => <Code {...props} />,


### PR DESCRIPTION
## 📚 Context
When a function has an experimental precursor or clear ancestor, this must be documented on another page (in a separate `<Autofunction />`. The creates additional items in the left navigation which may be distracting and also may hinder users on older versions from correctly locating a function when they see a recent feature as unavailable in their older version.

## 🧠 Description of Changes
This PR adds an option argument, `ancestor` to the Autofunction. When a function does not exist in a selected version of Streamlit, the ancestor will be displayed if it exists. If the ancestor also does not exist, the current behavior is preserved.

**Revised:**
`<Autofunction function="streamlit.data_editor" ancestor="streamlit.experimental_data_editor" />` will cause `st.experimental_data_editor` to be displayed when selecting version 1.22.0 on the `st.data_editor` page. Version 1.17.0 will show that the method does not exist.

**Current:**
`<Autofunction function="streamlit.data_editor"  />` will only show `st.data_editor` starting from version 1.23.0. Version 1.22.0 will say that the method does not exist.

## 🌐 References
Notion doc: Autofunction improvements

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
