### PR TITLE
Add get_option, set_option

### DIFF
--- a/content/develop/api-reference/_index.md
+++ b/content/develop/api-reference/_index.md
@@ -2347,6 +2347,28 @@ your-project/
 ```
 
 </RefCard>
+<RefCard href="/develop/api-reference/configuration/st.get_option">
+
+<h4>Get config option</h4>
+
+Retrieve a single configuration option.
+
+```python
+st.get_option("theme.primaryColor")
+```
+
+</RefCard>
+<RefCard href="/develop/api-reference/configuration/st.set_option">
+
+<h4>Set config option</h4>
+
+Set a single configuration option. (This is very limited.)
+
+```python
+st.set_option("deprecation.showPyplotGlobalUse", False)
+```
+
+</RefCard>
 <RefCard href="/develop/api-reference/configuration/st.set_page_config">
 
 <h4>Set page title, favicon, and more</h4>

--- a/content/develop/api-reference/configuration/_index.md
+++ b/content/develop/api-reference/configuration/_index.md
@@ -20,6 +20,28 @@ your-project/
 ```
 
 </RefCard>
+<RefCard href="/develop/api-reference/configuration/st.get_option">
+
+<h4>Get config option</h4>
+
+Retrieve a single configuration option.
+
+```python
+st.get_option("theme.primaryColor")
+```
+
+</RefCard>
+<RefCard href="/develop/api-reference/configuration/st.set_option">
+
+<h4>Set config option</h4>
+
+Set a single configuration option. (This is very limited.)
+
+```python
+st.set_option("deprecation.showPyplotGlobalUse", False)
+```
+
+</RefCard>
 <RefCard href="/develop/api-reference/configuration/st.set_page_config">
 
 <h4>Set page title, favicon, and more</h4>

--- a/content/develop/api-reference/configuration/get_option.md
+++ b/content/develop/api-reference/configuration/get_option.md
@@ -1,0 +1,7 @@
+---
+title: st.get_option
+slug: /develop/api-reference/configuration/st.get_option
+description: st.get_option retrieves a single configuration option.
+---
+
+<Autofunction function="streamlit.get_option" />

--- a/content/develop/api-reference/configuration/set_option.md
+++ b/content/develop/api-reference/configuration/set_option.md
@@ -1,0 +1,7 @@
+---
+title: st.set_option
+slug: /develop/api-reference/configuration/st.set_option
+description: st.set_option updates a single configuration option.
+---
+
+<Autofunction function="streamlit.set_option" />

--- a/content/menu.md
+++ b/content/menu.md
@@ -583,6 +583,12 @@ site_menu:
   - category: Develop / API reference / Configuration / config.toml
     url: /develop/api-reference/configuration/config.toml
     isVersioned: true
+  - category: Develop / API reference / Configuration / st.get_option
+    url: /develop/api-reference/configuration/st.get_option
+    isVersioned: true
+  - category: Develop / API reference / Configuration / st.set_option
+    url: /develop/api-reference/configuration/st.set_option
+    isVersioned: true
   - category: Develop / API reference / Configuration / st.set_page_config
     url: /develop/api-reference/configuration/st.set_page_config
     isVersioned: true


### PR DESCRIPTION
## 📚 Context
`st.get_option` and `st.set_option` have existed in the library years. Although they were mentioned in the docs and in an error message, they weren't included in the API reference.

## 🧠 Description of Changes
This PR adds these functions to the API reference.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
