### PR TITLE
Update Cloud component and output directive to use React components in streamlit.json

### DIFF
--- a/components/blocks/cloud.js
+++ b/components/blocks/cloud.js
@@ -1,45 +1,107 @@
 import React, { useEffect, useRef } from "react";
 import classNames from "classnames";
 
-import styles from "./cloud.module.css";
+// Arguments:
+//
+// - name: a string with the subdomain of the URL. That's the part between "https://" and
+//   ".streamlit.app". This is more future-proof that typing the full domain in case we change
+//   the URL scheme at some point.
+//
+// - path: an optional string with the app's subpath. This is the part after ".streamlit.app/"
+//   and before any query params.
+//
+// - query: an optional string with query params to add. Do not include the "?" at the front.
+//
+// - height: an optional string with a value CSS height. Must include a unit.
+//
+//
+// Arguments you shouldn't use by hand. Instead, these are meant to be used in table.js, which
+// needs to handle deprecated arguments we used to support in the iframes from our docstrings.
+//
+// - domain: a string with the app's full domain, like "foo.streamlit.app".
+//
+// - stylePlaceholder: a string with a regex placeholder like "$1".
+//
+//
+// For example:
+//
+//   <Cloud name="foo" query="embedOptions=show_padding" height="500px" />
+//   -> https://foo.streamlit.app/?embed=true&embed_options=show_padding
+//
+//   <Cloud name="foo" path="bar" query="embedOptions=show_padding&embedOptions=show_colored_line" />
+//   -> https://foo.streamlit.app/bar/?embed=true&embed_options=show_padding&embed_options=show_colored_line
+//
+const Cloud = ({ name, path, query, height, domain, stylePlaceholder }) => {
+  if (!domain) domain = `${name}.streamlit.app`;
+  if (domain.endsWith("/")) domain = domain.slice(0, -1);
 
-const Cloud = ({ src, height }) => {
-  const iframeRef = useRef();
-  let CloudBlock;
-
-  if (height) {
-    CloudBlock = (
-      <section className={styles.Container}>
-        <iframe
-          loading="lazy"
-          src={`${src}`}
-          height={height}
-          className={styles.Iframe}
-          allow="camera;clipboard-read;clipboard-write;"
-          key={src}
-        />
-        {/* <a href={src} target="_blank" className={styles.Caption}>
-          (view standalone Streamlit app)
-        </a> */}
-      </section>
-    );
+  if (path) {
+    if (!path.startsWith("/")) path = "/" + path;
+    if (path.endsWith("/")) path = path.slice(0, -1);
   } else {
-    CloudBlock = (
-      <section className={styles.Container}>
-        <iframe
-          loading="lazy"
-          src={`${src}`}
-          className={classNames(styles.Iframe, styles.VideoAspectRatio)}
-          allow="camera;clipboard-read;clipboard-write;"
-          key={src}
-        />
-        {/* <a href={src} target="_blank" className={styles.Caption}>
-          (view standalone Streamlit app)
-        </a> */}
-      </section>
-    );
+    path = "";
   }
-  return CloudBlock;
+
+  const queryStr = query ? `&${query}` : "";
+
+  if (!height) height = "10rem";
+
+  const style = stylePlaceholder
+    ? // Hack so React lets us put a capture group placeholder in the style tag.
+      { ["--ignore-me"]: `42; ${stylePlaceholder}` }
+    : height
+      ? { height }
+      : null;
+
+  const frameSrc = `https://${domain}/~/+${path}/?embed=true${queryStr}`;
+  const linkSrc = `https://${domain}${path}/?utm_medium=oembed`;
+
+  return (
+    <section className="overflow-hidden rounded-xl border border-gray-40 my-4 flex flex-col">
+      <iframe
+        src={frameSrc}
+        allow="camera;clipboard-read;clipboard-write;"
+        loading="lazy"
+        className="w-full"
+        style={style}
+        key={frameSrc}
+      />
+
+      {/* This toolbar imitates the Cloud OEmbed toolbar */}
+      <div
+        className={classNames(
+          "flex flex-row px-3 py-1 bg-gray-20",
+          "text-xs tracking-[0.05em] text-gray-80 gap-16",
+        )}
+      >
+        <div className="flex-1">
+          <a
+            className="text-xs tracking-[0.05em] text-gray-80 hover:text-gray-70"
+            href="https://streamlit.io"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Built with Streamlit 🎈
+          </a>
+        </div>
+
+        <div>
+          <a
+            href={linkSrc}
+            className={classNames(
+              "text-xs tracking-[0.05em]",
+              "text-gray-80 hover:text-gray-70",
+              "flex flex-row gap-1",
+            )}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Fullscreen <i className="text-xs">open_in_new</i>
+          </a>
+        </div>
+      </div>
+    </section>
+  );
 };
 
 export default Cloud;

--- a/components/blocks/table.js
+++ b/components/blocks/table.js
@@ -1,5 +1,8 @@
 import React from "react";
+import ReactDOMServer from "react-dom/server";
 import classNames from "classnames";
+
+import Cloud from "./cloud.js";
 
 import styles from "./table.module.css";
 
@@ -100,7 +103,9 @@ const Table = ({
         const body = footer.jsx ? (
           footer.body
         ) : (
-          <section dangerouslySetInnerHTML={createMarkup(footer.body)} />
+          <section
+            dangerouslySetInnerHTML={createMarkup(insertCloud(footer.body))}
+          />
         );
         return (
           <React.Fragment key={`footer-${index}`}>
@@ -116,5 +121,26 @@ const Table = ({
     </section>
   );
 };
+
+// Regex capturing React components:
+const CLOUD_RE = new RegExp(
+  [
+    "<Cloud ",
+    'name="([^<>]*)" ',
+    'path="([^<>]*)" ',
+    'query="([^<>]*)" ',
+    'stylePlaceholder="([^<>]*)" ',
+    "\\/>",
+  ].join(""),
+  "g",
+);
+
+const CLOUD_HTML = ReactDOMServer.renderToString(
+  <Cloud name="$1" path="$2" query="$3" stylePlaceholder="$4" />,
+);
+
+function insertCloud(htmlStr) {
+  return htmlStr.replace(CLOUD_RE, CLOUD_HTML);
+}
 
 export default Table;

--- a/content/deploy/community-cloud/share-your-app/embed-your-app.md
+++ b/content/deploy/community-cloud/share-your-app/embed-your-app.md
@@ -17,13 +17,12 @@ For example, say you want to embed the <a href="https://30days.streamlit.app/" t
 
 ```javascript
 <iframe
-  src="https://30days.streamlit.app/?embed=true"
-  height="450"
-  style={{ width: "100%", border: "none" }}
+  src="https://30days.streamlit.app?embed=true"
+  style="height: 450px; width: 100%;"
 ></iframe>
 ```
 
-<Cloud src="https://30days.streamlit.app/?embed=true" />
+<Cloud name="30days" height="450px" />
 
 <Important>
 

--- a/content/develop/api-reference/charts/altair_chart.md
+++ b/content/develop/api-reference/charts/altair_chart.md
@@ -39,7 +39,7 @@ with tab2:
 
 Click the tabs in the interactive app below to see the charts with the Streamlit theme enabled and disabled.
 
-<Cloud src="https://doc-altair-chart.streamlit.app/?embed=true" height="500" />
+<Cloud name="doc-altair-chart" height="500px" />
 
 If you're wondering if your own customizations will still be taken into account, don't worry! You can still make changes to your chart configurations. In other words, although we now enable the Streamlit theme by default, you can overwrite it with custom colors or fonts. For example, if you want a chart line to be green instead of the default red, you can do it!
 
@@ -115,7 +115,7 @@ with tab2:
 
 Notice how the custom colors are still reflected in the chart, even when the Streamlit theme is enabled 👇
 
-<Cloud src="https://doc-altair-custom-colors.streamlit.app/?embed=true" height="675" />
+<Cloud name="doc-altair-custom-colors" height="675px" />
 
 For many more examples of Altair charts with and without the Streamlit theme, check out the [altair.streamlit.app](https://altair.streamlit.app).
 
@@ -263,4 +263,4 @@ To use images instead of emojis, replace the line containing `.mark_text()` with
 
 Now that you've learned how to annotate charts, the sky's the limit! We've extended the above example to let you interactively paste your favorite emoji and set its position on the chart with Streamlit widgets. 👇
 
-<Cloud src="https://example-time-series-annotation.streamlit.app/?embed=true" height="700" />
+<Cloud name="example-time-series-annotation" height="700px" />

--- a/content/develop/api-reference/charts/plotly_chart.md
+++ b/content/develop/api-reference/charts/plotly_chart.md
@@ -43,7 +43,7 @@ with tab2:
 
 Click the tabs in the interactive app below to see the charts with the Streamlit theme enabled and disabled.
 
-<Cloud src="https://doc-plotly-chart-theme.streamlit.app/?embed=true" height="525" />
+<Cloud name="doc-plotly-chart-theme" height="525px" />
 
 If you're wondering if your own customizations will still be taken into account, don't worry! You can still make changes to your chart configurations. In other words, although we now enable the Streamlit theme by default, you can overwrite it with custom colors or fonts. For example, if you want a chart line to be green instead of the default red, you can do it!
 
@@ -72,6 +72,6 @@ with tab2:
 
 Notice how the custom color scale is still reflected in the chart, even when the Streamlit theme is enabled 👇
 
-<Cloud src="https://doc-plotly-custom-colors.streamlit.app/?embed=true" height="650" />
+<Cloud name="doc-plotly-custom-colors" height="650px" />
 
 For many more examples of Plotly charts with and without the Streamlit theme, check out the [plotly.streamlit.app](https://plotly.streamlit.app).

--- a/content/develop/api-reference/charts/vega_lite_chart.md
+++ b/content/develop/api-reference/charts/vega_lite_chart.md
@@ -54,6 +54,6 @@ with tab2:
 
 Click the tabs in the interactive app below to see the charts with the Streamlit theme enabled and disabled.
 
-<Cloud src="https://doc-vega-lite-theme.streamlit.app/?embed=true" height="500" />
+<Cloud name="doc-vega-lite-theme" height="500px" />
 
 If you're wondering if your own customizations will still be taken into account, don't worry! You can still make changes to your chart configurations. In other words, although we now enable the Streamlit theme by default, you can overwrite it with custom colors or fonts. For example, if you want a chart line to be green instead of the default red, you can do it!

--- a/content/develop/api-reference/data/data_editor.md
+++ b/content/develop/api-reference/data/data_editor.md
@@ -16,4 +16,4 @@ This page only contains information on the `st.data_editor` API. For an overview
 
 You can configure the display and editing behavior of columns in `st.dataframe` and `st.data_editor` via the [Column configuration API](/develop/api-reference/data/st.column_config). We have developed the API to let you add images, charts, and clickable URLs in dataframe and data editor columns. Additionally, you can make individual columns editable, set columns as categorical and specify which options they can take, hide the index of the dataframe, and much more.
 
-<Cloud src="https://doc-column-config-overview.streamlit.app/?embed=true&embed_options=disable_scrolling" height="480"/>
+<Cloud name="doc-column-config-overview" query="embed_options=disable_scrolling" height="480px" />

--- a/content/develop/api-reference/data/dataframe.md
+++ b/content/develop/api-reference/data/dataframe.md
@@ -40,7 +40,7 @@ df = load_data()
 st.dataframe(df, use_container_width=st.session_state.use_container_width)
 ```
 
-<Cloud src="https://doc-dataframe2.streamlit.app/?embed=true" height="350" />
+<Cloud name="doc-dataframe2" height="350px" />
 
 <Autofunction function="DeltaGenerator.add_rows" />
 
@@ -52,4 +52,4 @@ Dataframes displayed with `st.dataframe` are interactive. End users can sort, re
 
 You can configure the display and editing behavior of columns in `st.dataframe` and `st.data_editor` via the [Column configuration API](/develop/api-reference/data/st.column_config). We have developed the API to let you add images, charts, and clickable URLs in dataframe and data editor columns. Additionally, you can make individual columns editable, set columns as categorical and specify which options they can take, hide the index of the dataframe, and much more.
 
-<Cloud src="https://doc-column-config-overview.streamlit.app/?embed=true&embed_options=disable_scrolling" height="480"/>
+<Cloud name="doc-column-config-overview" query="embed_options=disable_scrolling" height="480px" />

--- a/content/develop/api-reference/status/toast.md
+++ b/content/develop/api-reference/status/toast.md
@@ -22,7 +22,7 @@ if st.button('Three cheers'):
     st.toast('Hooray!', icon='🎉')
 ```
 
-<Cloud src="https://doc-status-toast1.streamlit.app/?embed=true" height="300" />
+<Cloud name="doc-status-toast1" height="300px" />
 
 Toast messages can also be updated. Assign `st.toast(my_message)` to a variable
 and use the `.toast()` method to update it. Note: if a toast has already disappeared
@@ -43,4 +43,4 @@ if st.button('Cook breakfast'):
     cook_breakfast()
 ```
 
-<Cloud src="https://doc-status-toast2.streamlit.app/?embed=true" height="200" />
+<Cloud name="doc-status-toast2" height="200px" />

--- a/content/develop/api-reference/text/markdown.md
+++ b/content/develop/api-reference/text/markdown.md
@@ -21,4 +21,4 @@ st.markdown('''{md}''')
 st.markdown(md)
 ```
 
-<Cloud src="https://doc-markdown1.streamlit.app/?embed=true" height="500" />
+<Cloud name="doc-markdown1" height="500px" />

--- a/content/develop/api-reference/widgets/radio.md
+++ b/content/develop/api-reference/widgets/radio.md
@@ -36,7 +36,7 @@ with col2:
     )
 ```
 
-<Cloud src="https://doc-radio1.streamlit.app/?embed=true" height="300" />
+<Cloud name="doc-radio1" height="300px" />
 
 ### Featured videos
 

--- a/content/develop/api-reference/widgets/selectbox.md
+++ b/content/develop/api-reference/widgets/selectbox.md
@@ -37,4 +37,4 @@ with col2:
     )
 ```
 
-<Cloud src="https://doc-selectbox1.streamlit.app/?embed=true" height="300" />
+<Cloud name="doc-selectbox1" height="300px" />

--- a/content/develop/api-reference/widgets/text_input.md
+++ b/content/develop/api-reference/widgets/text_input.md
@@ -45,4 +45,4 @@ with col2:
         st.write("You entered: ", text_input)
 ```
 
-<Cloud src="https://doc-text-input1.streamlit.app/?embed=true" height="400" />
+<Cloud name="doc-text-input1" height="400px" />

--- a/content/develop/concepts/app-design/dataframes.md
+++ b/content/develop/concepts/app-design/dataframes.md
@@ -26,7 +26,7 @@ df = pd.DataFrame(
 st.dataframe(df, use_container_width=True)
 ```
 
-<Cloud src="https://doc-dataframe-basic.streamlit.app/?embed=true" height="300px"/>
+<Cloud name="doc-dataframe-basic" height="300px"/>
 
 ## `st.dataframe` UI features
 
@@ -66,7 +66,7 @@ favorite_command = edited_df.loc[edited_df["rating"].idxmax()]["command"]
 st.markdown(f"Your favorite command is **{favorite_command}** 🎈")
 ```
 
-<Cloud src="https://doc-data-editor.streamlit.app/?embed=true" height="300px"/>
+<Cloud name="doc-data-editor" height="300px"/>
 
 Try it out by double-clicking on any cell. You'll notice you can edit all cell values. Try editing the values in the rating column and observe how the text output at the bottom changes:
 
@@ -94,7 +94,7 @@ edited_df = st.data_editor(df, num_rows="dynamic")
 - To add new rows, click the plus icon (<i style={{ verticalAlign: "-.25em" }} className={{ class: "material-icons-sharp" }}>add</i>) in the toolbar. Alternatively, click inside a shaded cell below the bottom row of the table.
 - To delete rows, select one or more rows using the checkboxes on the left. Click the delete icon (<i style={{ verticalAlign: "-.25em" }} className={{ class: "material-icons-sharp" }}>delete</i>) or press the `delete` key on your keyboard.
 
-<Cloud src="https://doc-data-editor-clipboard.streamlit.app/?embed=true" height="400px"/>
+<Cloud name="doc-data-editor-clipboard" height="400px"/>
 
 ### Copy and paste support
 
@@ -137,7 +137,7 @@ In this code snippet, the `key` parameter is set to `"my_key"`. After the data e
 
 This can be useful when working with large dataframes and you only need to know which cells have changed, rather than access the entire edited dataframe.
 
-<Cloud src="https://doc-data-editor-changed.streamlit.app/?embed=true" height="700px"/>
+<Cloud name="doc-data-editor-changed" height="700px"/>
 
 Use all we've learned so far and apply them to the above embedded app. Try editing cells, adding new rows, and deleting rows.
 
@@ -210,7 +210,7 @@ You can configure the display and editing behavior of columns in `st.dataframe` 
 
 Column configuration includes the following column types: Text, Number, Checkbox, Selectbox, Date, Time, Datetime, List, Link, Image, Line chart, Bar chart, and Progress. There is also a generic Column option. See the embedded app below to view these different column types. Each column type is individually previewed in the [Column configuration API](/develop/api-reference/data/st.column_config) documentation.
 
-<Cloud src="https://doc-column-config-overview.streamlit.app/?embed=true&embed_options=disable_scrolling" height="480"/>
+<Cloud name="doc-column-config-overview" query="embed_options=disable_scrolling" height="480px"/>
 
 ### Format values
 
@@ -246,7 +246,7 @@ if st.button('Get results'):
     st.write(result)
 ```
 
-<Cloud src="https://doc-column-config-empty.streamlit.app/?embed=true" height="300"/>
+<Cloud name="doc-column-config-empty" height="300px"/>
 
 ## Additional formatting options
 

--- a/content/develop/concepts/architecture/forms.md
+++ b/content/develop/concepts/architecture/forms.md
@@ -63,7 +63,7 @@ st.map(df, size='size', color='color')
 
 </Collapse>
 
-<Cloud src="https://doc-forms-overview.streamlit.app/?embed=true" height="800"/>
+<Cloud name="doc-forms-overview" height="800px"/>
 
 ## User interaction
 
@@ -95,7 +95,7 @@ st.write(my_number)
 st.write(my_color)
 ```
 
-<Cloud src="https://doc-forms-default.streamlit.app/?embed=true" height="450"/>
+<Cloud name="doc-forms-default" height="450px"/>
 
 ## Forms are containers
 
@@ -120,7 +120,7 @@ else:
     animal.subheader('&nbsp;')
 ```
 
-<Cloud src="https://doc-forms-container.streamlit.app/?embed=true" height="375"/>
+<Cloud name="doc-forms-container" height="375px"/>
 
 ## Processing form submissions
 
@@ -153,7 +153,7 @@ if submit:
     col2.title(f'{a+b:.2f}')
 ```
 
-<Cloud src="https://doc-forms-process1.streamlit.app/?embed=true" height="400"/>
+<Cloud name="doc-forms-process1" height="400px"/>
 
 ### Use a callback with session state
 
@@ -186,7 +186,7 @@ with st.form('addition'):
     st.form_submit_button('add', on_click=sum)
 ```
 
-<Cloud src="https://doc-forms-process2.streamlit.app/?embed=true" height="400"/>
+<Cloud name="doc-forms-process2" height="400px"/>
 
 ### Use `st.rerun`
 
@@ -216,7 +216,7 @@ if submit:
     st.rerun()
 ```
 
-<Cloud src="https://doc-forms-process3.streamlit.app/?embed=true" height="400"/>
+<Cloud name="doc-forms-process3" height="400px"/>
 
 ## Limitations
 

--- a/content/develop/concepts/architecture/widget-behavior.md
+++ b/content/develop/concepts/architecture/widget-behavior.md
@@ -101,7 +101,7 @@ with st.form(key="my_form"):
     st.form_submit_button("I'm here!", on_click=take_attendance)
 ```
 
-<Cloud src="https://doc-guide-widgets-form-callbacks.streamlit.app/?embed=true" height="250"/>
+<Cloud name="doc-guide-widgets-form-callbacks" height="250px"/>
 
 ## Statefulness of widgets
 
@@ -126,7 +126,7 @@ st.slider("With default, no key", minimum, maximum, value=5)
 st.slider("With default, with key", minimum, maximum, value=5, key="b")
 ```
 
-<Cloud src="https://doc-guide-widgets-change-parameters.streamlit.app/?embed=true" height="550"/>
+<Cloud name="doc-guide-widgets-change-parameters" height="550px"/>
 
 #### Updating a slider with no default value
 
@@ -263,6 +263,6 @@ update_value()
 st.slider("A", minimum, maximum, key="a")
 ```
 
-<Cloud src="https://doc-guide-widgets-change-parameters-solution.streamlit.app/?embed=true" height="250"/>
+<Cloud name="doc-guide-widgets-change-parameters-solution" height="250px"/>
 
 The `update_value()` helper function is actually doing two things. On the surface, it's making sure there are no inconsistent changes to the parameters values as described. Importantly, it's also interrupting the widget clean-up process. When the min or max value of the widget changes, Streamlit sees it as a new widget on rerun. Without saving a value to `st.session_state.a`, the value would be thrown out and replaced by the "new" widget's default value.

--- a/content/develop/concepts/configuration/static-file-serving.md
+++ b/content/develop/concepts/configuration/static-file-serving.md
@@ -54,4 +54,4 @@ Additional resources:
 - [https://docs.streamlit.io/develop/concepts/configuration](https://docs.streamlit.io/develop/concepts/configuration)
 - [https://static-file-serving.streamlit.app/](https://static-file-serving.streamlit.app/)
 
-<Cloud src="https://static-file-serving.streamlit.app/?embedded=true" height="1000" />
+<Cloud name="static-file-serving" height="1000px" />

--- a/content/develop/concepts/connections/connecting-to-data.md
+++ b/content/develop/concepts/connections/connecting-to-data.md
@@ -36,7 +36,7 @@ Community Cloud apps do not guarantee the persistence of local file storage, so 
 
 To see the example below running live, check out the interactive demo below:
 
-<Cloud src="https://experimental-connection.streamlit.app/SQL?embed=true" />
+<Cloud name="experimental-connection" path="SQL" />
 
 #### Step 1: Install prerequisite library - SQLAlchemy
 
@@ -202,7 +202,7 @@ Maintaining a tailored internal Connection implementation across many apps can b
 
 Check out the [Build your own Connection page](https://experimental-connection.streamlit.app/Build_your_own) in the st.experimental connection demo app below for a quick tutorial and working implementation. This demo builds a minimal but very functional Connection on top of DuckDB.
 
-<Cloud src="https://experimental-connection.streamlit.app/Build_your_own?embed=true" />
+<Cloud name="experimental-connection" path="Build_your_own" />
 
 The typical steps are:
 

--- a/content/develop/concepts/connections/connecting-to-data.md
+++ b/content/develop/concepts/connections/connecting-to-data.md
@@ -36,7 +36,7 @@ Community Cloud apps do not guarantee the persistence of local file storage, so 
 
 To see the example below running live, check out the interactive demo below:
 
-<Cloud name="experimental-connection" path="SQL" />
+<Cloud name="experimental-connection" path="SQL" height="600px" />
 
 #### Step 1: Install prerequisite library - SQLAlchemy
 
@@ -202,7 +202,7 @@ Maintaining a tailored internal Connection implementation across many apps can b
 
 Check out the [Build your own Connection page](https://experimental-connection.streamlit.app/Build_your_own) in the st.experimental connection demo app below for a quick tutorial and working implementation. This demo builds a minimal but very functional Connection on top of DuckDB.
 
-<Cloud name="experimental-connection" path="Build_your_own" />
+<Cloud name="experimental-connection" path="Build_your_own" height="600px" />
 
 The typical steps are:
 

--- a/content/develop/tutorials/execution-flow/fragments/create-a-multiple-container-fragment.md
+++ b/content/develop/tutorials/execution-flow/fragments/create-a-multiple-container-fragment.md
@@ -89,7 +89,7 @@ with st.sidebar:
 
 </Collapse>
 
-<Cloud src="https://doc-tutorial-fragment-multiple-container.streamlit.app/?embed=true" height="650" />
+<Cloud name="doc-tutorial-fragment-multiple-container" height="650px" />
 
 ## Build the example
 

--- a/content/develop/tutorials/execution-flow/fragments/start-and-stop-fragment-auto-reruns.md
+++ b/content/develop/tutorials/execution-flow/fragments/start-and-stop-fragment-auto-reruns.md
@@ -92,7 +92,7 @@ show_latest_data()
 
 </Collapse>
 
-<Cloud src="https://doc-tutorial-fragment-streaming.streamlit.app/?embed=true" height="550" />
+<Cloud name="doc-tutorial-fragment-streaming" height="550px" />
 
 ## Build the example
 

--- a/content/develop/tutorials/llms/conversational-apps.md
+++ b/content/develop/tutorials/llms/conversational-apps.md
@@ -17,7 +17,7 @@ In this tutorial, we'll start by walking through Streamlit's chat elements, `st.
 
 Here's a sneak peek of the LLM-powered chatbot GUI with streaming we'll build in this tutorial:
 
-<Cloud src="https://doc-chat-llm.streamlit.app/?embed=true" height="700px" />
+<Cloud name="doc-chat-llm" height="700px" />
 
 Play around with the above demo to get a feel for what we'll build in this tutorial. A few things to note:
 
@@ -66,7 +66,7 @@ with st.chat_message("assistant"):
     st.bar_chart(np.random.randn(30, 3))
 ```
 
-<Cloud src="https://doc-chat-message-user1.streamlit.app/?embed=true" height="450px" />
+<Cloud name="doc-chat-message-user1" height="450px" />
 
 While we've used the preferred `with` notation in the above examples, you can also just call methods directly in the returned objects. The below example is equivalent to the one above:
 
@@ -93,7 +93,7 @@ if prompt:
     st.write(f"User has sent the following prompt: {prompt}")
 ```
 
-<Cloud src="https://doc-chat-input.streamlit.app/?embed=true" height="350px" />
+<Cloud name="doc-chat-input" height="350px" />
 
 Pretty straightforward, right? Now let's combine `st.chat_message` and `st.chat_input` to build a bot the mirrors or echoes your input.
 
@@ -184,7 +184,7 @@ if prompt := st.chat_input("What is up?"):
 
 </Collapse>
 
-<Cloud src="https://doc-chat-echo.streamlit.app/?embed=true" height="700px" />
+<Cloud name="doc-chat-echo" height="700px" />
 
 While the above example is very simple, it's a good starting point for building more complex conversational apps. Notice how the bot responds instantly to your input. In the next section, we'll add a delay to simulate the bot "thinking" before responding.
 
@@ -304,7 +304,7 @@ if prompt := st.chat_input("What is up?"):
 
 </Collapse>
 
-<Cloud src="https://doc-chat-simple.streamlit.app/?embed=true" height="700px" />
+<Cloud name="doc-chat-simple" height="700px" />
 
 Play around with the above demo to get a feel for what we've built. It's a very simple chatbot GUI, but it has all the components of a more sophisticated chatbot. In the next section, we'll see how to build a ChatGPT-like app using OpenAI.
 
@@ -427,7 +427,7 @@ if prompt := st.chat_input("What is up?"):
 
 </Collapse>
 
-<Cloud src="https://doc-chat-llm.streamlit.app/?embed=true" height="700px" />
+<Cloud name="doc-chat-llm" height="700px" />
 
 Congratulations! You've built your own ChatGPT-like app in less than 50 lines of code.
 

--- a/content/develop/tutorials/llms/llm-quickstart.md
+++ b/content/develop/tutorials/llms/llm-quickstart.md
@@ -11,7 +11,7 @@ In this tutorial, you will build a Streamlit LLM app that can generate text from
 
 _This tutorial is adapted from a blog post by Chanin Nantesanamat: [LangChain tutorial #1: Build an LLM-powered app in 18 lines of code](https://blog.streamlit.io/langchain-tutorial-1-build-an-llm-powered-app-in-18-lines-of-code/)._
 
-<Cloud src="https://doc-tutorial-llm-18-lines-of-code.streamlit.app/?embed=true" height="600" />
+<Cloud name="doc-tutorial-llm-18-lines-of-code" height="600px" />
 
 ## Objectives
 

--- a/content/develop/tutorials/multipage-apps/custom-navigation.md
+++ b/content/develop/tutorials/multipage-apps/custom-navigation.md
@@ -30,7 +30,7 @@ your-repository/
 
 Here's a look at what we'll build:
 
-<Cloud src="https://doc-custom-navigation.streamlit.app/?embed=true" height="400" />
+<Cloud name="doc-custom-navigation" height="400px" />
 
 ## Build the example
 

--- a/content/get-started/fundamentals/tutorials/create-a-multi-page-app.md
+++ b/content/get-started/fundamentals/tutorials/create-a-multi-page-app.md
@@ -254,7 +254,7 @@ page_names_to_funcs[demo_name]()
 
 </details>
 
-<Cloud src="https://doc-hello.streamlit.app/?embed=true" height="700" />
+<Cloud name="doc-hello" height="700px" />
 
 Notice how large the file is! Each app “page" is written as a function, and the selectbox is used to pick which page to display. As our app grows, maintaining the code requires a lot of additional overhead. Moreover, we’re limited by the `st.selectbox` UI to choose which “page" to run, we cannot customize individual page titles with `st.set_page_config`, and we’re unable to navigate between pages using URLs.
 
@@ -559,7 +559,7 @@ streamlit run Hello.py
 
 That’s it! The `Hello.py` script now corresponds to the main page of your app, and other scripts that Streamlit finds in the pages folder will also be present in the new page selector that appears in the sidebar.
 
-<Cloud src="https://doc-mpa-hello.streamlit.app/?embed=true" height="700" />
+<Cloud name="doc-mpa-hello" height="700px" />
 
 ## Next steps
 

--- a/content/get-started/installation/command-line.md
+++ b/content/get-started/installation/command-line.md
@@ -98,7 +98,7 @@ computer is properly set up. More specifically, you’ll need:
    ```
 
 8. Streamlit's Hello app should appear in a new tab in your web browser!
-   <Cloud src="https://doc-mpa-hello.streamlit.app/?embed=true" height="700" />
+   <Cloud name="doc-mpa-hello" height="700px" />
 9. Close your terminal when you are done.
 
 ## Create a "Hello World" app and run it

--- a/python/stoutput.py
+++ b/python/stoutput.py
@@ -13,6 +13,13 @@ class StOutput(Directive):
        URL
        STYLE
 
+    And it outputs something like:
+
+        <Cloud name="SUBDOMAIN" path="SUBPATH" query="QUERYPARAMS" stylePlaceholder="STYLE" />
+
+    ...where every attribute is guaranteed to be present (even when empty) and there's always
+    exactly one space before/after each attribute.
+
     Parameters
     ----------
         URL
@@ -26,9 +33,13 @@ class StOutput(Directive):
     .. output::
        https://foo.bar.baz
 
+       <Cloud name="foo" path="" query="" stylePlaceholder="" />
+
     .. output::
        https://foo.bar.baz/bleep/bloop?plim=plom
        height: 5rem; border: 1px solid red;
+
+       <Cloud name="foo" path="bleep/bloop" query="plim=plom" stylePlaceholder="height: 5rem; border: 1px solid red;" />
     """
 
     has_content = True
@@ -46,14 +57,21 @@ class StOutput(Directive):
             additional_styles = self.arguments[1]
         else:
             additional_styles = ""
-        name, path, query = re.findall(r'https:\/\/([^\/\s]+)\.streamlit\.app\/?([^?\s]+)?\??([\S]+)?', src)[0]
+        name, path, query = re.findall(
+            r'https:\/\/([^\/\s]+)\.streamlit\.app\/?([^?\s]+)?\??([\S]+)?', src)[0]
 
         if name=="":
             raise ValueError(
                 f"Custom subdomain was not recognized.\n--> Culprit: {src}"
             )
 
-        component = f"""<Cloud name="{name}" path="{path}" query="{query}" stylePlaceholder="{additional_styles}" />"""
+        component = (
+            '<Cloud'
+            f' name="{name}"'
+            f' path="{path}"'
+            f' query="{query}"'
+            f' stylePlaceholder="{additional_styles}"'
+            ' />')
 
         node = nodes.raw(
             format="html",

--- a/python/stoutput.py
+++ b/python/stoutput.py
@@ -2,24 +2,33 @@
 """
 from docutils import nodes
 from docutils.parsers.rst import Directive
-
+import re
 
 class StOutput(Directive):
-    """Insert Streamlit app into HTML doc.
+    """Convert the ".. output" directive into a <Cloud> component.
 
-    The first argument is a URL to be iframed, and the second argument
-    (optional) is a string of inline styles to assign to the iframe.
+    The ".. output::" directive looks like this:
+
+    .. output::
+       URL
+       STYLE
+
+    Parameters
+    ----------
+        URL
+            The full path of the Streamlit app to embed, including protocol.
+        STYLE (optional)
+            A string of inline styles.
 
     Examples
     --------
 
-        .. output::
-        https://static.streamlit.io/0.25.0-2EdmD/index.html?id=jD8gaXYmw8WZeSNQbko9p
+    .. output::
+       https://foo.bar.baz
 
-        .. output::
-        https://static.streamlit.io/0.25.0-2EdmD/index.html?id=jD8gaXYmw8WZeSNQbko9p
-        height: 5rem; border: 1px solid red;
-
+    .. output::
+       https://foo.bar.baz/bleep/bloop?plim=plom
+       height: 5rem; border: 1px solid red;
     """
 
     has_content = True
@@ -29,35 +38,29 @@ class StOutput(Directive):
 
     def run(self):
         src = self.arguments[0]
-
         if not src.startswith("https://"):
             raise ValueError(
-                "Iframed URLs in docs should be HTTPS!\n" "--> Culprit: %s" % src
+                f"Please use HTTPS in '.. output::' directives\n--> Culprit: {src}"
             )
-
         if len(self.arguments) > 1:
             additional_styles = self.arguments[1]
         else:
-            additional_styles = "height: 10rem;"
+            additional_styles = ""
+        name, path, query = re.findall(r'https:\/\/([^\/\s]+)\.streamlit\.app\/?([^?\s]+)?\??([\S]+)?', src)[0]
+
+        if name=="":
+            raise ValueError(
+                f"Custom subdomain was not recognized.\n--> Culprit: {src}"
+            )
+
+        component = f"""<Cloud name="{name}" path="{path}" query="{query}" stylePlaceholder="{additional_styles}" />"""
 
         node = nodes.raw(
-            rawsource="",
             format="html",
-            text="""
-                <iframe
-                    loading="lazy"
-                    src="%(src)s?embed=true"
-                    style="
-                        width: 100%%;
-                        border: none;
-                        margin-bottom: 1rem;
-                        %(additional_styles)s
-                    "
-                    allow="camera;clipboard-read;clipboard-write;"
-                ></iframe>
-            """
-            % {"src": src, "additional_styles": additional_styles},
+            text=component,
+            rawsource=component
         )
+
         return [node]
 
 


### PR DESCRIPTION
## 📚 Context
This is a variation/alternative to #1059 

## 🧠 Description of Changes
This implements the same underlying correction as #1059. However, instead of pushing the raw text of the output directive into streamlit.json, this instead pushes the React code `<Cloud ... />` into the "example" sections of streamlit.json. Within `<Table>`, the component is parsed and rendered with a slightly more human-friendly regex expression to pick out each embedded app.

This makes an easier template to follow if we desire other directives to produce React components (as would be particularly nice for SiS exceptions and version-preserving links in the future).

This PR updates all existing embedded apps in docstrings to `<Cloud ... />` so older versions are styled consistently. The remainder of the older docstrings are preserved so no source links are broken and no newer information has bled into older versions.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
