### PR TITLE
Add optional border for Image component

### DIFF
--- a/components/blocks/image.js
+++ b/components/blocks/image.js
@@ -3,7 +3,7 @@ import classNames from "classnames";
 
 import styles from "./image.module.css";
 
-const Image = ({ caption, pure, src, alt, clean }) => {
+const Image = ({ caption, pure, src, alt, clean, frame }) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const openModal = () => {
@@ -13,6 +13,8 @@ const Image = ({ caption, pure, src, alt, clean }) => {
   const closeModal = () => {
     setIsOpen(false);
   };
+
+  const borderStyle = frame ? styles.ImageBorder : "";
 
   useEffect(() => {
     const handleEsc = (event) => {
@@ -46,7 +48,7 @@ const Image = ({ caption, pure, src, alt, clean }) => {
             onClick={openModal}
             src={src}
             alt={alt}
-            className={classNames(captionClass, styles.Image)}
+            className={classNames(captionClass, styles.Image, borderStyle)}
           />
           {customCaption}
         </section>
@@ -78,7 +80,7 @@ const Image = ({ caption, pure, src, alt, clean }) => {
         <section className={styles.InnerContainer}>
           <img
             onClick={openModal}
-            className={classNames(captionClass, styles.Image)}
+            className={classNames(captionClass, styles.Image, borderStyle)}
             src={src}
             alt={alt}
           />

--- a/components/blocks/image.module.css
+++ b/components/blocks/image.module.css
@@ -14,6 +14,14 @@
   @apply max-w-full max-h-screen transition duration-100 ease-in-out hover:opacity-80 cursor-pointer;
 }
 
+.ImageBorder {
+  @apply border-solid border border-gray-90;
+}
+
+:global(.dark) .ImageBorder {
+  @apply border-gray-20;
+}
+
 .Caption {
   @apply italic text-gray-90 pt-2 md:pt-4 text-sm tracking-tight;
 }


### PR DESCRIPTION
## 📚 Context
Some images blend in with the background (either in light mode or dark mode, depending on the image). A thin border to contrast with the background behind the image can help.

## 🧠 Description of Changes
This PR adds an optional flag `frame` to the `Image` component. (`border` is a reserved word). When activated, a thin dark border is added around an image in light mode, and a thin light border is added around an image in dark mode. (The border color matches the background color in the opposite mode.)

New:
<img width="1044" alt="image" src="https://github.com/streamlit/docs/assets/135349133/306bb683-ee41-43e4-bef1-24e94574d9a1">
(Border not strictly needed for this particular darkmode image, but shown here for reference)
<img width="959" alt="image" src="https://github.com/streamlit/docs/assets/135349133/0021bbce-558a-4d66-adf6-011b4c2f8c6f">


Previous:
<img width="1048" alt="image" src="https://github.com/streamlit/docs/assets/135349133/a133ebfd-d5c2-4bdf-b0e2-4e96073997c2">
<img width="976" alt="image" src="https://github.com/streamlit/docs/assets/135349133/c78cd9b4-e23d-4557-b799-4bd233d24eb9">


## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [ ] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
