### PR TITLE
Fix typo in get-started/fundamentals/summary

### DIFF
--- a/content/get-started/fundamentals/summary.md
+++ b/content/get-started/fundamentals/summary.md
@@ -11,7 +11,7 @@ the loop and review how it works together:
 1. Streamlit apps are Python scripts that run from top to bottom.
 1. Every time a user opens a browser tab pointing to your app, the script is executed and a new session starts.
 1. As the script executes, Streamlit draws its output live in a browser.
-1. Every time a user interacts with a widget, your script is re-executed and Streamlit redraws its output in the brower.
+1. Every time a user interacts with a widget, your script is re-executed and Streamlit redraws its output in the browser.
    - The output value of that widget matches the new value during that rerun.
 1. Scripts use the Streamlit cache to avoid recomputing expensive functions, so updates happen very fast.
 1. Session State lets you save information that persists between reruns when you need more than a simple widget.


### PR DESCRIPTION
## 🧠 Description of Changes

Fix typo in content/get-started/fundamentals/summary.md

**Revised:**

"browser"

**Current:**

"brower"

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
