### PR TITLE
Fix typo in additional-features.md

### DIFF
--- a/content/get-started/fundamentals/additional-features.md
+++ b/content/get-started/fundamentals/additional-features.md
@@ -5,7 +5,7 @@ slug: /get-started/fundamentals/additional-features
 
 # Additional Streamlit features
 
-So you've read all about Streamlit's [Basic concepts](/get-started/fundamentals/main-concepts) and gotten a tase of caching and Session State in [Advanced concepts](/get-started/fundamentals/advanced-concepts). But what about the bells and whistles? Here's a quick look at some extra features to take your app to the next level.
+So you've read all about Streamlit's [Basic concepts](/get-started/fundamentals/main-concepts) and gotten a taste of caching and Session State in [Advanced concepts](/get-started/fundamentals/advanced-concepts). But what about the bells and whistles? Here's a quick look at some extra features to take your app to the next level.
 
 ## Theming
 


### PR DESCRIPTION
Fix the typo in the first paragraph, a typo is present where the word "tase" appears instead of "taste."

## 📚 Context

The documentation should use the word 'taste' instead of 'tase' in the first paragraph of the fundamental section to accurately describe the concept being discussed.

Fixes #1043

## 🧠 Description of Changes

A typo is present where the word "tase" appears instead of "taste" which has been changed.


**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 💥 Impact

This error impacts the clarity and accuracy of the documentation, and it should be rectified to enhance user understanding.

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
