### PR TITLE
Add support for Important and Tip in docstrings

### DIFF
--- a/styles/admonition.scss
+++ b/styles/admonition.scss
@@ -21,6 +21,24 @@ div.admonition {
     }
   }
 
+  // Tip
+  &.tip {
+    @apply bg-indigo-10 dark:bg-indigo-100;
+
+    p.first.admonition-title {
+      @apply text-indigo-70;
+    }
+  }
+
+  // Important
+  &.important {
+    @apply bg-orange-10 dark:bg-orange-100/30;
+
+    p.first.admonition-title {
+      @apply text-orange-70;
+    }
+  }
+
   // Warning
   &.warning {
     @apply bg-orange-10 dark:bg-orange-100/30;

--- a/styles/admonition.scss
+++ b/styles/admonition.scss
@@ -21,6 +21,15 @@ div.admonition {
     }
   }
 
+  // Tip
+  &.tip {
+    @apply bg-indigo-10 dark:bg-indigo-100;
+
+    p.first.admonition-title {
+      @apply text-indigo-70;
+    }
+  }
+
   // Important
   &.important {
     @apply bg-orange-10 dark:bg-orange-100/30;

--- a/styles/admonition.scss
+++ b/styles/admonition.scss
@@ -21,6 +21,15 @@ div.admonition {
     }
   }
 
+  // Important
+  &.important {
+    @apply bg-orange-10 dark:bg-orange-100/30;
+
+    p.first.admonition-title {
+      @apply text-orange-70;
+    }
+  }
+
   // Warning
   &.warning {
     @apply bg-orange-10 dark:bg-orange-100/30;

--- a/styles/admonition.scss
+++ b/styles/admonition.scss
@@ -21,24 +21,6 @@ div.admonition {
     }
   }
 
-  // Tip
-  &.tip {
-    @apply bg-indigo-10 dark:bg-indigo-100;
-
-    p.first.admonition-title {
-      @apply text-indigo-70;
-    }
-  }
-
-  // Important
-  &.important {
-    @apply bg-orange-10 dark:bg-orange-100/30;
-
-    p.first.admonition-title {
-      @apply text-orange-70;
-    }
-  }
-
   // Warning
   &.warning {
     @apply bg-orange-10 dark:bg-orange-100/30;


### PR DESCRIPTION
## 📚 Context
Currently, only Warning and Note blocks are correctly styled when used in docstrings. This PR adds the correct colors for Tip and Important blocks as well.

New:
![image](https://github.com/user-attachments/assets/83bfd531-1a9d-4b7d-9af8-a5aeb0467c3b)

Before:
![image](https://github.com/user-attachments/assets/c6260d08-732e-417f-ae74-6ad3b3bffb1a)

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
