### PR TITLE
Fix scroll padding, so headers don't appear behind the top bar when you navigate to a page via an #anchor.

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 html {
-  @apply overflow-x-hidden overflow-y-auto scroll-pt-12;
+  @apply overflow-x-hidden overflow-y-auto scroll-pt-24;
 }
 
 body {


### PR DESCRIPTION
## 📚 Context

When you click navigate to a page like <https://docs.streamlit.io/develop/api-reference/utilities/st.context#contextcookies>, which has a hash pointing to a specific part of the page (`#contextcookies` in this case), that part of the page gets partially obscured by the site's top bar. With this change, this no longer happens.

Compare the above with <https://deploy-preview-1132--streamlit-docs.netlify.app/develop/api-reference/utilities/st.context#contextcookies>! Here you'll the "context cookies" header is visible rather than hidden under the top bar.

## 🧠 Description of Changes

Fix the number used in scroll padding to match what we use for the top bar height.

## 💥 Impact

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

None

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
