### PR TITLE
Add list of Cloud IP addresses for whitelisting and uv.lock

### DIFF
--- a/content/deploy/community-cloud/deploy-your-app/app-dependencies.md
+++ b/content/deploy/community-cloud/deploy-your-app/app-dependencies.md
@@ -90,7 +90,7 @@ There are other Python package managers in addition to `pip`. If you want to con
     </tr>
 </table>
 
-&dagger; For efficiency, Community Cloud will attempt process `requirements.txt` with `uv`, but will fall back to `pip` if needed. `uv` is generally faster and more efficient than `pip`.
+&dagger; For efficiency, Community Cloud will attempt to process `requirements.txt` with `uv`, but will fall back to `pip` if needed. `uv` is generally faster and more efficient than `pip`.
 
 <Warning>
 

--- a/content/deploy/community-cloud/deploy-your-app/app-dependencies.md
+++ b/content/deploy/community-cloud/deploy-your-app/app-dependencies.md
@@ -61,12 +61,16 @@ In the above example, `streamlit` is pinned to version `1.24.1`, `pandas` must b
 
 ### Other Python package managers
 
-There are other Python package managers in addition to `pip`. If you want to consider alternatives to using a `requirements.txt` file, Community Cloud will look for and use the first dependency file it finds in the following order:
+There are other Python package managers in addition to `pip`. If you want to consider alternatives to using a `requirements.txt` file, Community Cloud will use the first dependency file it finds. Community Cloud will search the directory where your entrypoint file is, then it will search the root of your repository. In each location, dependency files are prioritized in the following order:
 
 <table style={{ textAlign: 'center' }}>
     <tr>
         <th style={{ fontSize: '1.2em' }}> Recognized Filename</th>
         <th style={{ fontSize: '1.2em' }}>Python Package Manager</th>
+    </tr>
+    <tr>
+        <td style={{ fontSize: '1em' }}><code>uv.lock</code></td>
+        <td style={{ fontSize: '1em' }}><a href="https://docs.astral.sh/uv/concepts/projects/sync/" target="_blank">uv</a></td>
     </tr>
     <tr>
         <td style={{ fontSize: '1em' }}><code>Pipfile</code></td>
@@ -78,7 +82,7 @@ There are other Python package managers in addition to `pip`. If you want to con
     </tr>
     <tr>
         <td style={{ fontSize: '1em' }}><code>requirements.txt</code></td>
-        <td style={{ fontSize: '1em' }}><a href="https://pip.pypa.io/en/stable/user_guide/#requirements-files" target="_blank">pip</a></td>
+        <td style={{ fontSize: '1em' }}><a href="https://pip.pypa.io/en/stable/user_guide/#requirements-files" target="_blank">pip</a><sup>&dagger;</sup></td>
     </tr>
     <tr>
         <td style={{ fontSize: '1em' }}><code>pyproject.toml</code></td>
@@ -86,9 +90,11 @@ There are other Python package managers in addition to `pip`. If you want to con
     </tr>
 </table>
 
+&dagger; For efficiency, Community Cloud will attempt process `requirements.txt` with `uv`, but will fall back to `pip` if needed. `uv` is generally faster and more efficient than `pip`.
+
 <Warning>
 
-You should only use one requirements file for your app. If you include more than one (e.g. `requirements.txt` and `Pipfile`), only the first file encountered will be used as described above. Additionally, Streamlit will first look in the directory of your Streamlit app; however, if no requirements file is found, Streamlit will then look at the root of the repo.
+You should only use one dependency file for your app. If you include more than one (e.g. `requirements.txt` and `environment.yaml`), only the first file encountered will be used as described above, with any dependency file in your entrypoint file's directory taking precedence over any dependency file in the root of your repository.
 
 </Warning>
 

--- a/content/deploy/community-cloud/status-and-limitations.md
+++ b/content/deploy/community-cloud/status-and-limitations.md
@@ -52,6 +52,37 @@ enableXsrfProtection = true
 gatherUsageStats = true
 ```
 
+## IP addresses
+
+If you need to whitelist IP addresses for a connection, Community Cloud is currently served from the following IP addresses:
+
+<Warning>
+
+    These IP addresses may change at any time without notice.
+
+</Warning>
+
+<div style={{ display: "flex", flexWrap: "wrap", flexDirection: "row", alignItems: "start" }}>
+    <div style={{ width: "150px" }}>35.230.127.150</div>
+    <div style={{ width: "150px" }}>35.203.151.101</div>
+    <div style={{ width: "150px" }}>34.19.100.134</div>
+    <div style={{ width: "150px" }}>34.83.176.217</div>
+    <div style={{ width: "150px" }}>35.230.58.211</div>
+    <div style={{ width: "150px" }}>35.203.187.165</div>
+    <div style={{ width: "150px" }}>35.185.209.55</div>
+    <div style={{ width: "150px" }}>34.127.88.74</div>
+    <div style={{ width: "150px" }}>34.127.0.121</div>
+    <div style={{ width: "150px" }}>35.230.78.192</div>
+    <div style={{ width: "150px" }}>35.247.110.67</div>
+    <div style={{ width: "150px" }}>35.197.92.111</div>
+    <div style={{ width: "150px" }}>34.168.247.159</div>
+    <div style={{ width: "150px" }}>35.230.56.30</div>
+    <div style={{ width: "150px" }}>34.127.33.101</div>
+    <div style={{ width: "150px" }}>35.227.190.87</div>
+    <div style={{ width: "150px" }}>35.199.156.97</div>
+    <div style={{ width: "150px" }}>34.82.135.155</div>
+</div>
+
 ## Other limitations
 
 - When you print something to the Cloud logs, you may need to do a `sys.stdout.flush()` before it shows up.


### PR DESCRIPTION
## 📚 Context
Sometimes users need to whitelist the IP addresses from which Community Cloud serves apps (such as for database connections). This PR adds the current list of IP addresses (with a large warning that they may change at any time without notice).

Community Cloud also added support for uv.lock. This was added to the list of possible dependency files.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
