### PR TITLE
Wrap headers containing inline clode

### DIFF
--- a/components/utilities/headerLink.js
+++ b/components/utilities/headerLink.js
@@ -34,7 +34,7 @@ const HeaderLink = ({ name, level, className, children }) => {
   // If we're getting something back, that means there is one, so we will wrap
   // the header contents in <span> to prevent it from flexing
   const withInlineCode = Array.from(children).find(
-    (child) => child && child.type && child.type === "code",
+    (child) => child?.type === "code",
   );
 
   const Header = `h${level}`;

--- a/components/utilities/headerLink.js
+++ b/components/utilities/headerLink.js
@@ -31,9 +31,10 @@ const HeaderLink = ({ name, level, className, children }) => {
   };
 
   // Check if there's a <code> tag in the heading, so we can style it properly.
-  // If we're getting something back, that means there is one, so we add the special class
+  // If we're getting something back, that means there is one, so we will wrap
+  // the header contents in <span> to prevent it from flexing
   const withInlineCode = Array.from(children).find(
-    (child) => child && child.props && child.props.mdxType === "inlineCode"
+    (child) => child && child.type && child.type === "code",
   );
 
   const Header = `h${level}`;

--- a/components/utilities/headerLink.module.css
+++ b/components/utilities/headerLink.module.css
@@ -3,7 +3,7 @@
 }
 
 .HeaderContainer {
-  @apply items-center font-bold text-gray-90 leading-snug;
+  @apply flex items-center font-bold text-gray-90 leading-snug;
   overflow-wrap: anywhere;
 }
 


### PR DESCRIPTION
## 📚 Context
Headers have been tweaked a couple times to correct the display of inlince code in headers. This PR restores the original functionality at the root cause.

The previous patches have resulted in the header link being displayed below the header.
**Revised**:
<img width="607" alt="image" src="https://github.com/streamlit/docs/assets/135349133/ebea9b49-ae8f-456d-b523-2513386d0cbb">

**Current**:
<img width="601" alt="image" src="https://github.com/streamlit/docs/assets/135349133/ff92c210-67eb-4f07-aee3-42dda0077fa2">

**Previous PRs**:
#953 
#984 

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
