### PR TITLE
Add selection highlight to Vega-Altair example; Use selection output

### DIFF
--- a/python/api-examples-source/charts.altair_selections.py
+++ b/python/api-examples-source/charts.altair_selections.py
@@ -27,6 +27,6 @@ chart = (
     .add_params(point_selector, interval_selector)
 )
 
-st.altair_chart(chart, key="alt_chart", on_select="rerun")
+event = st.altair_chart(chart, key="alt_chart", on_select="rerun")
 
-st.session_state.alt_chart
+event

--- a/python/api-examples-source/charts.altair_selections.py
+++ b/python/api-examples-source/charts.altair_selections.py
@@ -11,14 +11,20 @@ def load_data():
 
 df = load_data()
 
+point_selector = alt.selection_point("point_selection")
+interval_selector = alt.selection_interval("interval_selection")
 chart = (
     alt.Chart(df)
     .mark_circle()
-    .encode(x="a", y="b", size="c", color="c", tooltip=["a", "b", "c"])
-    .add_params(
-        alt.selection_interval("interval_selection"),
-        alt.selection_point("point_selection"),
+    .encode(
+        x="a",
+        y="b",
+        size="c",
+        color="c",
+        tooltip=["a", "b", "c"],
+        fillOpacity=alt.condition(point_selector, alt.value(1), alt.value(0.3)),
     )
+    .add_params(point_selector, interval_selector)
 )
 
 st.altair_chart(chart, key="alt_chart", on_select="rerun")

--- a/python/api-examples-source/charts.plotly_chart_event_state.py
+++ b/python/api-examples-source/charts.plotly_chart_event_state.py
@@ -4,6 +4,6 @@ import plotly.express as px
 df = px.data.iris()  # iris is a pandas DataFrame
 fig = px.scatter(df, x="sepal_width", y="sepal_length")
 
-st.plotly_chart(fig, key="iris", on_select="rerun")
+event = st.plotly_chart(fig, key="iris", on_select="rerun")
 
-st.session_state.iris
+event

--- a/python/api-examples-source/charts.plotly_chart_event_state_selections.py
+++ b/python/api-examples-source/charts.plotly_chart_event_state_selections.py
@@ -11,6 +11,6 @@ fig = px.scatter(
     hover_data=["petal_width"],
 )
 
-st.plotly_chart(fig, key="iris", on_select="rerun")
+event = st.plotly_chart(fig, key="iris", on_select="rerun")
 
-st.session_state.iris.selection
+event.selection

--- a/python/api-examples-source/data.dataframe_event_state_selections.py
+++ b/python/api-examples-source/data.dataframe_event_state_selections.py
@@ -10,11 +10,11 @@ def load_data():
 
 df = load_data()
 
-st.dataframe(
+event = st.dataframe(
     df,
     key="data",
     on_select="rerun",
     selection_mode=["multi-row", "multi-column"],
 )
 
-st.session_state.data.selection
+event.selection


### PR DESCRIPTION
## 📚 Context
Point selections are not visually apparent in Vega-Altair. This PR adds a selection highlight to the chart selections example for `st.vega_lite_chart` and `st.altair_chart`. The chart and dataframe selection examples were also switched to use the function output instead of Session State.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
