### PR TITLE
Skip over dividers when finding next/prev page

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -38,7 +38,7 @@ function getPreviousNextFromMenu(menu, slugStr, parent) {
   for (let index = 0; index < menu.length; index++) {
     // If we are inside top-level category, point them to the next top-level category
     if (current && !next) {
-      next = menu[index];
+      next = menu[index].url ? menu[index] : menu[index + 1];
     }
     if (current) {
       continue;
@@ -46,28 +46,35 @@ function getPreviousNextFromMenu(menu, slugStr, parent) {
 
     // For top-level categories
     if (menu[index].url === slugStr) {
-      // If we are NOT on the first top-level category (Streamlit Library), point the previous arrow
-      // to the previous parent
-      // Example: Streamlit Community Cloud points to Streamlit Library.
-      // Example: Knowledge Base points to Streamlit Community Cloud
+      // If we are NOT on the first top-level category (Get started), point the
+      // previous arrow to the parent
+      // Example: Develop points to Get started.
+      // Example: Deploy points to Develop
       if (index < 1) {
         prev = parent;
+        // If we are on the second item within a category and the first item is
+        // a divider, skip the divider and point to the parent
+      } else if (index === 1 && !menu[index - 1].url) {
+        prev = parent;
+        // If the current item is preceded by a divider, skip the divider and
+        // point to the item before the divider
+      } else if (!menu[index - 1].url) {
+        prev = menu[index - 2];
       } else {
         prev = menu[index - 1];
       }
 
-      // If we are on a top-level category, the next item should be its first child
-      // Example: Streamlit Library -> Get Started
-      // Example: Streamlit Community Cloud -> Community
-      if (parseInt(menu[index].depth) === 0) {
-        next = menu[index].children[0];
-      }
-
-      // If we are on a sub item that's expandable, then its first item should be its direct descendant
-      // Example: Tutorials -> Connect to data sources
-      // Example: Community -> Sign up
-      if (menu[index].children && menu[index].children.length > 0) {
-        next = menu[index].children[0];
+      // If we are on a top-level category or expandable item, the next item
+      // should be its first child. Skip over a divider if it's the first child.
+      // Example: Get started -> Installation
+      // Example: API reference -> Write and magic
+      const isTopLevel = parseInt(menu[index].depth) === 0;
+      const isExpandable =
+        menu[index].children && menu[index].children.length > 0;
+      if (isTopLevel || isExpandable) {
+        next = menu[index].children[0].url
+          ? menu[index].children[0]
+          : menu[index].children[1];
       }
 
       current = menu[index];
@@ -78,7 +85,7 @@ function getPreviousNextFromMenu(menu, slugStr, parent) {
       ({ current, prev, next } = getPreviousNextFromMenu(
         menu[index].children,
         slugStr,
-        menu[index]
+        menu[index],
       ));
     }
   }


### PR DESCRIPTION
## 📚 Context
Currently when using menu dividers, the next and previous page links at the bottom  of pages need to be manually set to skip over dividers.

## 🧠 Description of Changes
This PR implements a planned update for the navigation utility functions to correctly ignore dividers when they occur in the menu. (Incorrect links can still appear if two dividers are incorrectly placed adjacently.)

## 🌐 References
Notion project: [Docs: Develop, Deploy review](https://www.notion.so/snowflake-corp/Docs-Develop-Deploy-review-dac979882b214e23bd4b5102916b3477?pvs=4)

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
