### PR TITLE
Add pointer cursor to Hub embed links

### DIFF
--- a/components/blocks/cloud.js
+++ b/components/blocks/cloud.js
@@ -104,7 +104,7 @@ const Cloud = ({ name, path, query, height, domain, stylePlaceholder }) => {
       >
         <div className="flex-1">
           <a
-            className="text-xs tracking-[0.05em] text-gray-80 hover:text-gray-70"
+            className="text-xs tracking-[0.05em] text-gray-80 hover:text-gray-70 cursor-pointer"
             href="https://streamlit.io"
             target="_blank"
             rel="noopener noreferrer"
@@ -120,6 +120,7 @@ const Cloud = ({ name, path, query, height, domain, stylePlaceholder }) => {
               "text-xs tracking-[0.05em]",
               "text-gray-80 hover:text-gray-70",
               "flex flex-row gap-1",
+              "cursor-pointer",
             )}
             target="_blank"
             rel="noopener noreferrer"


### PR DESCRIPTION
## 📚 Context

To make the links in our embed iframe clearer, by showing a 👆 cursor on hover. 

## 🧠 Description of Changes

* Add `cursor-pointer` class to links. 

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
