### PR TITLE
Left justify menu dividers

### DIFF
--- a/components/navigation/navChild.js
+++ b/components/navigation/navChild.js
@@ -105,7 +105,6 @@ const NavChild = ({ slug, page, color, className }) => {
   } else if (isDivider) {
     navElement = (
       <div className={styles.LinkContainer}>
-        <hr className={styles.DividerLine} />
         <span className={styles.DividerText}>{page.name}</span>
         <hr className={styles.DividerLine} />
       </div>

--- a/components/navigation/navChild.module.css
+++ b/components/navigation/navChild.module.css
@@ -48,7 +48,7 @@
 .DividerText {
   @apply grow-0;
   @apply text-gray-70 uppercase tracking-widest leading-5;
-  @apply mx-1;
+  @apply mr-1;
 
   font-size: 0.625rem;
 }


### PR DESCRIPTION
## 📚 Context
Design tweak to menu dividers.

## 🧠 Description of Changes
Dividers are now left-justified instead of centered.

**Revised:**
<img width="349" alt="image" src="https://github.com/streamlit/docs/assets/135349133/a7c95ddc-ff51-4c30-a89d-22b2e8a4de7b">

**Current:**
<img width="337" alt="image" src="https://github.com/streamlit/docs/assets/135349133/69576abc-4b88-4ce0-b0f5-415eb3634dda">


## 🌐 References
Notion project: [Docs papercut: Left nav and dividers](https://www.notion.so/snowflake-corp/Docs-papercut-Left-nav-and-dividers-f186c3cb4ad9490c89e09d27c50de96e)

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.