### PR TITLE
Update trigger-a-full-script-rerun-from-a-fragment.md

### DIFF
--- a/content/develop/tutorials/execution-flow/fragments/trigger-a-full-script-rerun-from-a-fragment.md
+++ b/content/develop/tutorials/execution-flow/fragments/trigger-a-full-script-rerun-from-a-fragment.md
@@ -5,7 +5,7 @@ slug: /develop/tutorials/execution-flow/trigger-a-full-script-rerun-from-a-fragm
 
 # Trigger a full-script rerun from inside a fragment
 
-Streamlit lets you turn functions into [fragments](/develop/concepts/architecture/fragments), which can rerun independently from the full script. When a user interacts with a widget inside a fragment, only the fragment ruruns. Sometimes, you may want to trigger a full-script rerun from inside a fragment. To do this, call [`st.rerun`](/develop/api-reference/execution-flow/st.rerun) inside the fragment.
+Streamlit lets you turn functions into [fragments](/develop/concepts/architecture/fragments), which can rerun independently from the full script. When a user interacts with a widget inside a fragment, only the fragment reruns. Sometimes, you may want to trigger a full-script rerun from inside a fragment. To do this, call [`st.rerun`](/develop/api-reference/execution-flow/st.rerun) inside the fragment.
 
 ## Applied concepts
 


### PR DESCRIPTION
Fixes #1066: spelling `ruruns` -> `reruns`

## 📚 Context

<!-- Why do you want to make this change? What background should the reviewer know? -->
Very small (non-breaking) typo

## 🧠 Description of Changes

<!-- What was specifically changed? Which files, algorithms, links, media? -->
<!-- Please add them here as a bulleted list -->
- Fixes typo `docs/content/develop/tutorials/execution-flow/fragments/trigger-a-full-script-rerun-from-a-fragment.md`: `ruruns` -> `reruns`


## 💥 Impact

Closes #1060 

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
