### PR TITLE
Fix typos in API reference

### DIFF
--- a/content/develop/api-reference/_index.md
+++ b/content/develop/api-reference/_index.md
@@ -1047,7 +1047,7 @@ edited = st.data_editor(df, num_rows="dynamic")
 
 <Image pure alt="screenshot" src="/images/api/file_uploader.jpg" />
 
-<h4>File Uploader</h4>
+<h4>File uploader</h4>
 
 Display a file uploader widget.
 
@@ -1436,7 +1436,7 @@ c.write("This will show second")
 
 <Image pure alt="screenshot" src="/images/api/dialog.jpg" />
 
-<h4>Modal dialogs</h4>
+<h4>Modal dialog</h4>
 
 Insert a modal dialog that can rerun independently from the rest of the script.
 
@@ -1945,7 +1945,7 @@ st.switch_page("pages/my_page.py")
 
 <Image pure alt="screenshot" src="/images/api/dialog.jpg" />
 
-<h4>Modal dialogs</h4>
+<h4>Modal dialog</h4>
 
 Insert a modal dialog that can rerun independently from the rest of the script.
 

--- a/content/develop/api-reference/control-flow/_index.md
+++ b/content/develop/api-reference/control-flow/_index.md
@@ -15,7 +15,7 @@ By default, Streamlit apps execute the script entirely, but we allow some functi
 
 <Image pure alt="screenshot" src="/images/api/dialog.jpg" />
 
-<h4>Modal dialogs</h4>
+<h4>Modal dialog</h4>
 
 Insert a modal dialog that can rerun independently from the rest of the script.
 

--- a/content/develop/api-reference/layout/_index.md
+++ b/content/develop/api-reference/layout/_index.md
@@ -45,7 +45,7 @@ c.write("This will show second")
 
 <Image pure alt="screenshot" src="/images/api/dialog.jpg" />
 
-<h4>Modal dialogs</h4>
+<h4>Modal dialog</h4>
 
 Insert a modal dialog that can rerun independently from the rest of the script.
 


### PR DESCRIPTION
## 📚 Context

## 🧠 Description of Changes

- Changed "File uploader" to "File Uploader" in the API reference because we usually use sentence casing. 
- Changed "Modal dialogs" to "Modal dialog" in the API reference because we usually use singular for layout elements.  

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
