### PR TITLE
Autofunction: Let class docstring override @property functions

### DIFF
--- a/components/blocks/autofunction.js
+++ b/components/blocks/autofunction.js
@@ -312,15 +312,15 @@ const Autofunction = ({
     footers.push({ title: "Warning", body: functionObject.warning });
   }
 
-  // propertiesRows is initialized early to allow "Parameters" in any class
-  // docstring to be diverted to the properties section. Docstring parsing
-  // needs modification to first recognize "Attributes" or "Properites" then
-  // parse their contents.
+  // propertiesRows is initialized early to allow Attributes (recorded as args)
+  // in any class docstring to be diverted to the properties section.
   let propertiesRows = [];
+  let docstringProperties = []; // Used to avoid duplicates with @property
 
   for (const index in functionObject.args) {
     const row = {};
     const param = functionObject.args[index];
+    docstringProperties.push(param.name);
     const isDeprecated =
       param.deprecated && param.deprecated.deprecated === true;
     const deprecatedMarkup = isDeprecated
@@ -420,6 +420,10 @@ const Autofunction = ({
   for (const index in properties) {
     const row = {};
     const property = properties[index];
+    // If attribute is in class docstring don't also show the same @property.
+    if (docstringProperties.includes(property.name)) {
+      continue;
+    }
     const slicedSlug = slug.slice().join("/");
     const hrefName = `${functionObject.name}.${property.name}`
       .toLowerCase()


### PR DESCRIPTION
## 📚 Context
When the docstring parser creates the dictionary for a class in streamlit.json, @property-decorated functions get saved under the "property" key. Any "Attributes" in the docstring get saved under the "args" key. When Autofunction renders a class, the "properties" and "args" are combined under the "Attribute" header. Up until now, a class attribute was not recorded in "Attributes" if it existed as an @property-decorated method, to avoid duplicates.

This PR is needed to better support the StreamlitPage class for 1.36.0.

## 🧠 Description of Changes
This PR includes a check for duplicate attributes for classes. If an attribute exists in both the docstring "Attributes" list and as a @property-decorated function, Autofunction will only render the attribute from the docstring.

When an @property attribute is rendered, it includes an anchor link, expecting another Autofunction below to render the method. Not all attributes exists as @property-decorated functions that can be picked up automatically, and not all @property-decorated functions need to be fully rendered with their own Autofunction. Therefore, this PR gives the ability to override the automatic detection of @property-decorated methods.

This doesn't impact the current instances where "Attributes" in the docstring supplement the @property-decorated methods. (e.g. AppTest)

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
