### PR TITLE
Reduce left navigation spacing (1rem to 0.5 rem gradient)

### DIFF
--- a/components/navigation/navChild.js
+++ b/components/navigation/navChild.js
@@ -105,7 +105,6 @@ const NavChild = ({ slug, page, color, className }) => {
   } else if (isDivider) {
     navElement = (
       <div className={styles.LinkContainer}>
-        <hr className={styles.DividerLine} />
         <span className={styles.DividerText}>{page.name}</span>
         <hr className={styles.DividerLine} />
       </div>

--- a/components/navigation/navChild.js
+++ b/components/navigation/navChild.js
@@ -6,7 +6,7 @@ import useVersion from "../../lib/useVersion.js";
 
 import styles from "./navChild.module.css";
 
-const NavChild = ({ slug, page, color, className }) => {
+const NavChild = ({ slug, page, color, className, depth }) => {
   const [manualState, setManualState] = useState(null);
   const version = useVersion();
 
@@ -31,7 +31,7 @@ const NavChild = ({ slug, page, color, className }) => {
   const visibleItems = page.children.filter((child) => child.visible !== false);
   if (page.children?.length > 0 && visibleItems.length > 0 && opened) {
     subNav = (
-      <ul className={styles.List}>
+      <ul className={classNames(styles.List, LIST_DEPTH[depth])}>
         {page.children
           .filter((child) => child.visible !== false)
           .map((child) => (
@@ -143,7 +143,13 @@ const NavChild = ({ slug, page, color, className }) => {
   }
 
   return (
-    <li className={classNames(styles.Container, className)}>
+    <li
+      className={classNames(
+        styles.Container,
+        CONTAINER_DEPTH[depth],
+        className,
+      )}
+    >
       {navElement}
       {subNav}
     </li>
@@ -161,6 +167,19 @@ const CIRCLE_CLASS = {
   "indigo-70": styles.IndigoCircle,
   "gray-70": styles.GrayCircle,
   unset: styles.TransparentCircle,
+};
+
+const CONTAINER_DEPTH = {
+  11: styles.ContainerZero,
+  21: styles.ContainerOne,
+  31: styles.ContainerTwo,
+  unset: styles.ContainerTwo,
+};
+
+const LIST_DEPTH = {
+  11: styles.ListZero,
+  21: styles.ListOne,
+  unset: styles.ListOne,
 };
 
 export default NavChild;

--- a/components/navigation/navChild.module.css
+++ b/components/navigation/navChild.module.css
@@ -48,7 +48,7 @@
 .DividerText {
   @apply grow-0;
   @apply text-gray-70 uppercase tracking-widest leading-5;
-  @apply mx-1;
+  @apply mr-1;
 
   font-size: 0.625rem;
 }

--- a/components/navigation/navChild.module.css
+++ b/components/navigation/navChild.module.css
@@ -1,9 +1,28 @@
 .Container {
-  @apply text-sm tracking-tight dark:text-gray-40 mb-4;
+  @apply text-sm tracking-tight dark:text-gray-40 mb-2;
+}
+
+.ContainerZero {
+  @apply mb-4;
+}
+
+.ContainerOne {
+  @apply mb-3;
+}
+
+.ContainerTwo {
+  @apply mb-2;
 }
 
 .List {
-  @apply list-none mt-4;
+  @apply list-none mt-2;
+}
+
+.ListZero {
+  @apply mt-3;
+}
+.ListOne {
+  @apply mt-2;
 }
 
 .Accordion {


### PR DESCRIPTION
## 📚 Context
Due to the large spacing in the left navigation, it can be hard for the eyes to track, especially when large categories are expanded.

## 🧠 Description of Changes
This PR reduced the line spacing from a uniform 1rem to a spacing that steps down from 1rem to a minimum of 0.5rem.

**Revised:**
Will update if chosen.

**Current:**
Will update if chosen.

## 🌐 References


**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
