### PR TITLE
Allow diff line highlighting for codeblocks

### DIFF
--- a/components/blocks/code.module.css
+++ b/components/blocks/code.module.css
@@ -75,6 +75,13 @@
   @apply inline;
 }
 
+.Pre code :global(.deleted) {
+  @apply text-red-70 bg-red-70 bg-opacity-20;
+}
+.Pre code :global(.inserted) {
+  @apply text-green-70 bg-green-70 bg-opacity-20;
+}
+
 /* Dark mode adjustments */
 :global(.dark) .Pre code :global(.operator),
 :global(.dark) .Pre code :global(.decorator) {


### PR DESCRIPTION
## 📚 Context
Add red and green line highlighting for code blocks with language diff. This is helpful for instructions and tutorials when directing users to make edits.

New:
<img width="910" alt="image" src="https://github.com/user-attachments/assets/f64d6a3f-6c8f-4cd5-ad21-6359f53339d6">

Previous:
<img width="905" alt="image" src="https://github.com/user-attachments/assets/48a74855-5500-4c06-9f55-857f5673d381">

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
