### PR TITLE
Fix regex string literals to be raw strings which solves Syntax Error about the backslash escape character

### DIFF
--- a/python/api-examples-source/data.column_config.py
+++ b/python/api-examples-source/data.column_config.py
@@ -91,7 +91,7 @@ column_configuration = {
     "email": st.column_config.TextColumn(
         "Email",
         help="The user's email address",
-        validate="^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$",
+        validate=r"^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$",
     ),
 }
 

--- a/python/api-examples-source/data.link_column.py
+++ b/python/api-examples-source/data.link_column.py
@@ -24,9 +24,9 @@ st.data_editor(
         "apps": st.column_config.LinkColumn(
             "Trending apps",
             help="The top trending Streamlit apps",
-            validate="^https://[a-z]+\.streamlit\.app$",
+            validate=r"^https://[a-z]+\.streamlit\.app$",
             max_chars=100,
-            display_text="https://(.*?)\.streamlit\.app",
+            display_text=r"https://(.*?)\.streamlit\.app",
         ),
         "creator": st.column_config.LinkColumn(
             "App Creator", display_text="Open profile"

--- a/python/api-examples-source/data.text_column.py
+++ b/python/api-examples-source/data.text_column.py
@@ -21,7 +21,7 @@ st.data_editor(
             help="Streamlit **widget** commands 🎈",
             default="st.",
             max_chars=50,
-            validate="^st\.[a-z_]+$",
+            validate=r"^st\.[a-z_]+$",
         )
     },
     hide_index=True,


### PR DESCRIPTION
## 📚 Context

Fixes the following error.

```shell
 ❯ streamlit run data.text_column.py

  You can now view your Streamlit app in your browser.

  Local URL: http://localhost:8501
  Network URL: http://192.168.68.104:8501

  For better performance, install the Watchdog module:

  $ xcode-select --install
  $ pip install watchdog

/workspace/streamlit/docs/python/api-examples-source/data.text_column.py:24: SyntaxWarning: invalid escape sequence '\.'
  validate="^st\.[a-z_]+$",

```

## 🧠 Description of Changes

<!-- What was specifically changed? Which files, algorithms, links, media? -->
<!-- Please add them here as a bulleted list -->

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
