### PR TITLE
Improve dark mode contrast

### DIFF
--- a/components/blocks/autofunction.module.css
+++ b/components/blocks/autofunction.module.css
@@ -35,7 +35,7 @@
 }
 
 :global(.dark) .Select {
-  @apply bg-gray-100 text-darkModeGray-40;
+  @apply bg-gray-100 text-gray-40;
 }
 
 :global(.old-version) .Select {

--- a/components/blocks/autofunction.module.css
+++ b/components/blocks/autofunction.module.css
@@ -35,7 +35,7 @@
 }
 
 :global(.dark) .Select {
-  @apply bg-gray-100 text-white;
+  @apply bg-gray-100 text-darkModeGray-40;
 }
 
 :global(.old-version) .Select {

--- a/components/blocks/callout.module.css
+++ b/components/blocks/callout.module.css
@@ -19,5 +19,5 @@
 }
 
 :global(.dark) .Container p {
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }

--- a/components/blocks/callout.module.css
+++ b/components/blocks/callout.module.css
@@ -19,5 +19,5 @@
 }
 
 :global(.dark) .Container p {
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }

--- a/components/blocks/cloud.module.css
+++ b/components/blocks/cloud.module.css
@@ -15,5 +15,5 @@
 }
 
 :global(.dark) .Caption {
-  @apply text-darkModeGray-40;
+  @apply text-gray-40;
 }

--- a/components/blocks/cloud.module.css
+++ b/components/blocks/cloud.module.css
@@ -15,5 +15,5 @@
 }
 
 :global(.dark) .Caption {
-  @apply text-white;
+  @apply text-darkModeGray-40;
 }

--- a/components/blocks/codeTile.module.css
+++ b/components/blocks/codeTile.module.css
@@ -22,7 +22,7 @@
 
 :global(.dark) .Container section pre {
   @apply bg-gray-100;
-  @apply text-darkModeGray-40;
+  @apply text-gray-40;
 }
 
 .Container h1,

--- a/components/blocks/codeTile.module.css
+++ b/components/blocks/codeTile.module.css
@@ -22,7 +22,7 @@
 
 :global(.dark) .Container section pre {
   @apply bg-gray-100;
-  @apply text-white;
+  @apply text-darkModeGray-40;
 }
 
 .Container h1,

--- a/components/blocks/dataSourcesCard.module.css
+++ b/components/blocks/dataSourcesCard.module.css
@@ -33,11 +33,11 @@
 :global(.dark) .Container h6,
 :global(.dark) .Container p,
 :global(.dark) .Container a {
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }
 
 :global(.dark) .Container section div pre {
-  @apply bg-gray-90 text-darkModeGray-40;
+  @apply bg-gray-90 text-gray-40;
 }
 
 :global(.dark) .Container img {

--- a/components/blocks/dataSourcesCard.module.css
+++ b/components/blocks/dataSourcesCard.module.css
@@ -33,11 +33,11 @@
 :global(.dark) .Container h6,
 :global(.dark) .Container p,
 :global(.dark) .Container a {
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }
 
 :global(.dark) .Container section div pre {
-  @apply bg-gray-90 text-white;
+  @apply bg-gray-90 text-darkModeGray-40;
 }
 
 :global(.dark) .Container img {

--- a/components/blocks/iconHeader.module.css
+++ b/components/blocks/iconHeader.module.css
@@ -77,5 +77,5 @@
 }
 
 :global(.dark) .IndigoText {
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }

--- a/components/blocks/iconHeader.module.css
+++ b/components/blocks/iconHeader.module.css
@@ -77,5 +77,5 @@
 }
 
 :global(.dark) .IndigoText {
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }

