### PR TITLE
Wrap code within h4 tags in RefCard component to prevent overflow

### DIFF
--- a/components/blocks/refCard.module.css
+++ b/components/blocks/refCard.module.css
@@ -112,6 +112,10 @@
   @apply hidden;
 }
 
+.Container h4 code {
+  overflow-wrap: anywhere;
+}
+
 /* Deprecation notice */
 .Container i.DeprecatedIcon {
   @apply absolute -right-2 top-0 cursor-pointer;


### PR DESCRIPTION
## 📚 Context

`<code>` within `<h4>` elements used in `<RefCard>` Components in the [What's new](https://docs.streamlit.io/#whats-new) section of the docs homepage overflow horizontally. This issue occurs on screens of certain dimensions. E.g. on a 13 inch MBP.

## 🧠 Description of Changes

- Applies a `overflow-wrap: anywhere` CSS property to prevent overflow

**Revised:**

<img width="949" alt="image" src="https://github.com/streamlit/docs/assets/20672874/f075997a-bda6-4cf6-9eaa-1734060164a5">

**Current:**

<img width="1072" alt="image" src="https://github.com/streamlit/docs/assets/20672874/5e6455d9-32fb-4dc3-8a3a-4b77e04f7602">

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
