### PR TITLE
Add CSP rules for LinkedIn and Facebook "ad pixels".

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -28,6 +28,7 @@ connect-src \
   https://*.auryc.com/ \
   https://www.google-analytics.com/ \
   https://stats.g.doubleclick.net/ \
+  https://px.ads.linkedin.com/ \
   https://*.algolia.net/ \
   https://*.algolianet.com/ \
 ; \
@@ -54,6 +55,8 @@ script-src \
   https://identity.netlify.com/ \
   https://netlify-cdp-loader.netlify.app/netlify.js \
   https://www.youtube.com/iframe_api/ \
+  https://snap.licdn.com/ \
+  https://connect.facebook.net/ \
   https://*.algolia.net/ \
   https://*.algolianet.com/ \
 ; \

--- a/next.config.js
+++ b/next.config.js
@@ -20,6 +20,7 @@ const CSP_HEADER = [
     "https://*.auryc.com/", // Analytics (Heap)
     "https://www.google-analytics.com/", // Analytics
     "https://stats.g.doubleclick.net/", // Analytics
+    "https://px.ads.linkedin.com/", // LinkedIn ad pixel
     "https://*.algolia.net/", // Search
     "https://*.algolianet.com/", // Search
   ";",
@@ -46,6 +47,8 @@ const CSP_HEADER = [
     "https://identity.netlify.com/", // Netlify dev tools
     "https://netlify-cdp-loader.netlify.app/netlify.js", // Netlify dev tools
     "https://www.youtube.com/iframe_api/", // YouTube Embed
+    "https://snap.licdn.com/", // LinkedIn ad pixel
+    "https://connect.facebook.net/", // Facebook ad pixel
     "https://*.algolia.net/", // Search
     "https://*.algolianet.com/", // Search
   ";",


### PR DESCRIPTION
## 📚 Context

The marketing team recently added "ad pixels" for LinkedIn and Facebook in Segment, so we can better track our campaigns. This updates our CSP policy to allow those scripts to run.

## 🧐 How to review this

1. Open a new browser tab
2. Open the browser's dev tools panel
3. Copy/paste PR preview URL into the URL bar for the tab you opened in step 1
4. Click "Accept all" in the cookie banner
5. See if any red error messages appear in the dev tools console

## 🧠 Description of Changes

Updates CSP policy.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
