### PR TITLE
Release 1.41.0

### DIFF
--- a/content/deploy/tutorials/kubernetes.md
+++ b/content/deploy/tutorials/kubernetes.md
@@ -88,7 +88,7 @@ Docker builds images by reading the instructions from a `Dockerfile`. A `Docke
 Here's an example `Dockerfile` that you can add to the root of your directory.
 
 ```docker
-FROM python:3.8-slim
+FROM python:3.9-slim
 
 RUN groupadd --gid 1000 appuser \
     && useradd --uid 1000 --gid 1000 -ms /bin/bash appuser

--- a/content/develop/api-reference/configuration/config-toml.md
+++ b/content/develop/api-reference/configuration/config-toml.md
@@ -69,7 +69,7 @@ level = "info"
 # Python's documentation for available attributes:
 # https://docs.python.org/3/library/logging.html#formatter-objects
 # Default: "%(asctime)s %(message)s"
-messageFormat = "%(asctime)s %(levelname) -7s %(name)s: %(message)s"
+messageFormat = "%(asctime)s %(message)s"
 ```
 
 #### Client
@@ -78,26 +78,39 @@ messageFormat = "%(asctime)s %(levelname) -7s %(name)s: %(message)s"
 [client]
 
 # Controls whether uncaught app exceptions and deprecation warnings
-# are displayed in the browser. By default, this is set to True and
-# Streamlit displays app exceptions and associated tracebacks, and
-# deprecation warnings, in the browser.
-# If set to False, deprecation warnings and full exception messages
-# will print to the console only. Exceptions will still display in the
-# browser with a generic error message. For now, the exception type and
-# traceback show in the browser also, but they will be removed in the
-# future.
-# Default: true
-showErrorDetails = true
+# are displayed in the browser. This can be one of the following:
+# - "full"       : In the browser, Streamlit displays app deprecation
+#                  warnings and exceptions, including exception types,
+#                  exception messages, and associated tracebacks.
+# - "stacktrace" : In the browser, Streamlit displays exceptions,
+#                  including exception types, generic exception messages,
+#                  and associated tracebacks. Deprecation warnings and
+#                  full exception messages will only print to the
+#                  console.
+# - "type"       : In the browser, Streamlit displays exception types and
+#                  generic exception messages. Deprecation warnings, full
+#                  exception messages, and associated tracebacks only
+#                  print to the console.
+# - "none"       : In the browser, Streamlit displays generic exception
+#                  messages. Deprecation warnings, full exception
+#                  messages, associated tracebacks, and exception types
+#                  will only print to the console.
+# - True         : This is deprecated. Streamlit displays "full"
+#                  error details.
+# - False        : This is deprecated. Streamlit displays "stacktrace"
+#                  error details.
+# Default: "full"
+showErrorDetails = "full"
 
 # Change the visibility of items in the toolbar, options menu,
 # and settings dialog (top right of the app).
 # Allowed values:
-# * "auto"      : Show the developer options if the app is accessed through
+# - "auto"      : Show the developer options if the app is accessed through
 #                 localhost or through Streamlit Community Cloud as a developer.
 #                 Hide them otherwise.
-# * "developer" : Show the developer options.
-# * "viewer"    : Hide the developer options.
-# * "minimal"   : Show only options set externally (e.g. through
+# - "developer" : Show the developer options.
+# - "viewer"    : Hide the developer options.
+# - "minimal"   : Show only options set externally (e.g. through
 #                 Streamlit Community Cloud) or through st.set_page_config.
 #                 If there are no options left, hide the menu.
 # Default: "auto"
@@ -140,9 +153,9 @@ enforceSerializableSessionState = false
 # during a script re-run. For more information, check out the docs:
 # https://docs.streamlit.io/develop/concepts/design/custom-classes#enums
 # Allowed values:
-# * "off"          : Disables Enum coercion.
-# * "nameOnly"     : Enum classes can be coerced if their member names match.
-# * "nameAndValue" : Enum classes can be coerced if their member names AND
+# - "off"          : Disables Enum coercion.
+# - "nameOnly"     : Enum classes can be coerced if their member names match.
+# - "nameAndValue" : Enum classes can be coerced if their member names AND
 #                    member values match.
 # Default: "nameOnly"
 enumCoercion = "nameOnly"
@@ -162,11 +175,11 @@ folderWatchBlacklist = []
 # Change the type of file watcher used by Streamlit, or turn it off
 # completely.
 # Allowed values:
-# * "auto"     : Streamlit will attempt to use the watchdog module, and
+# - "auto"     : Streamlit will attempt to use the watchdog module, and
 #                falls back to polling if watchdog is not available.
-# * "watchdog" : Force Streamlit to use the watchdog module.
-# * "poll"     : Force Streamlit to always use polling.
-# * "none"     : Streamlit will not watch files.
+# - "watchdog" : Force Streamlit to use the watchdog module.
+# - "poll"     : Force Streamlit to always use polling.
+# - "none"     : Streamlit will not watch files.
 # Default: "auto"
 fileWatcherType = "auto"
 
@@ -201,19 +214,17 @@ port = 8501
 # Default: ""
 baseUrlPath = ""
 
-# Enables support for Cross-Origin Resource Sharing (CORS) protection, for
-# added security.
-# Due to conflicts between CORS and XSRF, if `server.enableXsrfProtection` is
-# on and `server.enableCORS` is off at the same time, we will prioritize
-# `server.enableXsrfProtection`.
+# Enables support for Cross-Origin Resource Sharing (CORS) protection,
+# for added security.
+# If XSRF protection is enabled and CORS protection is disabled at the
+# same time, Streamlit will enable them both instead.
 # Default: true
 enableCORS = true
 
 # Enables support for Cross-Site Request Forgery (XSRF) protection, for
 # added security.
-# Due to conflicts between CORS and XSRF, if `server.enableXsrfProtection` is
-# on and `server.enableCORS` is off at the same time, we will prioritize
-# `server.enableXsrfProtection`.
+# If XSRF protection is enabled and CORS protection is disabled at the
+# same time, Streamlit will enable them both instead.
 # Default: true
 enableXsrfProtection = true
 

--- a/content/develop/concepts/custom-components/components-api.md
+++ b/content/develop/concepts/custom-components/components-api.md
@@ -91,8 +91,8 @@ To make the process of creating bi-directional Streamlit Components easier, we'v
 
 To build a Streamlit Component, you need the following installed in your development environment:
 
-- Python 3.8 - Python 3.12
-- Streamlit 1.11.1 or higher
+- Python 3.9 - Python 3.13
+- Streamlit
 - [nodejs](https://nodejs.org/en/)
 - [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/)
 

--- a/content/develop/quick-references/api-cheat-sheet.md
+++ b/content/develop/quick-references/api-cheat-sheet.md
@@ -5,7 +5,7 @@ slug: /develop/quick-reference/cheat-sheet
 
 # Streamlit API cheat sheet
 
-This is a summary of the docs for the latest version of Streamlit, [v1.40.0](https://pypi.org/project/streamlit/1.40.0/).
+This is a summary of the docs for the latest version of Streamlit, [v1.41.0](https://pypi.org/project/streamlit/1.41.0/).
 
 <Masonry>
 

--- a/content/develop/quick-references/release-notes/2024.md
+++ b/content/develop/quick-references/release-notes/2024.md
@@ -9,6 +9,52 @@ keywords: changelog, release notes, version history
 
 This page contains release notes for Streamlit versions released in 2024. For the latest version of Streamlit, see [Release notes](/develop/quick-reference/release-notes).
 
+## **Version 1.41.0 (latest)**
+
+_Release date: December 10, 2024_
+
+**Notable Changes**
+
+- 🔲 [`st.metric`](/develop/api-reference/data/st.metric) and [`st.columns`](/develop/api-reference/layout/st.columns) have a parameter to show an optional border ([#9927](https://github.com/streamlit/streamlit/pull/9927), [#9928](https://github.com/streamlit/streamlit/pull/9928)).
+- 🎨 Text and background color in [Markdown](/develop/api-reference/text/st.markdown) can use the “primary” color from the `theme.primaryColor` configuration option ([#9676](https://github.com/streamlit/streamlit/pull/9676)).
+- 🥶 You can freeze columns with [column configuration](/develop/api-reference/data/st.column_config) to make them always visible when scrolling horizontally ([#9535](https://github.com/streamlit/streamlit/pull/9535), [#7078](https://github.com/streamlit/streamlit/issues/7078)).
+- 3️⃣ The `type` parameter for [buttons](/develop/api-reference/widgets/st.button) accepts a new option, `"tertiary"` ([#9923](https://github.com/streamlit/streamlit/pull/9923)).
+- 🚶‍♂️ Streamlit supports `pathlib.Path` objects everywhere you can use a string path ([#9711](https://github.com/streamlit/streamlit/pull/9711), [#9783](https://github.com/streamlit/streamlit/pull/9783)).
+- ⏱️ [`st.date_input`](/develop/api-reference/widgets/st.date_input) and [`st.time_input`](/develop/api-reference/widgets/st.time_input) accept ISO formatted strings for initial values ([#9753](https://github.com/streamlit/streamlit/pull/9753)).
+- 💬 [`st.write_stream`](/develop/api-reference/write-magic/st.write_stream) accepts async generators, which it converts internally to sync generators ([#8724](https://github.com/streamlit/streamlit/pull/8724), [#8161](https://github.com/streamlit/streamlit/issues/8161)).
+- 🪵 The [`client.showErrorDetails`](/develop/api-reference/configuration/config.toml#client) configuration option has additional values to show or hide more information ([#9909](https://github.com/streamlit/streamlit/pull/9909)).
+- 🔎 When Streamlit shows stack traces in the app for uncaught exceptions, internal code is omitted or reduced for easier debugging ([#9913](https://github.com/streamlit/streamlit/pull/9913)).
+- 📈 [`st.line_chart`](/develop/api-reference/charts/st.line_chart) shows tooltips for the nearest point on hover ([#9674](https://github.com/streamlit/streamlit/pull/9674)).
+- 🌐 [`st.html`](/develop/api-reference/utilities/st.html) will attempt to convert non-string objects with `._repr_html_()` before falling back to `str()` ([#9877](https://github.com/streamlit/streamlit/pull/9877)).
+- 🐍 Streamlit supports Python 3.13 and no longer supports Python 3.8 ([#9635](https://github.com/streamlit/streamlit/pull/9635)).
+
+**Other Changes**
+
+- 🔣 Material Symbols have been updated with the latest icons ([#9813](https://github.com/streamlit/streamlit/pull/9813), [#9810](https://github.com/streamlit/streamlit/issues/9810)).
+- 👽 Streamlit supports Watchdog version 6 ([#9785](https://github.com/streamlit/streamlit/pull/9785)). Thanks, [RubenVanEldik](https://github.com/RubenVanEldik).
+- 🌀 Bug fix: Streamlit only shows cached function spinners on cache misses and doesn’t show spinners for nested cached functions ([#9956](https://github.com/streamlit/streamlit/pull/9956), [#9951](https://github.com/streamlit/streamlit/issues/9951)).
+- 🔈 Bug fix: Streamlit’s audio buffer handles channels better to correctly play audio recordings in Firefox ([#9885](https://github.com/streamlit/streamlit/pull/9885), [#9799](https://github.com/streamlit/streamlit/issues/9799)).
+- 🦊 Bug fix: URL patterns are matched correctly to allow Community Cloud developer tools to display correctly in Firefox ([#9849](https://github.com/streamlit/streamlit/pull/9849), [#9848](https://github.com/streamlit/streamlit/issues/9848)).
+- ☠️ Bug fix: Corrected a performance and alignment problem with containers ([#9901](https://github.com/streamlit/streamlit/pull/9901), [#9456](https://github.com/streamlit/streamlit/issues/9456), [#9560](https://github.com/streamlit/streamlit/issues/9560)).
+- 👻 Bug fix: `st.rerun` will raise an error if an invalid `scope` is passed to it ([#9911](https://github.com/streamlit/streamlit/pull/9911), [#9908](https://github.com/streamlit/streamlit/issues/9908)).
+- 🦋 Bug fix: Dataframe toolbars show correctly in dialogs ([#9897](https://github.com/streamlit/streamlit/pull/9897), [#9461](https://github.com/streamlit/streamlit/issues/9461)).
+- 🦀 Bug fix: `LinkColumn` regex for `display_text` uses the correct URI decoding ([#9895](https://github.com/streamlit/streamlit/pull/9895), [#9893](https://github.com/streamlit/streamlit/issues/9893)).
+- 🦎 Bug fix: `st.dataframe` has correct type hinting when `on_selection="ignore"` ([#9898](https://github.com/streamlit/streamlit/pull/9898), [#9669](https://github.com/streamlit/streamlit/issues/9669)).
+- 🐌 Bug fix: Padding is applied consistently for wide and centered layout mode ([#9882](https://github.com/streamlit/streamlit/pull/9882), [#9707](https://github.com/streamlit/streamlit/issues/9707)).
+- 🕸️ Bug fix: `st.graphviz_chart` is displayed correctly when `use_container_width=True` ([#9867](https://github.com/streamlit/streamlit/pull/9867), [#9866](https://github.com/streamlit/streamlit/issues/9866)).
+- 🦗 Bug fix: The overloaded definitions of `st.pills` and `st.segmented_control` use the correct selection-mode default ([#9801](https://github.com/streamlit/streamlit/pull/9801)). Thanks, [RubenVanEldik](https://github.com/RubenVanEldik)!
+- 🦂 Bug fix: `st.text_area` (and other widgets) are correctly submitted in a form when using `Ctrl+Enter` ([#9847](https://github.com/streamlit/streamlit/pull/9847), [#9841](https://github.com/streamlit/streamlit/issues/9841)).
+- 🦟 Bug Fix: `st.write` renders `DeltaGenerator` objects with [`st.help`](http://st.help) ([#9828](https://github.com/streamlit/streamlit/pull/9828), [#9827](https://github.com/streamlit/streamlit/issues/9827)).
+- 🦠 Bug fix: `st.text_area` correctly matches the value in Session State when used with a key ([#9829](https://github.com/streamlit/streamlit/pull/9829), [#9825](https://github.com/streamlit/streamlit/issues/9825)).
+- 🪰 Bug fix: `st.text_input` does not trigger a rerun when a user submits an unchanged value ([#9826](https://github.com/streamlit/streamlit/pull/9826)).
+- 🪳 Bug fix: Improved styling for `st.exception` to fix overflow and incorrect padding ([#9818](https://github.com/streamlit/streamlit/pull/9818), [#9817](https://github.com/streamlit/streamlit/issues/9817), [#9816](https://github.com/streamlit/streamlit/issues/9816)).
+- 🕷️ Bug fix: Large dataframe don’t overflow and cover the dataframe toolbar in fullscreen mode ([#9803](https://github.com/streamlit/streamlit/pull/9803), [#9798](https://github.com/streamlit/streamlit/issues/9798)).
+- 🐞 Bug fix: `st.audio_input` shows the correct time on recording in time zones with a half-hour offset ([#9791](https://github.com/streamlit/streamlit/pull/9791), [#9631](https://github.com/streamlit/streamlit/issues/9631)).
+- 🐝 Bug fix: In iOS, `st.number_input` shows a number pad instead of a keyboard when in focus ([#9766](https://github.com/streamlit/streamlit/pull/9766), [#9763](https://github.com/streamlit/streamlit/issues/9763)).
+- 🐜 Bug fix: Widget keys containing hyphens are correctly added to HTML classes in the DOM with an `st-key-` prefix ([#9793](https://github.com/streamlit/streamlit/pull/9793)).
+- 🪲 Bug fix: Audio files created by `st.audio_input` include a timestamp to ensure unique file names ([#9768](https://github.com/streamlit/streamlit/pull/9768)).
+- 🐛 Bug fix: Double slash URL pathnames do not create a 301 redirect ([#9754](https://github.com/streamlit/streamlit/pull/9754), [#9690](https://github.com/streamlit/streamlit/issues/9690)).
+
 ## **Version 1.40.0**
 
 _Release date: November 6, 2024_

--- a/content/develop/quick-references/release-notes/2024.md
+++ b/content/develop/quick-references/release-notes/2024.md
@@ -16,7 +16,7 @@ _Release date: December 10, 2024_
 **Notable Changes**
 
 - 🔲 [`st.metric`](/develop/api-reference/data/st.metric) and [`st.columns`](/develop/api-reference/layout/st.columns) have a parameter to show an optional border ([#9927](https://github.com/streamlit/streamlit/pull/9927), [#9928](https://github.com/streamlit/streamlit/pull/9928)).
-- 🎨 Text and background color in [Markdown](/develop/api-reference/text/st.markdown) can use the “primary” color from the `theme.primaryColor` configuration option ([#9676](https://github.com/streamlit/streamlit/pull/9676)).
+- 🎨 Text and background color in [Markdown](/develop/api-reference/text/st.markdown) can use the "primary" color from the `theme.primaryColor` configuration option ([#9676](https://github.com/streamlit/streamlit/pull/9676)).
 - 🥶 You can freeze columns with [column configuration](/develop/api-reference/data/st.column_config) to make them always visible when scrolling horizontally ([#9535](https://github.com/streamlit/streamlit/pull/9535), [#7078](https://github.com/streamlit/streamlit/issues/7078)).
 - 3️⃣ The `type` parameter for [buttons](/develop/api-reference/widgets/st.button) accepts a new option, `"tertiary"` ([#9923](https://github.com/streamlit/streamlit/pull/9923)).
 - 🚶‍♂️ Streamlit supports `pathlib.Path` objects everywhere you can use a string path ([#9711](https://github.com/streamlit/streamlit/pull/9711), [#9783](https://github.com/streamlit/streamlit/pull/9783)).
@@ -32,8 +32,8 @@ _Release date: December 10, 2024_
 
 - 🔣 Material Symbols have been updated with the latest icons ([#9813](https://github.com/streamlit/streamlit/pull/9813), [#9810](https://github.com/streamlit/streamlit/issues/9810)).
 - 👽 Streamlit supports Watchdog version 6 ([#9785](https://github.com/streamlit/streamlit/pull/9785)). Thanks, [RubenVanEldik](https://github.com/RubenVanEldik).
-- 🌀 Bug fix: Streamlit only shows cached function spinners on cache misses and doesn’t show spinners for nested cached functions ([#9956](https://github.com/streamlit/streamlit/pull/9956), [#9951](https://github.com/streamlit/streamlit/issues/9951)).
-- 🔈 Bug fix: Streamlit’s audio buffer handles channels better to correctly play audio recordings in Firefox ([#9885](https://github.com/streamlit/streamlit/pull/9885), [#9799](https://github.com/streamlit/streamlit/issues/9799)).
+- 🌀 Bug fix: Streamlit only shows cached function spinners on cache misses and doesn't show spinners for nested cached functions ([#9956](https://github.com/streamlit/streamlit/pull/9956), [#9951](https://github.com/streamlit/streamlit/issues/9951)).
+- 🔈 Bug fix: Streamlit's audio buffer handles channels better to correctly play audio recordings in Firefox ([#9885](https://github.com/streamlit/streamlit/pull/9885), [#9799](https://github.com/streamlit/streamlit/issues/9799)).
 - 🦊 Bug fix: URL patterns are matched correctly to allow Community Cloud developer tools to display correctly in Firefox ([#9849](https://github.com/streamlit/streamlit/pull/9849), [#9848](https://github.com/streamlit/streamlit/issues/9848)).
 - ☠️ Bug fix: Corrected a performance and alignment problem with containers ([#9901](https://github.com/streamlit/streamlit/pull/9901), [#9456](https://github.com/streamlit/streamlit/issues/9456), [#9560](https://github.com/streamlit/streamlit/issues/9560)).
 - 👻 Bug fix: `st.rerun` will raise an error if an invalid `scope` is passed to it ([#9911](https://github.com/streamlit/streamlit/pull/9911), [#9908](https://github.com/streamlit/streamlit/issues/9908)).
@@ -48,7 +48,7 @@ _Release date: December 10, 2024_
 - 🦠 Bug fix: `st.text_area` correctly matches the value in Session State when used with a key ([#9829](https://github.com/streamlit/streamlit/pull/9829), [#9825](https://github.com/streamlit/streamlit/issues/9825)).
 - 🪰 Bug fix: `st.text_input` does not trigger a rerun when a user submits an unchanged value ([#9826](https://github.com/streamlit/streamlit/pull/9826)).
 - 🪳 Bug fix: Improved styling for `st.exception` to fix overflow and incorrect padding ([#9818](https://github.com/streamlit/streamlit/pull/9818), [#9817](https://github.com/streamlit/streamlit/issues/9817), [#9816](https://github.com/streamlit/streamlit/issues/9816)).
-- 🕷️ Bug fix: Large dataframe don’t overflow and cover the dataframe toolbar in fullscreen mode ([#9803](https://github.com/streamlit/streamlit/pull/9803), [#9798](https://github.com/streamlit/streamlit/issues/9798)).
+- 🕷️ Bug fix: Large dataframe don't overflow and cover the dataframe toolbar in fullscreen mode ([#9803](https://github.com/streamlit/streamlit/pull/9803), [#9798](https://github.com/streamlit/streamlit/issues/9798)).
 - 🐞 Bug fix: `st.audio_input` shows the correct time on recording in time zones with a half-hour offset ([#9791](https://github.com/streamlit/streamlit/pull/9791), [#9631](https://github.com/streamlit/streamlit/issues/9631)).
 - 🐝 Bug fix: In iOS, `st.number_input` shows a number pad instead of a keyboard when in focus ([#9766](https://github.com/streamlit/streamlit/pull/9766), [#9763](https://github.com/streamlit/streamlit/issues/9763)).
 - 🐜 Bug fix: Widget keys containing hyphens are correctly added to HTML classes in the DOM with an `st-key-` prefix ([#9793](https://github.com/streamlit/streamlit/pull/9793)).

--- a/content/develop/quick-references/release-notes/_index.md
+++ b/content/develop/quick-references/release-notes/_index.md
@@ -21,43 +21,51 @@ pip install --upgrade streamlit
 
 </Tip>
 
-## **Version 1.40.0 (latest)**
+## **Version 1.41.0 (latest)**
 
-_Release date: November 6, 2024_
-
-**Highlights**
-
-- 💊 Introducing [`st.pills`](/develop/api-reference/widgets/st.pills) to create a single- or multi-select group of pill-buttons.
-- 🎛️ Introducing [`st.segmented_control`](/develop/api-reference/widgets/st.segmented_control) to create a segmented button or button group.
-- 🎤 Announcing the general availability of [`st.audio_input`](), a widget to let users record sound with their microphones.
+_Release date: December 10, 2024_
 
 **Notable Changes**
 
-- ➡️ Markdown renders a limited set of typographical symbols (arrows and comparators).
-- <img src="/logo.svg" style={{ display: "inline-block", width: "1em" }} /> You can use `:streamlit:` to render the Streamlit logo in [Markdown](/develop/api-reference/text/st.markdown).
-- 🐍 [`st.text`](/develop/api-reference/text/st.text) wraps text and no longer uses monospace font.
-- 🪣 You can set `use_container_width` for [`st.image`](/develop/api-reference/media/st.image). `use_column_width` is deprecated.
-- 📅 [`st.date_input`](/develop/api-reference/widgets/st.date_input) infers the first day of the week from the user's locale ([#9706](https://github.com/streamlit/streamlit/pull/9706), [#5215](https://github.com/streamlit/streamlit/issues/5215)).
+- 🔲 [`st.metric`](/develop/api-reference/data/st.metric) and [`st.columns`](/develop/api-reference/layout/st.columns) have a parameter to show an optional border ([#9927](https://github.com/streamlit/streamlit/pull/9927), [#9928](https://github.com/streamlit/streamlit/pull/9928)).
+- 🎨 Text and background color in [Markdown](/develop/api-reference/text/st.markdown) can use the “primary” color from the `theme.primaryColor` configuration option ([#9676](https://github.com/streamlit/streamlit/pull/9676)).
+- 🥶 You can freeze columns with [column configuration](/develop/api-reference/data/st.column_config) to make them always visible when scrolling horizontally ([#9535](https://github.com/streamlit/streamlit/pull/9535), [#7078](https://github.com/streamlit/streamlit/issues/7078)).
+- 3️⃣ The `type` parameter for [buttons](/develop/api-reference/widgets/st.button) accepts a new option, `"tertiary"` ([#9923](https://github.com/streamlit/streamlit/pull/9923)).
+- 🚶‍♂️ Streamlit supports `pathlib.Path` objects everywhere you can use a string path ([#9711](https://github.com/streamlit/streamlit/pull/9711), [#9783](https://github.com/streamlit/streamlit/pull/9783)).
+- ⏱️ [`st.date_input`](/develop/api-reference/widgets/st.date_input) and [`st.time_input`](/develop/api-reference/widgets/st.time_input) accept ISO formatted strings for initial values ([#9753](https://github.com/streamlit/streamlit/pull/9753)).
+- 💬 [`st.write_stream`](/develop/api-reference/write-magic/st.write_stream) accepts async generators, which it converts internally to sync generators ([#8724](https://github.com/streamlit/streamlit/pull/8724), [#8161](https://github.com/streamlit/streamlit/issues/8161)).
+- 🪵 The [`client.showErrorDetails`](/develop/api-reference/configuration/config.toml#client) configuration option has additional values to show or hide more information ([#9909](https://github.com/streamlit/streamlit/pull/9909)).
+- 🔎 When Streamlit shows stack traces in the app for uncaught exceptions, internal code is omitted or reduced for easier debugging ([#9913](https://github.com/streamlit/streamlit/pull/9913)).
+- 📈 [`st.line_chart`](/develop/api-reference/charts/st.line_chart) shows tooltips for the nearest point on hover ([#9674](https://github.com/streamlit/streamlit/pull/9674)).
+- 🌐 [`st.html`](/develop/api-reference/utilities/st.html) will attempt to convert non-string objects with `._repr_html_()` before falling back to `str()` ([#9877](https://github.com/streamlit/streamlit/pull/9877)).
+- 🐍 Streamlit supports Python 3.13 and no longer supports Python 3.8 ([#9635](https://github.com/streamlit/streamlit/pull/9635)).
 
 **Other Changes**
 
-- 🎶 Streamlit's CLI tool accepts array values for configuration options ([#9577](https://github.com/streamlit/streamlit/pull/9577)).
-- ⛓️ Static file serving supports symlinks ([#9147](https://github.com/streamlit/streamlit/pull/9147), [#9146](https://github.com/streamlit/streamlit/issues/9146)). Thanks, [link89](https://github.com/link89)!
-- 🚀 Streamlit provides helpful links for deployment when an app is running locally ([#9681](https://github.com/streamlit/streamlit/pull/9681)).
-- ↕️ The fullscreen button for charts matches with the dataframe toolbar ([#9721](https://github.com/streamlit/streamlit/pull/9721)).
-- 🏃 The running-man icon has a brief delay before rendering to avoid an unnecessary flicker for fast running apps ([#9732](https://github.com/streamlit/streamlit/pull/9732)).
-- 🖇️ The `ComponentRequestHandler` allows symlinks ([#9588](https://github.com/streamlit/streamlit/pull/9588)).
-- 👆 Streamlit works with `pillow` version 11 ([#9742](https://github.com/streamlit/streamlit/pull/9742)). Thanks, [hauntsaninja](https://github.com/hauntsaninja)!
-- 🗺️ Deck.gl was upgraded to version 9.0.33 ([#9636](https://github.com/streamlit/streamlit/pull/9636)).
-- 🦠 Bug fix: `st.latex` stays center-aligned when using the `help` keyword argument ([#9698](https://github.com/streamlit/streamlit/pull/9698), [#9682](https://github.com/streamlit/streamlit/issues/9682)). Thanks, [emmagarr](https://github.com/emmagarr)!
-- 🪰 Bug fix: Apps correctly access local storage on Android ([#9744](https://github.com/streamlit/streamlit/pull/9744), [#9740](https://github.com/streamlit/streamlit/issues/9740)).
-- 🕷️ Bug fix: Cached class methods can be cleared ([#9642](https://github.com/streamlit/streamlit/pull/9642), [#9633](https://github.com/streamlit/streamlit/issues/9633)).
-- 🐞 Bug fix: Streamlit clears fragment auto-reruns when a user changes pages. This prevents an invalid index ([#9617](https://github.com/streamlit/streamlit/pull/9617)).
-- 🐝 Bug fix: `st.page_link` margins are correct ([#9625](https://github.com/streamlit/streamlit/pull/9625)).
-- 🐜 Bug fix: Form widgets show submission instructions when in focus ([#9576](https://github.com/streamlit/streamlit/pull/9576), [#7079](https://github.com/streamlit/streamlit/issues/7079)).
-- 🪲 Bug fix: `st.navigation` correctly reconciles `client.showSidebarNavigation` ([#9589](https://github.com/streamlit/streamlit/pull/9589), [#9581](https://github.com/streamlit/streamlit/issues/9581)).
-- 🐛 Bug fix: `st.text_area` requires a minimum height of 68px which fits two lines ([#9561](https://github.com/streamlit/streamlit/pull/9561), [#9217](https://github.com/streamlit/streamlit/issues/9217)).
-- 💅 Bug fix: Various styling fixes ([#9529](https://github.com/streamlit/streamlit/pull/9529), [#8131](https://github.com/streamlit/streamlit/issues/8131), [#9555](https://github.com/streamlit/streamlit/pull/9555), [#9496](https://github.com/streamlit/streamlit/issues/9496), [#9554](https://github.com/streamlit/streamlit/pull/9554), [#9349](https://github.com/streamlit/streamlit/issues/9349), [#7739](https://github.com/streamlit/streamlit/issues/7739)).
+- 🔣 Material Symbols have been updated with the latest icons ([#9813](https://github.com/streamlit/streamlit/pull/9813), [#9810](https://github.com/streamlit/streamlit/issues/9810)).
+- 👽 Streamlit supports Watchdog version 6 ([#9785](https://github.com/streamlit/streamlit/pull/9785)). Thanks, [RubenVanEldik](https://github.com/RubenVanEldik).
+- 🌀 Bug fix: Streamlit only shows cached function spinners on cache misses and doesn’t show spinners for nested cached functions ([#9956](https://github.com/streamlit/streamlit/pull/9956), [#9951](https://github.com/streamlit/streamlit/issues/9951)).
+- 🔈 Bug fix: Streamlit’s audio buffer handles channels better to correctly play audio recordings in Firefox ([#9885](https://github.com/streamlit/streamlit/pull/9885), [#9799](https://github.com/streamlit/streamlit/issues/9799)).
+- 🦊 Bug fix: URL patterns are matched correctly to allow Community Cloud developer tools to display correctly in Firefox ([#9849](https://github.com/streamlit/streamlit/pull/9849), [#9848](https://github.com/streamlit/streamlit/issues/9848)).
+- ☠️ Bug fix: Corrected a performance and alignment problem with containers ([#9901](https://github.com/streamlit/streamlit/pull/9901), [#9456](https://github.com/streamlit/streamlit/issues/9456), [#9560](https://github.com/streamlit/streamlit/issues/9560)).
+- 👻 Bug fix: `st.rerun` will raise an error if an invalid `scope` is passed to it ([#9911](https://github.com/streamlit/streamlit/pull/9911), [#9908](https://github.com/streamlit/streamlit/issues/9908)).
+- 🦋 Bug fix: Dataframe toolbars show correctly in dialogs ([#9897](https://github.com/streamlit/streamlit/pull/9897), [#9461](https://github.com/streamlit/streamlit/issues/9461)).
+- 🦀 Bug fix: `LinkColumn` regex for `display_text` uses the correct URI decoding ([#9895](https://github.com/streamlit/streamlit/pull/9895), [#9893](https://github.com/streamlit/streamlit/issues/9893)).
+- 🦎 Bug fix: `st.dataframe` has correct type hinting when `on_selection="ignore"` ([#9898](https://github.com/streamlit/streamlit/pull/9898), [#9669](https://github.com/streamlit/streamlit/issues/9669)).
+- 🐌 Bug fix: Padding is applied consistently for wide and centered layout mode ([#9882](https://github.com/streamlit/streamlit/pull/9882), [#9707](https://github.com/streamlit/streamlit/issues/9707)).
+- 🕸️ Bug fix: `st.graphviz_chart` is displayed correctly when `use_container_width=True` ([#9867](https://github.com/streamlit/streamlit/pull/9867), [#9866](https://github.com/streamlit/streamlit/issues/9866)).
+- 🦗 Bug fix: The overloaded definitions of `st.pills` and `st.segmented_control` use the correct selection-mode default ([#9801](https://github.com/streamlit/streamlit/pull/9801)). Thanks, [RubenVanEldik](https://github.com/RubenVanEldik)!
+- 🦂 Bug fix: `st.text_area` (and other widgets) are correctly submitted in a form when using `Ctrl+Enter` ([#9847](https://github.com/streamlit/streamlit/pull/9847), [#9841](https://github.com/streamlit/streamlit/issues/9841)).
+- 🦟 Bug Fix: `st.write` renders `DeltaGenerator` objects with [`st.help`](http://st.help) ([#9828](https://github.com/streamlit/streamlit/pull/9828), [#9827](https://github.com/streamlit/streamlit/issues/9827)).
+- 🦠 Bug fix: `st.text_area` correctly matches the value in Session State when used with a key ([#9829](https://github.com/streamlit/streamlit/pull/9829), [#9825](https://github.com/streamlit/streamlit/issues/9825)).
+- 🪰 Bug fix: `st.text_input` does not trigger a rerun when a user submits an unchanged value ([#9826](https://github.com/streamlit/streamlit/pull/9826)).
+- 🪳 Bug fix: Improved styling for `st.exception` to fix overflow and incorrect padding ([#9818](https://github.com/streamlit/streamlit/pull/9818), [#9817](https://github.com/streamlit/streamlit/issues/9817), [#9816](https://github.com/streamlit/streamlit/issues/9816)).
+- 🕷️ Bug fix: Large dataframe don’t overflow and cover the dataframe toolbar in fullscreen mode ([#9803](https://github.com/streamlit/streamlit/pull/9803), [#9798](https://github.com/streamlit/streamlit/issues/9798)).
+- 🐞 Bug fix: `st.audio_input` shows the correct time on recording in time zones with a half-hour offset ([#9791](https://github.com/streamlit/streamlit/pull/9791), [#9631](https://github.com/streamlit/streamlit/issues/9631)).
+- 🐝 Bug fix: In iOS, `st.number_input` shows a number pad instead of a keyboard when in focus ([#9766](https://github.com/streamlit/streamlit/pull/9766), [#9763](https://github.com/streamlit/streamlit/issues/9763)).
+- 🐜 Bug fix: Widget keys containing hyphens are correctly added to HTML classes in the DOM with an `st-key-` prefix ([#9793](https://github.com/streamlit/streamlit/pull/9793)).
+- 🪲 Bug fix: Audio files created by `st.audio_input` include a timestamp to ensure unique file names ([#9768](https://github.com/streamlit/streamlit/pull/9768)).
+- 🐛 Bug fix: Double slash URL pathnames do not create a 301 redirect ([#9754](https://github.com/streamlit/streamlit/pull/9754), [#9690](https://github.com/streamlit/streamlit/issues/9690)).
 
 ## Older versions of Streamlit
 

--- a/content/develop/quick-references/release-notes/_index.md
+++ b/content/develop/quick-references/release-notes/_index.md
@@ -28,7 +28,7 @@ _Release date: December 10, 2024_
 **Notable Changes**
 
 - 🔲 [`st.metric`](/develop/api-reference/data/st.metric) and [`st.columns`](/develop/api-reference/layout/st.columns) have a parameter to show an optional border ([#9927](https://github.com/streamlit/streamlit/pull/9927), [#9928](https://github.com/streamlit/streamlit/pull/9928)).
-- 🎨 Text and background color in [Markdown](/develop/api-reference/text/st.markdown) can use the “primary” color from the `theme.primaryColor` configuration option ([#9676](https://github.com/streamlit/streamlit/pull/9676)).
+- 🎨 Text and background color in [Markdown](/develop/api-reference/text/st.markdown) can use the "primary" color from the `theme.primaryColor` configuration option ([#9676](https://github.com/streamlit/streamlit/pull/9676)).
 - 🥶 You can freeze columns with [column configuration](/develop/api-reference/data/st.column_config) to make them always visible when scrolling horizontally ([#9535](https://github.com/streamlit/streamlit/pull/9535), [#7078](https://github.com/streamlit/streamlit/issues/7078)).
 - 3️⃣ The `type` parameter for [buttons](/develop/api-reference/widgets/st.button) accepts a new option, `"tertiary"` ([#9923](https://github.com/streamlit/streamlit/pull/9923)).
 - 🚶‍♂️ Streamlit supports `pathlib.Path` objects everywhere you can use a string path ([#9711](https://github.com/streamlit/streamlit/pull/9711), [#9783](https://github.com/streamlit/streamlit/pull/9783)).
@@ -44,8 +44,8 @@ _Release date: December 10, 2024_
 
 - 🔣 Material Symbols have been updated with the latest icons ([#9813](https://github.com/streamlit/streamlit/pull/9813), [#9810](https://github.com/streamlit/streamlit/issues/9810)).
 - 👽 Streamlit supports Watchdog version 6 ([#9785](https://github.com/streamlit/streamlit/pull/9785)). Thanks, [RubenVanEldik](https://github.com/RubenVanEldik).
-- 🌀 Bug fix: Streamlit only shows cached function spinners on cache misses and doesn’t show spinners for nested cached functions ([#9956](https://github.com/streamlit/streamlit/pull/9956), [#9951](https://github.com/streamlit/streamlit/issues/9951)).
-- 🔈 Bug fix: Streamlit’s audio buffer handles channels better to correctly play audio recordings in Firefox ([#9885](https://github.com/streamlit/streamlit/pull/9885), [#9799](https://github.com/streamlit/streamlit/issues/9799)).
+- 🌀 Bug fix: Streamlit only shows cached function spinners on cache misses and doesn't show spinners for nested cached functions ([#9956](https://github.com/streamlit/streamlit/pull/9956), [#9951](https://github.com/streamlit/streamlit/issues/9951)).
+- 🔈 Bug fix: Streamlit's audio buffer handles channels better to correctly play audio recordings in Firefox ([#9885](https://github.com/streamlit/streamlit/pull/9885), [#9799](https://github.com/streamlit/streamlit/issues/9799)).
 - 🦊 Bug fix: URL patterns are matched correctly to allow Community Cloud developer tools to display correctly in Firefox ([#9849](https://github.com/streamlit/streamlit/pull/9849), [#9848](https://github.com/streamlit/streamlit/issues/9848)).
 - ☠️ Bug fix: Corrected a performance and alignment problem with containers ([#9901](https://github.com/streamlit/streamlit/pull/9901), [#9456](https://github.com/streamlit/streamlit/issues/9456), [#9560](https://github.com/streamlit/streamlit/issues/9560)).
 - 👻 Bug fix: `st.rerun` will raise an error if an invalid `scope` is passed to it ([#9911](https://github.com/streamlit/streamlit/pull/9911), [#9908](https://github.com/streamlit/streamlit/issues/9908)).
@@ -60,7 +60,7 @@ _Release date: December 10, 2024_
 - 🦠 Bug fix: `st.text_area` correctly matches the value in Session State when used with a key ([#9829](https://github.com/streamlit/streamlit/pull/9829), [#9825](https://github.com/streamlit/streamlit/issues/9825)).
 - 🪰 Bug fix: `st.text_input` does not trigger a rerun when a user submits an unchanged value ([#9826](https://github.com/streamlit/streamlit/pull/9826)).
 - 🪳 Bug fix: Improved styling for `st.exception` to fix overflow and incorrect padding ([#9818](https://github.com/streamlit/streamlit/pull/9818), [#9817](https://github.com/streamlit/streamlit/issues/9817), [#9816](https://github.com/streamlit/streamlit/issues/9816)).
-- 🕷️ Bug fix: Large dataframe don’t overflow and cover the dataframe toolbar in fullscreen mode ([#9803](https://github.com/streamlit/streamlit/pull/9803), [#9798](https://github.com/streamlit/streamlit/issues/9798)).
+- 🕷️ Bug fix: Large dataframe don't overflow and cover the dataframe toolbar in fullscreen mode ([#9803](https://github.com/streamlit/streamlit/pull/9803), [#9798](https://github.com/streamlit/streamlit/issues/9798)).
 - 🐞 Bug fix: `st.audio_input` shows the correct time on recording in time zones with a half-hour offset ([#9791](https://github.com/streamlit/streamlit/pull/9791), [#9631](https://github.com/streamlit/streamlit/issues/9631)).
 - 🐝 Bug fix: In iOS, `st.number_input` shows a number pad instead of a keyboard when in focus ([#9766](https://github.com/streamlit/streamlit/pull/9766), [#9763](https://github.com/streamlit/streamlit/issues/9763)).
 - 🐜 Bug fix: Widget keys containing hyphens are correctly added to HTML classes in the DOM with an `st-key-` prefix ([#9793](https://github.com/streamlit/streamlit/pull/9793)).

--- a/content/develop/tutorials/llms/llm-quickstart.md
+++ b/content/develop/tutorials/llms/llm-quickstart.md
@@ -26,7 +26,7 @@ Bonus: Deploy the app on Streamlit Community Cloud!
 
 ## Prerequisites
 
-- Python 3.8+
+- Python 3.9+
 - Streamlit
 - LangChain
 - [OpenAI API key](https://platform.openai.com/account/api-keys?ref=blog.streamlit.io)

--- a/content/get-started/installation/command-line.md
+++ b/content/get-started/installation/command-line.md
@@ -14,7 +14,7 @@ computer is properly set up. More specifically, you’ll need:
 
 1. **Python**
 
-   We support [version 3.8 to 3.12](https://www.python.org/downloads/).
+   We support [version 3.9 to 3.13](https://www.python.org/downloads/).
 
 1. **A Python environment manager** (recommended)
 

--- a/content/kb/FAQ/sanity-checks.md
+++ b/content/kb/FAQ/sanity-checks.md
@@ -15,7 +15,7 @@ guaranteeing compatibility with _at least_ the last three minor versions of Pyth
 As new versions of Python are released, we will try to be compatible with the new version as soon
 as possible, though frequently we are at the mercy of other Python packages to support these new versions as well.
 
-Streamlit currently supports versions 3.8, 3.9, 3.10, 3.11, and 3.12 of Python.
+Streamlit currently supports versions 3.9, 3.10, 3.11, 3.12, and 3.13 of Python.
 
 ## Check #1: Is Streamlit running?
 
@@ -125,47 +125,16 @@ Streamlit includes [pyarrow](https://arrow.apache.org/docs/python/) as an instal
 Using cached pyarrow-1.0.1.tar.gz (1.3 MB)
   Installing build dependencies ... error
   ERROR: Command errored out with exit status 1:
-   command: 'c:\users\streamlit\appdata\local\programs\python\python38-32\python.exe' 'c:\users\streamlit\appdata\local\programs\python\python38-32\lib\site-packages\pip' install --ignore-installed --no-user --prefix 'C:\Users\streamlit\AppData\Local\Temp\pip-build-env-s7owjrle\overlay' --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'cython >= 0.29' 'numpy==1.14.5; python_version<'"'"'3.8'"'"'' 'numpy==1.16.0; python_version>='"'"'3.8'"'"'' setuptools setuptools_scm wheel
+   command: 'c:\users\streamlit\appdata\local\programs\python\python38-32\python.exe' 'c:\users\streamlit\appdata\local\programs\python\python38-32\lib\site-packages\pip' install --ignore-installed --no-user --prefix 'C:\Users\streamlit\AppData\Local\Temp\pip-build-env-s7owjrle\overlay' --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'cython >= 0.29' 'numpy==1.14.5; python_version<'"'"'3.9'"'"'' 'numpy==1.16.0; python_version>='"'"'3.9'"'"'' setuptools setuptools_scm wheel
        cwd: None
 
   Complete output (319 lines):
 
       Running setup.py install for numpy: finished with status 'error'
       ERROR: Command errored out with exit status 1:
-       command: 'c:\users\streamlit\appdata\local\programs\python\python38-32\python.exe' -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'C:\\Users\\streamlit\\AppData\\Local\\Temp\\pip-install-0jwfwx_u\\numpy\\setup.py'"'"'; __file__='"'"'C:\\Users\\streamlit\\AppData\\Local\\Temp\\pip-install-0jwfwx_u\\numpy\\setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record 'C:\Users\streamlit\AppData\Local\Temp\pip-record-eys4l2gc\install-record.txt' --single-version-externally-managed --prefix 'C:\Users\streamlit\AppData\Local\Temp\pip-build-env-s7owjrle\overlay' --compile --install-headers 'C:\Users\streamlit\AppData\Local\Temp\pip-build-env-s7owjrle\overlay\Include\numpy'
-           cwd: C:\Users\streamlit\AppData\Local\Temp\pip-install-0jwfwx_u\numpy\
-      Complete output (298 lines):
-
-      blas_opt_info:
-      blas_mkl_info:
-      No module named 'numpy.distutils._msvccompiler' in numpy.distutils; trying from distutils
-      customize MSVCCompiler
-        libraries mkl_rt not found in ['c:\\users\\streamlit\\appdata\\local\\programs\\python\\python38-32\\lib', 'C:\\', 'c:\\users\\streamlit\\appdata\\local\\programs\\python\\python38-32\\libs']
-        NOT AVAILABLE
-
-      blis_info:
-      No module named 'numpy.distutils._msvccompiler' in numpy.distutils; trying from distutils
-      customize MSVCCompiler
-        libraries blis not found in ['c:\\users\\streamlit\\appdata\\local\\programs\\python\\python38-32\\lib', 'C:\\', 'c:\\users\\streamlit\\appdata\\local\\programs\\python\\python38-32\\libs']
-        NOT AVAILABLE
 
       # <truncated for brevity> #
 
-      c:\users\streamlit\appdata\local\programs\python\python38-32\lib\distutils\dist.py:274: UserWarning: Unknown distribution option: 'define_macros'
-        warnings.warn(msg)
-      running install
-      running build
-      running config_cc
-      unifing config_cc, config, build_clib, build_ext, build commands --compiler options
-      running config_fc
-      unifing config_fc, config, build_clib, build_ext, build commands --fcompiler options
-      running build_src
-      build_src
-      building py_modules sources
-      creating build
-      creating build\src.win32-3.8
-      creating build\src.win32-3.8\numpy
-      creating build\src.win32-3.8\numpy\distutils
       building library "npymath" sources
       No module named 'numpy.distutils._msvccompiler' in numpy.distutils; trying from distutils
       error: Microsoft Visual C++ 14.0 is required. Get it with "Build Tools for Visual Studio": https://visualstudio.microsoft.com/downloads/

--- a/pages/index.js
+++ b/pages/index.js
@@ -192,6 +192,50 @@ export default function Home({ window, menu }) {
             <TileContainer>
               <RefCard
                 size="third"
+                href="/develop/api-reference/layout/st.columns"
+              >
+                <i className="material-icons-sharp">view_column</i>
+                <h4>Add borders to columns and metrics</h4>
+                <p>
+                  <code>st.columns</code> and <code>st.metric</code> have a new
+                  <code>border</code> parameter to show an optional border.
+                </p>
+              </RefCard>
+              <RefCard
+                size="third"
+                href="/develop/api-reference/text/st.markdown"
+              >
+                <i className="material-icons-sharp">palette</i>
+                <h4>Primary color in Markdown</h4>
+                <p>
+                  Now you can use the color "primary" in Markdown to color or
+                  highlight text with your app's primary color.
+                </p>
+              </RefCard>
+              <RefCard
+                size="third"
+                href="/develop/api-reference/data/st.column_config"
+              >
+                <i className="material-icons-sharp">push_pin</i>
+                <h4>Pin or freeze dataframe columns</h4>
+                <p>
+                  Column configuration has a new <code>pinned</code> parameter
+                  to pin columns on the left as users scroll horizontally.
+                </p>
+              </RefCard>
+              <RefCard
+                size="third"
+                href="/develop/api-reference/widgets/st.button"
+              >
+                <i className="material-icons-sharp">ads_click</i>
+                <h4>Tertiary buttons</h4>
+                <p>
+                  Buttons have a new, "tertiary" type for a more subtle
+                  appearance.
+                </p>
+              </RefCard>
+              <RefCard
+                size="third"
                 href="/develop/api-reference/widgets/st.pills"
               >
                 <i className="material-icons-sharp">more_horiz</i>
@@ -208,47 +252,6 @@ export default function Home({ window, menu }) {
                 <i className="material-icons-sharp">view_week</i>
                 <h4>Segmented control</h4>
                 <p>You can create a segmented button or button group.</p>
-              </RefCard>
-              <RefCard
-                size="third"
-                href="/develop/api-reference/widgets/st.audio_input"
-              >
-                <i className="material-icons-sharp">mic</i>
-                <h4>Audio input</h4>
-                <p>
-                  <code>st.audio_input</code> lets users record sound with their
-                  microphone.
-                </p>
-              </RefCard>
-              <RefCard
-                size="third"
-                href="/develop/api-reference/text/st.markdown"
-              >
-                <i className="material-icons-sharp">branding_watermark</i>
-                <h4>Markdown improvements</h4>
-                <p>
-                  Add a Streamlit logo with <code>:streamlit:</code> or render
-                  arrows like <code>&lt;- -&gt;</code>.
-                </p>
-              </RefCard>
-              <RefCard size="third" href="/develop/api-reference/text/st.text">
-                <i className="material-icons-sharp">title</i>
-                <h4>Plain text</h4>
-                <p>
-                  <code>st.text</code> renders plain text without monospace
-                  font.
-                </p>
-              </RefCard>
-              <RefCard
-                size="third"
-                href="/develop/api-reference/widgets/st.date_input"
-              >
-                <i className="material-icons-sharp">event</i>
-                <h4>Date input localization</h4>
-                <p>
-                  The first day of the week in <code>st.date_input</code> is
-                  determined from the user's locale.
-                </p>
               </RefCard>
             </TileContainer>
 

--- a/python/api-examples-source/charts.video3/requirements.txt
+++ b/python/api-examples-source/charts.video3/requirements.txt
@@ -1,2 +1,2 @@
-streamlit>=1.40.0
+streamlit>=1.41.0
 webvtt-py

--- a/python/api-examples-source/guides/requirements.txt
+++ b/python/api-examples-source/guides/requirements.txt
@@ -1,1 +1,1 @@
-streamlit>=1.40.0
+streamlit>=1.41.0

--- a/python/api-examples-source/hello/requirements.txt
+++ b/python/api-examples-source/hello/requirements.txt
@@ -8,4 +8,4 @@ numpy==1.23.5
 scipy
 altair==4.2.0
 pydeck==0.8.0
-streamlit>=1.40.0
+streamlit>=1.41.0

--- a/python/api-examples-source/mpa-hello/requirements.txt
+++ b/python/api-examples-source/mpa-hello/requirements.txt
@@ -4,4 +4,4 @@ scipy
 altair==4.2.0
 pydeck==0.8.0
 opencv-python-headless==4.6.0.66
-streamlit>=1.40.0
+streamlit>=1.41.0

--- a/python/api-examples-source/navigation.example_1/requirements.txt
+++ b/python/api-examples-source/navigation.example_1/requirements.txt
@@ -1,1 +1,1 @@
-streamlit>=1.40.0
+streamlit>=1.41.0

--- a/python/api-examples-source/navigation.example_2/requirements.txt
+++ b/python/api-examples-source/navigation.example_2/requirements.txt
@@ -1,1 +1,1 @@
-streamlit>=1.40.0
+streamlit>=1.41.0

--- a/python/api-examples-source/requirements.txt
+++ b/python/api-examples-source/requirements.txt
@@ -11,4 +11,4 @@ pydeck
 Faker
 openai
 vega_datasets
-streamlit-nightly
+streamlit>=1.41.0

--- a/python/api-examples-source/st-experimental-connection/1.22/st-experimental-connection/requirements.txt
+++ b/python/api-examples-source/st-experimental-connection/1.22/st-experimental-connection/requirements.txt
@@ -1,4 +1,4 @@
-streamlit>=1.40.0
+streamlit>=1.41.0
 toml
 sqlalchemy==1.4
 duckdb

--- a/python/api-examples-source/theming/requirements.txt
+++ b/python/api-examples-source/theming/requirements.txt
@@ -1,4 +1,4 @@
-streamlit>=1.40.0
+streamlit>=1.41.0
 vega_datasets
 altair==4.2.0
 plotly==5.13.0

--- a/python/api-examples-source/tutorials/custom-navigation/requirements.txt
+++ b/python/api-examples-source/tutorials/custom-navigation/requirements.txt
@@ -1,1 +1,1 @@
-streamlit>=1.40.0
+streamlit>=1.41.0

--- a/python/api-examples-source/tutorials/requirements.txt
+++ b/python/api-examples-source/tutorials/requirements.txt
@@ -1,1 +1,1 @@
-streamlit>=1.40.0
+streamlit>=1.41.0

--- a/python/api-examples-source/utilities.switch_page/requirements.txt
+++ b/python/api-examples-source/utilities.switch_page/requirements.txt
@@ -1,1 +1,1 @@
-streamlit>=1.40.0
+streamlit>=1.41.0

--- a/python/api-examples-source/widget.button.py
+++ b/python/api-examples-source/widget.button.py
@@ -5,3 +5,6 @@ if st.button("Say hello"):
     st.write("Why hello there")
 else:
     st.write("Goodbye")
+
+if st.button("Aloha", type="tertiary"):
+    st.write("Ciao")

--- a/python/api-examples-source/widget.page_link/requirements.txt
+++ b/python/api-examples-source/widget.page_link/requirements.txt
@@ -1,1 +1,1 @@
-streamlit>=1.40.0
+streamlit>=1.41.0

--- a/python/tutorial-source/llm-18-lines-of-code/requirements.txt
+++ b/python/tutorial-source/llm-18-lines-of-code/requirements.txt
@@ -1,2 +1,2 @@
-streamlit>=1.40.0
+streamlit>=1.41.0
 langchain-openai


### PR DESCRIPTION
## 📚 Context
Docs for release 1.41.0.

## 🧠 Description of Changes
* Border parameter for `st.metric` and `st.column`
* Pinned parameter for column configuration
* Primary color in Markdown
* Borderless/tertiary buttons
* Consistent support for `pathlib.Path` paths in addition to strings
* Support for ISO-formatted string for date and time values
* More options for `client.showErrorDetails`
* Release notes, what's new, cheat sheet


**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
