### PR TITLE
Add "enable" toggle to camera_input embedded app

### DIFF
--- a/python/api-examples-source/widget.camera_input.py
+++ b/python/api-examples-source/widget.camera_input.py
@@ -1,6 +1,7 @@
 import streamlit as st
 
-picture = st.camera_input("Take a picture")
+enable = st.checkbox("Enable camera")
+picture = st.camera_input("Take a picture", disabled=not enable)
 
 if picture:
     st.image(picture)


### PR DESCRIPTION
## 📚 Context
`st.camera_input` automatically asks for camera permission when rendered. This PR sets the embedded app for `st.camera_input` to be disabled by default so users don't get prompted from permission on the associated docs page until they get to the example.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
