### PR TITLE
docs: add link to Koyeb deploy tutorial

### DIFF
--- a/content/deploy/tutorials/_index.md
+++ b/content/deploy/tutorials/_index.md
@@ -41,4 +41,5 @@ While we work on official Streamlit deployment guides for other hosting provider
 - [Host Streamlit on **Heroku**](https://towardsdatascience.com/quickly-build-and-deploy-an-application-with-streamlit-988ca08c7e83), by Maarten Grootendorst.
 - [Deploy Streamlit on **Ploomber Cloud**](https://docs.cloud.ploomber.io/en/latest/apps/streamlit.html), by Ido Michael.
 - [Host Streamlit on **21YunBox**](https://www.21yunbox.com/docs/#/deploy-streamlit), by Toby Lei.
+- [Deploy a Streamlit App on **Koyeb**](https://www.koyeb.com/docs/deploy/streamlit), by Justin Ellingwood.
 - [Community-supported deployment wiki](https://discuss.streamlit.io/t/streamlit-deployment-guide-wiki/5099).


### PR DESCRIPTION
## 📚 Context

<!-- Why do you want to make this change? What background should the reviewer know? -->
Adding Koyeb, a cloud platform, to the list of deployment tutorial links.  The tutorial lives in Koyeb's offiical documentation and covers how to deploy a basic application to the platform using buildpacks or a Dockerfile.

## 🧠 Description of Changes

* Index of the deploy tutorials section to include a link the the relevant guide (`content/deploy/tutorials/_index.md`)
<!-- What was specifically changed? Which files, algorithms, links, media? -->
<!-- Please add them here as a bulleted list -->

**Revised:**

![image](https://github.com/user-attachments/assets/b819860a-ccc3-4483-9655-0aecdb42dac1)

**Current:**

![image](https://github.com/user-attachments/assets/a9391a76-c7ec-4a8f-9e73-2a5f4caa1af7)

## 💥 Impact

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
