### PR TITLE
Add title to dialog examples

### DIFF
--- a/content/develop/api-reference/_index.md
+++ b/content/develop/api-reference/_index.md
@@ -1403,7 +1403,7 @@ Insert a modal dialog that can rerun independently from the rest of the script.
 
 ```python
 @st.experimental_dialog("Sign up")
-def email_form("Sign up"):
+def email_form():
     name = st.text_input("Name")
     email = st.text_input("Email")
 ```

--- a/content/develop/api-reference/_index.md
+++ b/content/develop/api-reference/_index.md
@@ -1402,8 +1402,8 @@ c.write("This will show second")
 Insert a modal dialog that can rerun independently from the rest of the script.
 
 ```python
-@st.experimental_dialog()
-def email_form():
+@st.experimental_dialog("Sign up")
+def email_form("Sign up"):
     name = st.text_input("Name")
     email = st.text_input("Email")
 ```
@@ -1875,7 +1875,7 @@ st.page_link("pages/profile.py", label="My profile")
 Insert a modal dialog that can rerun independently from the rest of the script.
 
 ```python
-@st.experimental_dialog()
+@st.experimental_dialog("Sign up")
 def email_form():
     name = st.text_input("Name")
     email = st.text_input("Email")

--- a/content/develop/api-reference/control-flow/_index.md
+++ b/content/develop/api-reference/control-flow/_index.md
@@ -20,7 +20,7 @@ By default, Streamlit apps execute the script entirely, but we allow some functi
 Insert a modal dialog that can rerun independently from the rest of the script.
 
 ```python
-@st.experimental_dialog()
+@st.experimental_dialog("Sign up")
 def email_form():
     name = st.text_input("Name")
     email = st.text_input("Email")

--- a/content/develop/quick-references/api-cheat-sheet.md
+++ b/content/develop/quick-references/api-cheat-sheet.md
@@ -232,7 +232,7 @@ st.switch_page("pages/my_page.py")
 >>>   st.form_submit_button("Login")
 
 # Define a dialog function
->>> @st.experimental_dialog
+>>> @st.experimental_dialog("Welcome!")
 >>> def modal_dialog():
 >>>     st.write("Hello")
 >>>


### PR DESCRIPTION
## 📚 Context
The PR adds a `title` argument to the `st.experimental_dialog` examples since its a required parameter.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
