### PR TITLE
Customize Autofunction handling of AttributeDict

### DIFF
--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -469,29 +469,31 @@ const Autofunction = ({
 
   body = (
     <Table
-      head={{
-        title: (
-          <>
-            {isAttributeDict
-              ? "Dictionary schema"
-              : isClass
-                ? "Class description"
-                : "Function signature"}
-            <a
-              className={styles.Title.a}
-              href={functionObject.source}
-              target="_blank"
-              rel="noopener noreferrer"
-              title={
-                "View st." + functionObject.name + " source code on GitHub"
-              }
-            >
-              [source]
-            </a>
-          </>
-        ),
-        content: `<p class='code'> ${functionObject.signature}</p> `,
-      }}
+      head={
+        isAttributeDict
+          ? ""
+          : {
+              title: (
+                <>
+                  {isClass ? "Class description" : "Function signature"}
+                  <a
+                    className={styles.Title.a}
+                    href={functionObject.source}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title={
+                      "View st." +
+                      functionObject.name +
+                      " source code on GitHub"
+                    }
+                  >
+                    [source]
+                  </a>
+                </>
+              ),
+              content: `<p class='code'> ${functionObject.signature}</p> `,
+            }
+      }
       body={args.length ? { title: "Parameters" } : null}
       bodyRows={args.length ? args : null}
       foot={[

--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useRef } from "react";
 import reverse from "lodash/reverse";
 import classNames from "classnames";
 import Table from "./table";
-import { H2 } from "./headers";
+import { H2, H3 } from "./headers";
 import Warning from "./warning";
 import Deprecation from "./deprecation";
 import { withRouter, useRouter } from "next/router";
@@ -167,8 +167,10 @@ const Autofunction = ({
   let functionObject;
   let functionDescription;
   let header;
+  let headerTitle;
   let body;
   let isClass;
+  let isAttributeDict;
   let methods = [];
   let properties = [];
 
@@ -176,6 +178,7 @@ const Autofunction = ({
     functionObject =
       streamlit[streamlitFunction] ?? streamlit[oldStreamlitFunction];
     isClass = functionObject.is_class;
+    isAttributeDict = functionObject.is_attribute_dict ?? false;
     if (
       functionObject.description !== undefined &&
       functionObject.description
@@ -238,6 +241,31 @@ const Autofunction = ({
     const name = functionObject.signature
       ? `${functionObject.signature}`.split("(")[0].replace("streamlit", "st")
       : "";
+    headerTitle = isAttributeDict ? (
+      <H3 className={styles.Title}>
+        <a
+          aria-hidden="true"
+          tabIndex="-1"
+          href={`#${cleanHref(name)}`.toLowerCase()}
+          className="absolute"
+        >
+          <span className="icon icon-link"></span>
+        </a>
+        {name}
+      </H3>
+    ) : (
+      <H2 className={styles.Title}>
+        <a
+          aria-hidden="true"
+          tabIndex="-1"
+          href={`#${cleanHref(name)}`.toLowerCase()}
+          className="absolute"
+        >
+          <span className="icon icon-link"></span>
+        </a>
+        {name}
+      </H2>
+    );
     header = (
       <div className={styles.HeaderContainer}>
         <div
@@ -246,17 +274,7 @@ const Autofunction = ({
             relative
           `}
         >
-          <H2 className={styles.Title}>
-            <a
-              aria-hidden="true"
-              tabIndex="-1"
-              href={`#${cleanHref(name)}`.toLowerCase()}
-              className="absolute"
-            >
-              <span className="icon icon-link"></span>
-            </a>
-            {name}
-          </H2>
+          {headerTitle}
           <VersionSelector
             versionList={versionList}
             currentVersion={currentVersion}
@@ -454,7 +472,11 @@ const Autofunction = ({
       head={{
         title: (
           <>
-            {isClass ? "Class description" : "Function signature"}
+            {isAttributeDict
+              ? "Dictionary schema"
+              : isClass
+                ? "Class description"
+                : "Function signature"}
             <a
               className={styles.Title.a}
               href={functionObject.source}

--- a/components/blocks/autofunction.module.css
+++ b/components/blocks/autofunction.module.css
@@ -11,7 +11,7 @@
 }
 
 .Title {
-  @apply mt-6 mb-2 text-4xl;
+  @apply mt-6 mb-2;
 }
 
 .Form {


### PR DESCRIPTION
## 📚 Context
Release 1.35.0 introduces selections for dataframes and charts. The event state is returned as a customized dictionary-like object, `AttributeDict`. There are additional classes within the library which define the specific key-value pairs (attributes) that each element will return. Although they are "classes" officially, they are more like schemas and aren't ever returned directly to the user; they become `AttributeDict` objects at runtime.

This PR introduces special handling within Autofunction for these classes which are flagged as `AttributeDict` schemas. The title for the class is reduced in size (from H2 for stand classes and methods, to H3 for these schemas). Also, "Class description" is hidden and only the "Attributes" section is shown.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
