### PR TITLE
Remove 1.22 from SiS note

### DIFF
--- a/content/get-started/installation/sis.md
+++ b/content/get-started/installation/sis.md
@@ -9,7 +9,7 @@ Snowflake is a single, global platform that powers the Data Cloud. If you want t
 
 <Note>
 
-Streamlit in Snowflake is currently based on Streamlit version 1.22.0 with some [Limitations and unsupported features](https://docs.snowflake.com/en/developer-guide/streamlit/limitations). We are working on supporting newer versions and more features.
+For more information, see [Limitations and unsupported features](https://docs.snowflake.com/en/developer-guide/streamlit/limitations) in the Snowflake documentation.
 
 </Note>
 


### PR DESCRIPTION
## 📚 Context
SiS supports other versions besides 1.22 but the version selector still only shows 1.22.

PR #1115 will update the version selector to show exceptions across all versions, but is waiting on exact function exceptions by version. In the meantime, the note in Get started won't mention a version and just defer to Snowflake docs. This is a tradeoff of confusion that should be resolved in a week or two.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
