### PR TITLE
Fix a small typo in the docs

### DIFF
--- a/content/develop/api-reference/configuration/config-toml.md
+++ b/content/develop/api-reference/configuration/config-toml.md
@@ -42,9 +42,8 @@ streamlit config show
 [global]
 
 # ***DEPRECATED***
-# global.disableWatchdogWarning has been deprecated has been deprecated and
-# will be removed in a future version. This option will be removed on or after
-# 2024-01-20.
+# global.disableWatchdogWarning has been deprecated and will be removed in a
+# future version. This option will be removed on or after 2024-01-20.
 # ****************
 # By default, Streamlit checks if the Python watchdog module is available
 # and, if not, prints a warning asking for you to install it. The watchdog


### PR DESCRIPTION
## 📚 Context

The phrase "has been deprecated" was accidentally repeated twice in the comment for `disableWatchdogWarning`.

## 🧠 Description of Changes

* Fixed the wording for the comment and reformatted it.

## 💥 Impact

Minor.

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