--- a/components/blocks/image.module.css
+++ b/components/blocks/image.module.css
@@ -19,7 +19,7 @@
 }
 
 :global(.dark) .Caption {
-  @apply text-darkModeGray-40;
+  @apply text-gray-40;
 }
 
 .LightBox {
@@ -44,5 +44,5 @@
 }
 
 :global(.dark) .CloseButton {
-  @apply bg-gray-90 text-darkModeGray-40;
+  @apply bg-gray-90 text-gray-40;
 }

--- a/components/blocks/image.module.css
+++ b/components/blocks/image.module.css
@@ -19,7 +19,7 @@
 }
 
 :global(.dark) .Caption {
-  @apply text-white;
+  @apply text-darkModeGray-40;
 }
 
 .LightBox {
@@ -44,5 +44,5 @@
 }
 
 :global(.dark) .CloseButton {
-  @apply bg-gray-90 text-white;
+  @apply bg-gray-90 text-darkModeGray-40;
 }

--- a/components/blocks/inlineCallout.module.css
+++ b/components/blocks/inlineCallout.module.css
@@ -17,7 +17,7 @@
 }
 
 :global(.dark) .Text {
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }
 
 :global(.dark) .Container {

--- a/components/blocks/inlineCallout.module.css
+++ b/components/blocks/inlineCallout.module.css
@@ -17,7 +17,7 @@
 }
 
 :global(.dark) .Text {
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }
 
 :global(.dark) .Container {

--- a/components/blocks/newsEntry.module.css
+++ b/components/blocks/newsEntry.module.css
@@ -28,7 +28,7 @@
 
 :global(.dark) .Title,
 :global(.dark) .Text {
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }
 
 .Text {

--- a/components/blocks/newsEntry.module.css
+++ b/components/blocks/newsEntry.module.css
@@ -28,7 +28,7 @@
 
 :global(.dark) .Title,
 :global(.dark) .Text {
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }
 
 .Text {

--- a/components/blocks/refCard.module.css
+++ b/components/blocks/refCard.module.css
@@ -52,7 +52,7 @@
 }
 
 :global(.dark) .Container i {
-  @apply text-white;
+  @apply text-darkModeGray-40;
 }
 
 :global(.dark) .Container h1,
@@ -63,11 +63,11 @@
 :global(.dark) .Container h6,
 :global(.dark) .Container p,
 :global(.dark) .Container a {
-  @apply text-white;
+  @apply text-darkModeGray-40;
 }
 
 :global(.dark) .Container section div {
-  @apply bg-gray-90 text-white;
+  @apply bg-gray-90 text-darkModeGray-40;
 }
 
 :global(.dark) .Container img {

--- a/components/blocks/refCard.module.css
+++ b/components/blocks/refCard.module.css
@@ -52,7 +52,7 @@
 }
 
 :global(.dark) .Container i {
-  @apply text-darkModeGray-40;
+  @apply text-gray-40;
 }
 
 :global(.dark) .Container h1,
@@ -63,11 +63,11 @@
 :global(.dark) .Container h6,
 :global(.dark) .Container p,
 :global(.dark) .Container a {
-  @apply text-darkModeGray-40;
+  @apply text-gray-40;
 }
 
 :global(.dark) .Container section div {
-  @apply bg-gray-90 text-darkModeGray-40;
+  @apply bg-gray-90 text-gray-40;
 }
 
 :global(.dark) .Container img {

--- a/components/blocks/table.module.css
+++ b/components/blocks/table.module.css
@@ -19,11 +19,11 @@
 }
 
 :global(.dark) .HeadingRow {
-  @apply bg-darkBlue-100/60 text-darkModeGray-40;
+  @apply bg-darkBlue-100/60 text-gray-40;
 }
 
 :global(.dark) .Row td {
-  @apply text-darkModeGray-40;
+  @apply text-gray-40;
 }
 
 .Cell {

--- a/components/blocks/table.module.css
+++ b/components/blocks/table.module.css
@@ -19,11 +19,11 @@
 }
 
 :global(.dark) .HeadingRow {
-  @apply bg-darkBlue-100/60 text-white;
+  @apply bg-darkBlue-100/60 text-darkModeGray-40;
 }
 
 :global(.dark) .Row td {
-  @apply text-white;
+  @apply text-darkModeGray-40;
 }
 
 .Cell {

--- a/components/blocks/tile.module.css
+++ b/components/blocks/tile.module.css
@@ -92,5 +92,5 @@
 :global(.dark) .TransparentBackground i,
 :global(.dark) .TransparentBackground h4,
 :global(.dark) .TransparentBackground p {
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }

--- a/components/blocks/tile.module.css
+++ b/components/blocks/tile.module.css
@@ -92,5 +92,5 @@
 :global(.dark) .TransparentBackground i,
 :global(.dark) .TransparentBackground h4,
 :global(.dark) .TransparentBackground p {
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }

--- a/components/blocks/youtube.module.css
+++ b/components/blocks/youtube.module.css
@@ -15,5 +15,5 @@
 }
 
 :global(.dark) .Caption {
-  @apply text-darkModeGray-40;
+  @apply text-gray-40;
 }

--- a/components/blocks/youtube.module.css
+++ b/components/blocks/youtube.module.css
@@ -15,5 +15,5 @@
 }
 
 :global(.dark) .Caption {
-  @apply text-white;
+  @apply text-darkModeGray-40;
 }

--- a/components/navigation/arrowLink.js
+++ b/components/navigation/arrowLink.js
@@ -51,7 +51,7 @@ const ArrowLink = ({ children, link, type, content, target }) => {
             width="14"
             height="14"
             viewBox="0 0 14 14"
-            fill="text-gray-90 dark:text-white"
+            fill="text-gray-90 dark:text-darkModeGray-40"
             xmlns="http://www.w3.org/2000/svg"
             className={`
               ${styles.Icon}

--- a/components/navigation/arrowLink.js
+++ b/components/navigation/arrowLink.js
@@ -51,7 +51,7 @@ const ArrowLink = ({ children, link, type, content, target }) => {
             width="14"
             height="14"
             viewBox="0 0 14 14"
-            fill="text-gray-90 dark:text-darkModeGray-40"
+            fill="text-gray-90 dark:text-gray-40"
             xmlns="http://www.w3.org/2000/svg"
             className={`
               ${styles.Icon}

--- a/components/navigation/arrowLink.module.css
+++ b/components/navigation/arrowLink.module.css
@@ -11,7 +11,7 @@
 }
 
 :global(.dark) .Link {
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }
 
 .NextLink {

--- a/components/navigation/arrowLink.module.css
+++ b/components/navigation/arrowLink.module.css
@@ -11,7 +11,7 @@
 }
 
 :global(.dark) .Link {
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }
 
 .NextLink {

--- a/components/navigation/footer.module.css
+++ b/components/navigation/footer.module.css
@@ -23,7 +23,7 @@
 }
 
 :global(.dark) .Link {
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }
 
 .SocialNetworks {

--- a/components/navigation/footer.module.css
+++ b/components/navigation/footer.module.css
@@ -23,7 +23,7 @@
 }
 
 :global(.dark) .Link {
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }
 
 .SocialNetworks {

--- a/components/navigation/header.module.css
+++ b/components/navigation/header.module.css
@@ -37,7 +37,7 @@
 }
 
 :global(.dark) .LogoText {
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }
 
 .NavigationContainer {

--- a/components/navigation/header.module.css
+++ b/components/navigation/header.module.css
@@ -37,7 +37,7 @@
 }
 
 :global(.dark) .LogoText {
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }
 
 .NavigationContainer {

--- a/components/navigation/mobileNav.module.css
+++ b/components/navigation/mobileNav.module.css
@@ -12,5 +12,5 @@
 }
 
 :global(.dark) .Icon {
-  @apply text-white;
+  @apply text-darkModeGray-40;
 }

--- a/components/navigation/mobileNav.module.css
+++ b/components/navigation/mobileNav.module.css
@@ -12,5 +12,5 @@
 }
 
 :global(.dark) .Icon {
-  @apply text-darkModeGray-40;
+  @apply text-gray-40;
 }

--- a/components/navigation/navChild.module.css
+++ b/components/navigation/navChild.module.css
@@ -1,5 +1,5 @@
 .Container {
-  @apply text-sm tracking-tight dark:text-white mb-4;
+  @apply text-sm tracking-tight dark:text-darkModeGray-40 mb-4;
 }
 
 .List {
@@ -29,7 +29,7 @@
 :global(.dark) .ExternalIcon,
 :global(.dark) .ActivePage,
 :global(.dark) .ActivePage ~ .Icon {
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }
 
 .LinkContainer {
@@ -71,7 +71,7 @@
 }
 
 :global(.dark) .PageName:not(.ActivePage) {
-  @apply text-gray-40 !important;
+  @apply text-darkModeGray-50 !important;
 }
 
 .ActivePage {

--- a/components/navigation/navChild.module.css
+++ b/components/navigation/navChild.module.css
@@ -1,5 +1,5 @@
 .Container {
-  @apply text-sm tracking-tight dark:text-darkModeGray-40 mb-4;
+  @apply text-sm tracking-tight dark:text-gray-40 mb-4;
 }
 
 .List {
@@ -29,7 +29,7 @@
 :global(.dark) .ExternalIcon,
 :global(.dark) .ActivePage,
 :global(.dark) .ActivePage ~ .Icon {
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }
 
 .LinkContainer {
@@ -71,7 +71,7 @@
 }
 
 :global(.dark) .PageName:not(.ActivePage) {
-  @apply text-darkModeGray-50 !important;
+  @apply text-gray-50 !important;
 }
 
 .ActivePage {

--- a/components/navigation/navItem.module.css
+++ b/components/navigation/navItem.module.css
@@ -57,7 +57,7 @@
 }
 
 :global(.dark) .CategoryName {
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }
 
 .CondensedCategoryName {

--- a/components/navigation/navItem.module.css
+++ b/components/navigation/navItem.module.css
@@ -57,7 +57,7 @@
 }
 
 :global(.dark) .CategoryName {
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }
 
 .CondensedCategoryName {

--- a/components/utilities/download.module.css
+++ b/components/utilities/download.module.css
@@ -4,5 +4,5 @@
 }
 
 :global(.dark) .Link {
-  @apply text-darkModeGray-40 border-b-white !important;
+  @apply text-gray-40 border-b-white !important;
 }

--- a/components/utilities/download.module.css
+++ b/components/utilities/download.module.css
@@ -4,5 +4,5 @@
 }
 
 :global(.dark) .Link {
-  @apply text-white border-b-white !important;
+  @apply text-darkModeGray-40 border-b-white !important;
 }

--- a/components/utilities/floatingNav.module.css
+++ b/components/utilities/floatingNav.module.css
@@ -36,7 +36,7 @@
 }
 
 :global(.dark) .activeLink {
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }
 
 /* Paddings for different title hierarchies */

--- a/components/utilities/floatingNav.module.css
+++ b/components/utilities/floatingNav.module.css
@@ -32,11 +32,11 @@
 }
 
 .activeLink {
-  @apply text-gray-90 !important;
+  @apply text-gray-100 !important;
 }
 
 :global(.dark) .activeLink {
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }
 
 /* Paddings for different title hierarchies */

--- a/components/utilities/gdpr.module.css
+++ b/components/utilities/gdpr.module.css
@@ -38,5 +38,5 @@
 }
 
 :global(.dark) .Markdown h1 {
-  @apply text-white;
+  @apply text-darkModeGray-40;
 }

