### PR TITLE
Update and clarify connections, especially Snowflake

### DIFF
--- a/content/deploy/_index.md
+++ b/content/deploy/_index.md
@@ -19,13 +19,13 @@ Get all the information you need to deploy your app and share it with your users
         icon="cloud"
         bold="Streamlit Community Cloud."
         href="/deploy/streamlit-community-cloud"
-    >Deploy your app on our free platform and join a community of developers who share their apps around the world.</InlineCallout>
+    >Deploy your app on our free platform and join a community of developers who share their apps around the world. This is a great place for your non-commerical, personal, and educational apps.</InlineCallout>
     <InlineCallout
         color="lightBlue-70"
         icon="ac_unit"
-        bold="Streamlit in Snowflake"
-        href="https://docs.snowflake.com/developer-guide/streamlit/about-streamlit"
-    >Deploy your app in Snowflake for a secure, enterprise-grade environment.</InlineCallout>
+        bold="Snowflake"
+        href="/deploy/snowflake"
+    >Deploy your app in Snowflake for a secure, enterprise-grade environment. This is a great place for your business apps when you want to control user access to apps and data through roles.</InlineCallout>
     <InlineCallout
         color="lightBlue-70"
         icon="bolt"

--- a/content/deploy/snowflake/_index.md
+++ b/content/deploy/snowflake/_index.md
@@ -1,0 +1,55 @@
+---
+title: Streamlit in Snowflake
+slug: /deploy/snowflake
+---
+
+# Deploy Streamlit apps in Snowflake
+
+Host your apps alongside your data in a single, global platform. Snowflake provides industry-leading features that ensure the highest levels of security for your account, users, data, and apps. If you're looking for an enterprise hosting solution, try Snowflake!
+
+<TileContainer>
+    <Tile
+        icon="rocket_launch"
+        title="Streamlit in Snowflake Quickstart"
+        text="Create a free trial account and deploy an app with Streamlit in Snowflake."
+        link="/get-started/installation/streamlit-in-snowflake"
+        background="lightBlue-70"
+    />
+    <Tile
+        icon="code"
+        title="Examples"
+        text="Explore a plethora of example apps in Snowflake Labs' snowflake-demo-streamlit repository."
+        link="https://github.com/Snowflake-Labs/snowflake-demo-streamlit"
+        background="lightBlue-70"
+    />
+    <Tile
+        icon="book"
+        title="Get started with Snowflake"
+        text="Learn more in Snowflake's documentation."
+        link="https://docs.snowflake.com/user-guide-getting-started"
+        background="lightBlue-70"
+    />
+</TileContainer>
+
+There are three ways to host Streamlit apps in Snowflake.
+
+<InlineCalloutContainer>
+    <InlineCallout
+        color="lightBlue-70"
+        icon="bolt"
+        bold="Streamlit in Snowflake."
+        href=""
+    >Run your Streamlit app as a native object in Snowflake. Enjoy an in-browser editor and minimal work to configure your environment. Share your app with other users in your Snowflake account through role-based access control. This is a great way to deploy apps internally for your business. Check out Snowflake docs!</InlineCallout>
+    <InlineCallout
+        color="lightBlue-70"
+        icon="ac_unit"
+        bold="Snowflake Native Apps"
+        href="https://docs.snowflake.com/en/developer-guide/native-apps/adding-streamlit"
+    >Package your app with data and share it with other Snowflake accounts. This is a great way to share apps and their underlying data with other organizations who use Snowflake so they can run it in their own account. Check out Snowflake docs!</InlineCallout>
+    <InlineCallout
+        color="lightBlue-70"
+        icon="web_asset"
+        bold="Snowpark Container Services"
+        href="https://docs.snowflake.com/en/developer-guide/snowpark-container-services/overview"
+    >Deploy your app in a container that's optimized to run in Snowflake. This is the most flexible option where you can use any library. Share your app publicly or privately. Check out Snowflake docs!</InlineCallout>
+</InlineCalloutContainer>

--- a/content/develop/api-reference/connections/connections-snowflake.md
+++ b/content/develop/api-reference/connections/connections-snowflake.md
@@ -11,42 +11,22 @@ This page only contains the `st.connections.SnowflakeConnection` class. For a de
 
 <Autofunction function="streamlit.connections.SnowflakeConnection" />
 
-### Configuration
-
 {/**
 Internal note: This section is deep-linked from the library in 1.28.1 via /st.connections.snowflakeconnection-configuration through a redirect.
 Maintain the redirect if moved or modified.
 **/}
 
