### PR TITLE
Fix type in custom_classes.md

### DIFF
--- a/content/develop/concepts/app-design/custom-classes.md
+++ b/content/develop/concepts/app-design/custom-classes.md
@@ -221,7 +221,7 @@ Marshall_C = Student(1, "Marshall")
 Marshall_A == Marshall_C
 ```
 
-In this example, the dataclass `Student` is defined twice. All three Marshalls have the same internal values. If you compare `Marshall_A` and `Marshall_B` they will be equal because they were both created from the first definition of `Student`. However, if you compare `Marshall_A` and `Marshall_C` they will not be equal because `Marshall_C` was created from the _second_ definition of `Student`. Even though both `Student` dataclasses are defined exactly the same, they have differnt in-memory IDs and are therefore different.
+In this example, the dataclass `Student` is defined twice. All three Marshalls have the same internal values. If you compare `Marshall_A` and `Marshall_B` they will be equal because they were both created from the first definition of `Student`. However, if you compare `Marshall_A` and `Marshall_C` they will not be equal because `Marshall_C` was created from the _second_ definition of `Student`. Even though both `Student` dataclasses are defined exactly the same, they have different in-memory IDs and are therefore different.
 
 ### What's happening in Streamlit?
 


### PR DESCRIPTION
## 📚 Context

Fix a small typo: `differnt` to `different`

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
