### PR TITLE
Update publish-component.md

### DIFF
--- a/content/develop/concepts/custom-components/publish-component.md
+++ b/content/develop/concepts/custom-components/publish-component.md
@@ -36,7 +36,7 @@ The [component-template](https://github.com/streamlit/component-template) GitHub
 
    ```bash
    cd frontend
-   npm run export
+   npm run build
    ```
 
 5. Pass the build folder's path as the `path` parameter to `declare_component`. (If you're using the template Python file, you can set `_RELEASE = True` at the top of the file):


### PR DESCRIPTION
## 📚 Context

The "export" script no longer exists, it has been replaced by build. The documentation for publish a component still has the old version.

## 🧠 Description of Changes
`npm run export` change to `npm run build`