-`st.connection("snowflake")` can be configured using [Streamlit secrets](/develop/concepts/connections/secrets-management) or keyword args just like any other connection. It can also use existing Snowflake connection configuration when available.
-
-Note that [snowflake-snowpark-python](https://pypi.org/project/snowflake-snowpark-python/) must be installed to use this connection.
-
-#### Using Streamlit secrets
-
-For example, if your Snowflake account supports SSO, you can set up a quick local connection for development using [browser-based SSO](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use#how-browser-based-sso-works) and `secrets.toml` as follows:
-
-```toml
-# .streamlit/secrets.toml
-
-[connections.snowflake]
-account = "<ACCOUNT ID>"
-user = "<USERNAME>"
-authenticator = "EXTERNALBROWSER"
-```
-
-Learn more about [account indentifier here](https://docs.snowflake.com/en/user-guide/admin-account-identifier). You could also specify the full configuration and credentials in your secrets file, as in the [example here](/develop/tutorials/databases/snowflake#add-connection-parameters-to-your-local-app-secrets).
-
 #### Using existing Snowflake configuration
 
-Snowflake's python driver also supports a [connection configuration file](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-example#connecting-using-the-connections-toml-file), which is well integrated with Streamlit `SnowflakeConnection`. If you already have one or more connections configured, all you need to do is pass Streamlit the name of the connection to use. This can be done in several ways:
+Snowflake's Python connector supports a [connection configuration file](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#connecting-using-the-connections-toml-file), which is well integrated with Streamlit's `SnowflakeConnection`. If you already have one or more connections configured, all you need to do is pass Streamlit the name of the connection to use. If your `connections.toml` file defines a connection under `[myconnection]`, you can use that configuration in one of the following ways:
 
-- Set `connection_name` in your app code, such as `st.connnection("<name>", type="snowflake")`.
-- Set `connection_name = "<name>"` in the `[connections.snowflake]` section of your Streamlit secrets.
-- Set the environment variable `SNOWFLAKE_DEFAULT_CONNECTION_NAME=<name>`.
-- [Set a default connection](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-example#setting-a-default-connection) in your Snowflake configuration.
+- In your app code, set `name` for the connection command: `st.connnection("myconnection", type="snowflake")`. Streamlit will infer `connection_name` from `name`.
+- In the `[connections.snowflake]` section of `secrets.toml`, set `connection_name = "myconnection"`. In this case, you must use `st.connection("snowflake")`.
+- Set the environment variable `SNOWFLAKE_DEFAULT_CONNECTION_NAME=<"myconnection"`.
 
-When available in [Streamlit in Snowflake](https://docs.snowflake.com/en/developer-guide/streamlit/about-streamlit), `st.connection("snowflake")` will connect automatically using the [app owner role](https://docs.snowflake.com/en/developer-guide/streamlit/owners-rights) and does not require any configuration.
+If `connections.toml` defines a `[default]` connection, Streamlit will use that when you call `st.connection("snowflake")`. For more information, see [Setting a default connection](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#setting-a-default-connection).
+
+When your app is running in [Streamlit in Snowflake](https://docs.snowflake.com/en/developer-guide/streamlit/about-streamlit), `st.connection("snowflake")` will connect automatically using the [app owner's role](https://docs.snowflake.com/en/developer-guide/streamlit/owners-rights) and does not require any configuration.
 
 Learn more about setting up connections in the [Connecting Streamlit to Snowflake tutorial](/develop/tutorials/databases/snowflake) and [Connecting to data](/develop/concepts/connections/connecting-to-data).
 

--- a/content/menu.md
+++ b/content/menu.md
@@ -790,8 +790,8 @@ site_menu:
     url: /deploy/streamlit-community-cloud/manage-your-account/delete-your-account
   - category: Deploy / Streamlit Community Cloud / Status and limitations
     url: /deploy/streamlit-community-cloud/status
-  - category: Deploy / Streamlit in Snowflake
-    url: https://docs.snowflake.com/developer-guide/streamlit/about-streamlit
+  - category: Deploy / Snowflake
+    url: /deploy/snowflake
   - category: Deploy / Other platforms
     url: /deploy/tutorials
   - category: Deploy / Other platforms / Docker

--- a/public/_redirects
+++ b/public/_redirects
@@ -1145,7 +1145,7 @@
 /develop/quick-reference/older-versions /develop/quick-reference/release-notes/2024
 
 # Deep links included in streamlit/streamlit source code
-/st.connections.snowflakeconnection-configuration /develop/api-reference/connections/st.connections.snowflakeconnection#configuration
+/st.connections.snowflakeconnection-configuration /develop/api-reference/connections/st.connections.snowflakeconnection#using-existing-snowflake-configuration
 /st.page.automatic-page-labels /develop/concepts/multipage-apps/overview#how-streamlit-converts-filenames-into-labels-and-titles
 /st.page.automatic-page-urls /develop/concepts/multipage-apps/overview#how-streamlit-converts-filenames-into-url-pathnames
 /end-users/enable-peripherals /knowledge-base/using-streamlit/enable-camera


### PR DESCRIPTION
## 📚 Context
Snowflake is setting accounts to use MFA by default.

## 🧠 Description of Changes

This PR adds clarifications to `st.connection`, `SQLConnection`, and `SnowflakeConnection`. For `SnowflakeConnection`, additional examples to highlight configuration options for MFA and SSO accounts. The direct link to Snowflake docs from the menu has also changed to a Snowflake landing page to better highlight what Snowflake is a define the options for hosting Streamlit apps in Snowflake.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
