### PR TITLE
Fix typo in secrets-management.md

### DIFF
--- a/content/deploy/community-cloud/deploy-your-app/secrets-management.md
+++ b/content/deploy/community-cloud/deploy-your-app/secrets-management.md
@@ -15,7 +15,7 @@ Secrets management allows you to store secrets securely and access them in your 
 
 ### Deploy an app and set up secrets
 
-1. From your worksapce at <a href="https://share.streamlit.io" target="_blank">share.streamlit.io</a>, click "**New app**".
+1. From your workspace at <a href="https://share.streamlit.io" target="_blank">share.streamlit.io</a>, click "**New app**".
 2. Fill out your app's information and click "**Advanced settings...**"
 
    ![Access advanced settings when deploying your app](/images/streamlit-community-cloud/deploy-an-app-advanced-settings.png)


### PR DESCRIPTION
Fixes #1060: spelling error on page (`worksapce` -> `workspace`)

## 📚 Context

<!-- Why do you want to make this change? What background should the reviewer know? -->
Very small (non-breaking) typo

## 🧠 Description of Changes

<!-- What was specifically changed? Which files, algorithms, links, media? -->
<!-- Please add them here as a bulleted list -->
- Fixes typo `docs/content/deploy/community-cloud/deploy-your-app/secrets-management.md`: `worksapce` -> `workspace`


## 💥 Impact

Closes #1060 

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
