### PR TITLE
Fix: Replace deprecated `experimental_memo` reference with `cache_data` in FAQ

### DIFF
--- a/content/kb/FAQ/how-download-pandas-dataframe-csv.md
+++ b/content/kb/FAQ/how-download-pandas-dataframe-csv.md
@@ -15,7 +15,7 @@ import pandas as pd
 
 df = pd.read_csv("dir/file.csv")
 
-@st.experimental_memo
+@st.cache_data
 def convert_df(df):
    return df.to_csv(index=False).encode('utf-8')
 


### PR DESCRIPTION
## 📚 Context

The `experimental_memo` decorator was deprecated in 1.18.0.

## 🧠 Description of Changes

Replace `experimental_memo` reference with `cache_data` in the pandas DataFrame download to CSV FAQ.

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 💥 Impact

Minor fix

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
