### PR TITLE
Create .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,9 +35,4 @@
 
 # DOCS CONTENT
 
-/content* @sfc-gh-dmatthews @snowflakedb/docs-expandcollab
-
-#TODO
-# First create a team named docs-expandcollab in the streamlit repo, add @sfc-gh-dmatthews to it, then add this file to the .github folder
-
-  
+/content* @streamlit/docs-writers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,43 @@
+# Each line is a file pattern followed by one or more owners, which can be an individual user, multiple users, or a team.
+# For lines that contain two or more owners, the first owner is the primary topic writer, the second owner is the secondary writer.
+# The LAST matched pattern takes precedence, so specific items should be placed LATER in the file.
+
+# Format for owners is
+# Username @sfc-gh-<ldap_name>
+# Team @snowflakedb/team
+# Email email@snowflake.com
+
+# * @global-owner-of-last-resort
+
+# You can also use email addresses if you prefer. They'll be
+# used to look up users just like we do for commit author
+# emails.
+
+# *.foo foo@snowflake.com
+
+# Jenkinsfile @snowflakedb/repository-test-owner
+
+# We are not aiming to identify ownership for every directory or file yet, but for now add a few rules as examples so we can update as we go.
+
+# More details:
+  # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+  # Syntax, which is based on the rules for the .gitignore file: https://git-scm.com/docs/gitignore#_pattern_format
+
+#**************************************************************
+# General structure and notes
+# - Top to bottom starting in the root directory.
+# - Directories first, then individual files.
+# - Keep it alphabetical in the sections.
+# - A forward slash (/) matches everything in a directory.
+# - A wildcard (*) matches everything except the forward slash.
+#**************************************************************
+
+# DOCS CONTENT
+
+/content* @sfc-gh-dmatthews @snowflakedb/docs-expandcollab
+
+#TODO
+# First create a team named docs-expandcollab in the streamlit repo, add @sfc-gh-dmatthews to it, then add this file to the .github folder
+
+  


### PR DESCRIPTION
CODEOWNERS helps us determine who owns a file for the purposes of pull requests

## 📚 Context

Creating CODEOWNERS to help the Knowledge Management team manage our writer's pull requests.

## 🧠 Description of Changes

Added a text file. When changes are made to a file in streamlit/docs/content, @sfc-gh-dmatthews will be listed as the file's code owner, and will be added to the PR. Also, added the team name from snowflake-prod-docs so we can have consistent naming across projects. Please add this team to your repo in the event the team alias doesn't work in streamlit/docs.


## 💥 Impact

This will only have an effect on files in the streamlit/docs/content folder.

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
