### PR TITLE
Update create-a-multiple-container-fragment.md: INDENT FIX

### DIFF
--- a/content/develop/tutorials/execution-flow/fragments/create-a-multiple-container-fragment.md
+++ b/content/develop/tutorials/execution-flow/fragments/create-a-multiple-container-fragment.md
@@ -142,7 +142,7 @@ with st.sidebar:
    def black_cats():
        time.sleep(1)
        st.title("🐈‍⬛ 🐈‍⬛")
-   st.markdown("🐾 🐾 🐾 🐾")
+       st.markdown("🐾 🐾 🐾 🐾")
    ```
 
    This function represents "herding two cats" and uses `time.sleep()` to simulate a slower process. You will use this to draw two cats in one of your grid cards later on.
@@ -153,7 +153,7 @@ with st.sidebar:
    def orange_cats():
        time.sleep(1)
        st.title("🐈 🐈")
-   st.markdown("🐾 🐾 🐾 🐾")
+       st.markdown("🐾 🐾 🐾 🐾")
    ```
 
 1. (Optional) Test out your functions by calling each one within a grid card.


### PR DESCRIPTION
## 📚 Context

This is a slight change, fixing some indent bugs. 

I'm a bit confused when I read the code displayed in https://docs.streamlit.io/develop/tutorials/execution-flow/create-a-multiple-container-fragment#frame-out-your-apps-containers. 

Specifically, the line of `st.markdown("🐾 🐾 🐾 🐾")`, in both functions `black_cats()` and `orange_cats()` (see screenshots (Current) below), seem to miss an indent. This complies with neither my intuition nor [https://docs.streamlit.io/develop/tutorials/execution-flow/create-a-multiple-container-fragment#summary](the full demo code depicted above on this page).

Obviously, the cats and their footprints should be in the same containers and rendered simultaneously. 

## 🧠 Description of Changes

Nothing more than: 

 * add indents to get this bug fixed

**Revised:**

![image](https://github.com/streamlit/docs/assets/113576575/4ac0f56b-2832-471c-81c1-f08c6f3c4de1)

**Current:**

![image](https://github.com/streamlit/docs/assets/113576575/0ae58eb1-e6e1-415e-9067-cfb4661895fb)