### PR TITLE
fix typo in config.toml

### DIFF
--- a/content/develop/api-reference/configuration/config-toml.md
+++ b/content/develop/api-reference/configuration/config-toml.md
@@ -5,7 +5,7 @@ slug: /develop/api-reference/configuration/config.toml
 
 ## config.toml
 
-`config.toml` is an optional file you can define for your working directory or global development environment. When `config.toml` is defined both globally and in your working directory, Streamlit combines the configuration options and gives precendence to the working-directory configuration. Additionally, you can use environment variables and command-line options to override additional configuration options. For more information, see [Configuration options](/develop/concepts/configuration/options).
+`config.toml` is an optional file you can define for your working directory or global development environment. When `config.toml` is defined both globally and in your working directory, Streamlit combines the configuration options and gives precedence to the working-directory configuration. Additionally, you can use environment variables and command-line options to override additional configuration options. For more information, see [Configuration options](/develop/concepts/configuration/options).
 
 ### File location
 


### PR DESCRIPTION
## 📚 Context

Fixes a one-word typo.

## 🧠 Description of Changes

`precendence` > `precedence`

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
