### PR TITLE
Add path from root for logo example

### DIFF
--- a/python/api-examples-source/media.logo.py
+++ b/python/api-examples-source/media.logo.py
@@ -9,5 +9,8 @@ options = [HORIZONTAL_RED, ICON_RED, HORIZONTAL_BLUE, ICON_BLUE]
 sidebar_logo = st.selectbox("Sidebar logo", options, 0)
 main_body_logo = st.selectbox("Main body logo", options, 1)
 
-st.logo(sidebar_logo, icon_image=main_body_logo)
+st.logo(
+    f"python/api-examples-source/{sidebar_logo}",
+    icon_image=f"python/api-examples-source/{main_body_logo}",
+)
 st.sidebar.markdown("Hi!")


### PR DESCRIPTION
## 📚 Context
Since Community Cloud initializes apps from the root of the repository, the embedded example for `st.logo` needs a path prefix. The PR adds it to the example.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
