### PR TITLE
docs: fix Session State Hyperlink URL

### DIFF
--- a/content/develop/concepts/architecture/caching.md
+++ b/content/develop/concepts/architecture/caching.md
@@ -16,7 +16,7 @@ Streamlit runs your script from top to bottom at every user interaction or code 
 1. Long-running functions run again and again, which slows down your app.
 2. Objects get recreated again and again, which makes it hard to persist them across reruns or sessions.
 
-But don't worry! Streamlit lets you tackle both issues with its built-in caching mechanism. Caching stores the results of slow function calls, so they only need to run once. This makes your app much faster and helps with persisting objects across reruns. Cached values are available to all users of your app. If you need to save results that should only be accessible within a session, use [Session State](/develop/concepts/architecture/session-stat) instead.
+But don't worry! Streamlit lets you tackle both issues with its built-in caching mechanism. Caching stores the results of slow function calls, so they only need to run once. This makes your app much faster and helps with persisting objects across reruns. Cached values are available to all users of your app. If you need to save results that should only be accessible within a session, use [Session State](/develop/concepts/architecture/session-state) instead.
 
 <Collapse title="Table of contents" expanded={true}>
 


### PR DESCRIPTION
## 📚 Context

A Hyperlink URL typo in the documentation of Caching

## 🧠 Description of Changes

Just a fix of a hyperlink

**Revised:**

![image](https://github.com/user-attachments/assets/bc27d1fb-66d1-4aec-8aba-4a8b45d5099f)

**Current:**

![image](https://github.com/user-attachments/assets/de03d64a-076d-4fa0-b425-71f733bd4f20)


## 💥 Impact

A small fix :)

Size:

- [X] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
