### PR TITLE
Fix grammar typo

### DIFF
--- a/content/develop/tutorials/execution-flow/fragments/trigger-a-full-script-rerun-from-a-fragment.md
+++ b/content/develop/tutorials/execution-flow/fragments/trigger-a-full-script-rerun-from-a-fragment.md
@@ -9,7 +9,7 @@ Streamlit lets you turn functions into [fragments](/develop/concepts/architectur
 
 ## Applied concepts
 
-- Use a fragment rerun part or all of your app, depending on user input.
+- Use a fragment to rerun part or all of your app, depending on user input.
 
 ## Prerequisites
 


### PR DESCRIPTION
## 📚 Context
Corrected a typo in a fragment tutorial

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.