### PR TITLE
Catch rate limit error for chat.llm.py example

### DIFF
--- a/python/api-examples-source/chat.llm.py
+++ b/python/api-examples-source/chat.llm.py
@@ -4,7 +4,10 @@ from openai import OpenAI
 st.title("ChatGPT-like clone")
 with st.expander("ℹ️ Disclaimer"):
     st.caption(
-        "We appreciate your engagement! Please note, this demo is designed to process a maximum of 10 interactions. Thank you for your understanding."
+        """We appreciate your engagement! Please note, this demo is designed to
+        process a maximum of 10 interactions and may be unavailable if too many
+        people use the service concurrently. Thank you for your understanding.
+        """
     )
 
 client = OpenAI(api_key=st.secrets["OPENAI_API_KEY"])
@@ -15,16 +18,15 @@ if "openai_model" not in st.session_state:
 if "messages" not in st.session_state:
     st.session_state.messages = []
 
+if "max_messages" not in st.session_state:
+    # Counting both user and assistant messages, so 10 rounds of conversation
+    st.session_state.max_messages = 20
+
 for message in st.session_state.messages:
     with st.chat_message(message["role"]):
         st.markdown(message["content"])
 
-# Maximum allowed messages
-max_messages = (
-    20  # Counting both user and assistant messages, so 10 iterations of conversation
-)
-
-if len(st.session_state.messages) >= max_messages:
+if len(st.session_state.messages) >= st.session_state.max_messages:
     st.info(
         """Notice: The maximum message limit for this demo version has been reached. We value your interest!
         We encourage you to experience further interactions by building your own application with instructions
@@ -39,13 +41,26 @@ else:
             st.markdown(prompt)
 
         with st.chat_message("assistant"):
-            stream = client.chat.completions.create(
-                model=st.session_state["openai_model"],
-                messages=[
-                    {"role": m["role"], "content": m["content"]}
-                    for m in st.session_state.messages
-                ],
-                stream=True,
-            )
-            response = st.write_stream(stream)
-        st.session_state.messages.append({"role": "assistant", "content": response})
+            try:
+                stream = client.chat.completions.create(
+                    model=st.session_state["openai_model"],
+                    messages=[
+                        {"role": m["role"], "content": m["content"]}
+                        for m in st.session_state.messages
+                    ],
+                    stream=True,
+                )
+                response = st.write_stream(stream)
+                st.session_state.messages.append(
+                    {"role": "assistant", "content": response}
+                )
+            except:
+                st.session_state.max_messages = len(st.session_state.messages)
+                rate_limit_message = """
+                    Oops! Sorry, I can't talk now. Too many people have used
+                    this service recently.
+                """
+                st.session_state.messages.append(
+                    {"role": "assistant", "content": rate_limit_message}
+                )
+                st.rerun()


### PR DESCRIPTION
## 📚 Context
The key for our embedded OpenAI chat app example is receiving too much traffic and the app is showing a rate limit error.

## 🧠 Description of Changes
This PR adds a try-except block around retrieving a response to elegantly catch the error and convey to the user that there is too much traffic to try the demo.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.