--- a/components/utilities/gdpr.module.css
+++ b/components/utilities/gdpr.module.css
@@ -25,12 +25,12 @@
 
 :global(.dark) .Markdown p,
 :global(.dark) .Markdown p a {
-  @apply text-gray-20;
+  @apply text-gray-40;
 }
 
 :global(.dark) .Link,
 :global(.dark) .Button {
-  @apply text-gray-20;
+  @apply text-gray-40;
 }
 
 :global(.dark) .Button {

--- a/components/utilities/gdpr.module.css
+++ b/components/utilities/gdpr.module.css
@@ -38,5 +38,5 @@
 }
 
 :global(.dark) .Markdown h1 {
-  @apply text-darkModeGray-40;
+  @apply text-gray-40;
 }

--- a/components/utilities/headerLink.module.css
+++ b/components/utilities/headerLink.module.css
@@ -27,7 +27,7 @@ h1.HeaderContainer {
 :global(.dark) .HeaderContainer,
 :global(.dark) .CopiedMessage,
 :global(.dark) .CopiedIcon {
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }
 
 .CopyLink {

--- a/components/utilities/headerLink.module.css
+++ b/components/utilities/headerLink.module.css
@@ -27,7 +27,7 @@ h1.HeaderContainer {
 :global(.dark) .HeaderContainer,
 :global(.dark) .CopiedMessage,
 :global(.dark) .CopiedIcon {
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }
 
 .CopyLink {

--- a/components/utilities/helpful.module.css
+++ b/components/utilities/helpful.module.css
@@ -70,12 +70,12 @@
 :global(.dark) .ImproveTitle,
 :global(.dark) .ImproveText,
 :global(.dark) .Label {
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }
 
 :global(.dark) .Button {
   @apply bg-gray-80;
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }
 
 :global(.dark) .Icon {

--- a/components/utilities/helpful.module.css
+++ b/components/utilities/helpful.module.css
@@ -70,12 +70,12 @@
 :global(.dark) .ImproveTitle,
 :global(.dark) .ImproveText,
 :global(.dark) .Label {
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }
 
 :global(.dark) .Button {
   @apply bg-gray-80;
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }
 
 :global(.dark) .Icon {

--- a/components/utilities/psa.module.css
+++ b/components/utilities/psa.module.css
@@ -12,7 +12,7 @@
 }
 
 :global(.dark) .Icon {
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }
 
 .Title {
@@ -23,7 +23,7 @@
 :global(.dark) .Title,
 :global(.dark) .Text,
 :global(.dark) .Link {
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }
 
 .Text {

--- a/components/utilities/psa.module.css
+++ b/components/utilities/psa.module.css
@@ -12,7 +12,7 @@
 }
 
 :global(.dark) .Icon {
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }
 
 .Title {
@@ -23,7 +23,7 @@
 :global(.dark) .Title,
 :global(.dark) .Text,
 :global(.dark) .Link {
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }
 
 .Text {

--- a/components/utilities/search.module.css
+++ b/components/utilities/search.module.css
@@ -21,7 +21,7 @@
 }
 
 :global(.dark) .SearchBar {
-  @apply text-darkModeGray-40 bg-gray-90 !important;
+  @apply text-gray-40 bg-gray-90 !important;
 }
 
 .SearchIcon {
@@ -42,7 +42,7 @@
 :global(.dark) .HotKey,
 :global(.dark) .SearchText,
 :global(.dark) .SearchIcon {
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }
 
 /* Hits */
@@ -94,5 +94,5 @@
 }
 
 :global(.dark) .HitTitle {
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }

--- a/components/utilities/search.module.css
+++ b/components/utilities/search.module.css
@@ -21,7 +21,7 @@
 }
 
 :global(.dark) .SearchBar {
-  @apply text-white bg-gray-90 !important;
+  @apply text-darkModeGray-40 bg-gray-90 !important;
 }
 
 .SearchIcon {
@@ -42,7 +42,7 @@
 :global(.dark) .HotKey,
 :global(.dark) .SearchText,
 :global(.dark) .SearchIcon {
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }
 
 /* Hits */
@@ -94,5 +94,5 @@
 }
 
 :global(.dark) .HitTitle {
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }

--- a/components/utilities/searchModal.css
+++ b/components/utilities/searchModal.css
@@ -7,7 +7,7 @@
 }
 
 .ais-InstantSearch .ais-SearchBox-form input {
-  @apply h-16 w-full bg-gray-10 dark:bg-gray-90 border-b border-b-gray-40 text-gray-90 rounded-none pl-20 pr-4 text-base focus:outline-none focus:border-b-2 focus:border-b-yellow-90 dark:border-b-gray-80 dark:text-white;
+  @apply h-16 w-full bg-gray-10 dark:bg-gray-90 border-b border-b-gray-40 text-gray-90 rounded-none pl-20 pr-4 text-base focus:outline-none focus:border-b-2 focus:border-b-yellow-90 dark:border-b-gray-80 dark:text-darkModeGray-40;
 }
 
 .ais-InstantSearch .ais-SearchBox-form #search-clear,

--- a/components/utilities/searchModal.css
+++ b/components/utilities/searchModal.css
@@ -7,7 +7,7 @@
 }
 
 .ais-InstantSearch .ais-SearchBox-form input {
-  @apply h-16 w-full bg-gray-10 dark:bg-gray-90 border-b border-b-gray-40 text-gray-90 rounded-none pl-20 pr-4 text-base focus:outline-none focus:border-b-2 focus:border-b-yellow-90 dark:border-b-gray-80 dark:text-darkModeGray-40;
+  @apply h-16 w-full bg-gray-10 dark:bg-gray-90 border-b border-b-gray-40 text-gray-90 rounded-none pl-20 pr-4 text-base focus:outline-none focus:border-b-2 focus:border-b-yellow-90 dark:border-b-gray-80 dark:text-gray-40;
 }
 
 .ais-InstantSearch .ais-SearchBox-form #search-clear,

--- a/components/utilities/socialCallout.module.css
+++ b/components/utilities/socialCallout.module.css
@@ -6,7 +6,7 @@
 :global(.dark) .Title,
 :global(.dark) .Subtitle,
 :global(.dark) .Text {
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }
 
 .ListContainer {

--- a/components/utilities/socialCallout.module.css
+++ b/components/utilities/socialCallout.module.css
@@ -6,7 +6,7 @@
 :global(.dark) .Title,
 :global(.dark) .Subtitle,
 :global(.dark) .Text {
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }
 
 .ListContainer {

--- a/components/utilities/themeToggle.module.css
+++ b/components/utilities/themeToggle.module.css
@@ -17,7 +17,7 @@
 }
 
 :global(.dark) .Icon {
-  @apply text-white !important;
+  @apply text-darkModeGray-40 !important;
 }
 
 .DarkIcon {

--- a/components/utilities/themeToggle.module.css
+++ b/components/utilities/themeToggle.module.css
@@ -17,7 +17,7 @@
 }
 
 :global(.dark) .Icon {
-  @apply text-darkModeGray-40 !important;
+  @apply text-gray-40 !important;
 }
 
 .DarkIcon {

--- a/styles/lists.scss
+++ b/styles/lists.scss
@@ -1,7 +1,7 @@
 /* Styles for nested lists inside markdown */
 ol,
 ul {
-  @apply my-0 mx-6 p-0 mt-4 text-gray-90 dark:text-white;
+  @apply my-0 mx-6 p-0 mt-4 text-gray-90 dark:text-darkModeGray-40;
 }
 
 ol li,

--- a/styles/lists.scss
+++ b/styles/lists.scss
@@ -1,7 +1,7 @@
 /* Styles for nested lists inside markdown */
 ol,
 ul {
-  @apply my-0 mx-6 p-0 mt-4 text-gray-90 dark:text-darkModeGray-40;
+  @apply my-0 mx-6 p-0 mt-4 text-gray-90 dark:text-gray-40;
 }
 
 ol li,

--- a/styles/tables.scss
+++ b/styles/tables.scss
@@ -5,7 +5,7 @@
 
 #content-container table:not(.full-width) tr th,
 #content-container table:not(.full-width) tr td {
-  @apply border-t border-t-gray-20 py-3 text-xs leading-loose tracking-normal text-gray-90 dark:text-darkModeGray-40;
+  @apply border-t border-t-gray-20 py-3 text-xs leading-loose tracking-normal text-gray-90 dark:text-gray-40;
 }
 
 #content-container table:not(.full-width) tr th a,

--- a/styles/tables.scss
+++ b/styles/tables.scss
@@ -5,7 +5,7 @@
 
 #content-container table:not(.full-width) tr th,
 #content-container table:not(.full-width) tr td {
-  @apply border-t border-t-gray-20 py-3 text-xs leading-loose tracking-normal text-gray-90 dark:text-white;
+  @apply border-t border-t-gray-20 py-3 text-xs leading-loose tracking-normal text-gray-90 dark:text-darkModeGray-40;
 }
 
 #content-container table:not(.full-width) tr th a,

--- a/styles/text.scss
+++ b/styles/text.scss
@@ -48,7 +48,7 @@ h3,
 h4,
 h5,
 h6 {
-  @apply dark:text-darkModeGray-40;
+  @apply dark:text-gray-40;
 }
 
 /* Margin modifiers */
@@ -69,15 +69,15 @@ a {
 }
 
 p {
-  @apply mb-4 text-gray-90 break-words dark:text-darkModeGray-40;
+  @apply mb-4 text-gray-90 break-words dark:text-gray-40;
 }
 
 summary {
-  @apply mb-4 text-gray-90 dark:text-darkModeGray-40;
+  @apply mb-4 text-gray-90 dark:text-gray-40;
 }
 
 sup a {
-  @apply underline hover:no-underline dark:text-darkModeGray-40;
+  @apply underline hover:no-underline dark:text-gray-40;
 }
 
 p:last-child,
@@ -110,7 +110,7 @@ button:focus-visible {
 /* Inline code blocks */
 p > code,
 li > code {
-  @apply border border-gray-40 dark:border-darkModeGray-80 text-red-70 rounded-md px-1 mx-1 break-words;
+  @apply border border-gray-40 dark:border-gray-80 text-red-70 rounded-md px-1 mx-1 break-words;
 }
 
 p a code {
@@ -119,7 +119,7 @@ p a code {
 
 /* One-line code descriptions in docstrings */
 div.code-desc {
-  @apply mb-4 text-gray-90 dark:text-darkModeGray-40;
+  @apply mb-4 text-gray-90 dark:text-gray-40;
 }
 
 /* Inline code blocks in docstrings */

--- a/styles/text.scss
+++ b/styles/text.scss
@@ -91,7 +91,7 @@ li p:only-child {
 
 .bold,
 strong {
-  @apply font-bold dark:font-extrabold dark:text-darkModeGray-10;
+  @apply font-bold dark:font-extrabold;
 }
 
 ol + p,

--- a/styles/text.scss
+++ b/styles/text.scss
@@ -48,7 +48,7 @@ h3,
 h4,
 h5,
 h6 {
-  @apply dark:text-white;
+  @apply dark:text-darkModeGray-40;
 }
 
 /* Margin modifiers */
@@ -69,15 +69,15 @@ a {
 }
 
 p {
-  @apply mb-4 text-gray-90 break-words dark:text-white;
+  @apply mb-4 text-gray-90 break-words dark:text-darkModeGray-40;
 }
 
 summary {
-  @apply mb-4 text-gray-90 dark:text-white;
+  @apply mb-4 text-gray-90 dark:text-darkModeGray-40;
 }
 
 sup a {
-  @apply underline hover:no-underline dark:text-white;
+  @apply underline hover:no-underline dark:text-darkModeGray-40;
 }
 
 p:last-child,
@@ -89,8 +89,9 @@ li p:only-child {
   @apply font-mono font-normal break-words;
 }
 
-.bold {
-  @apply font-bold;
+.bold,
+strong {
+  @apply font-bold dark:font-extrabold dark:text-darkModeGray-10;
 }
 
 ol + p,
@@ -109,7 +110,7 @@ button:focus-visible {
 /* Inline code blocks */
 p > code,
 li > code {
-  @apply border border-gray-40 text-red-70 rounded-md px-1 mx-1 break-words;
+  @apply border border-gray-40 dark:border-darkModeGray-80 text-red-70 rounded-md px-1 mx-1 break-words;
 }
 
 p a code {
@@ -118,7 +119,7 @@ p a code {
 
 /* One-line code descriptions in docstrings */
 div.code-desc {
-  @apply mb-4 text-gray-90 dark:text-white;
+  @apply mb-4 text-gray-90 dark:text-darkModeGray-40;
 }
 
 /* Inline code blocks in docstrings */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -175,19 +175,6 @@ module.exports = {
         LinkedIn: "#0a66c2",
         mono: "#24292F",
       },
-      darkModeGray: {
-        //Temporary color set for easy text replacement
-        10: "#fafafa",
-        20: "#f0f2f6",
-        30: "#e6eaf1",
-        40: "#d5dae5",
-        50: "#bfc5d3",
-        60: "#a3a8b8",
-        70: "#808495",
-        80: "#555867",
-        90: "#262730",
-        100: "#0e1117",
-      },
     },
 
     extend: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -175,6 +175,19 @@ module.exports = {
         LinkedIn: "#0a66c2",
         mono: "#24292F",
       },
+      darkModeGray: {
+        //Temporary color set for easy text replacement
+        10: "#fafafa",
+        20: "#f0f2f6",
+        30: "#e6eaf1",
+        40: "#d5dae5",
+        50: "#bfc5d3",
+        60: "#a3a8b8",
+        70: "#808495",
+        80: "#555867",
+        90: "#262730",
+        100: "#0e1117",
+      },
     },
 
     extend: {


### PR DESCRIPTION
## 📚 Context
White text on a black background is high contrast but a little harsh on the eyes. With an overall dark screen, the white text can be glaring.

## 🧠 Description of Changes
This PR softens the dark mode contrast a few shades for eye comfort.

---

**Revised:**
Body text {gray-90 ***dark:gray-40***}
strong {gray-90 ***dark:extrabold***}
Left navigation {gray-80 ***dark:gray50***}
Inline code border {gray-40 ***dark:gray-80***}

<table>
<tr>
<td>
<img width="1084" alt="image" src="https://github.com/streamlit/docs/assets/135349133/b3822d5c-50b7-4440-9d43-6d977f3666cc">
</td>
<td>
<img width="1293" alt="image" src="https://github.com/streamlit/docs/assets/135349133/be77ae04-8c15-4ae2-b9ed-d376b7f850ac">
</td>
</tr>
</table>

**Current:**
Body text {gray-90 dark:white}
strong {gray-90 dark:white}
Left navigation {gray-80 dark:gray-40}
Inline code border {gray-40}

<table>
<tr>
<td>
<img width="1098" alt="image" src="https://github.com/streamlit/docs/assets/135349133/cde574f4-e11b-4a40-8f65-f754a0ae99c4">
</td>
<td>
<img width="1247" alt="image" src="https://github.com/streamlit/docs/assets/135349133/8fa12814-a18d-40aa-8901-db600ca2fb57">
</td>
</tr>
</table>

## 💥 Impact
CSS edits

## 🌐 References
Notion project: [Docs papercut: Dark mode text contrast](https://www.notion.so/snowflake-corp/Docs-papercut-Dark-mode-text-contrast-1bb2fa59779e4c1d81fa60a9346171a3?pvs=4)

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
