### PR TITLE
Fix text color in Flex container

### DIFF
--- a/components/layouts/flex.js
+++ b/components/layouts/flex.js
@@ -1,8 +1,15 @@
 import styles from "./flex.module.css";
+import classNames from "classnames";
 
 // Simple horizontal flex container used for MDX.
-const Flex = ({ children }) => {
-  return <section className={styles.Container}>{children}</section>;
+const Flex = ({ wrap = false, children }) => {
+  return (
+    <section
+      className={classNames(styles.Container, wrap ? styles.wrapContainer : "")}
+    >
+      {children}
+    </section>
+  );
 };
 
 export default Flex;

--- a/components/layouts/flex.module.css
+++ b/components/layouts/flex.module.css
@@ -1,3 +1,11 @@
 .Container {
-  @apply flex flex-col lg:flex-row;
+  @apply flex flex-col lg:flex-row text-gray-90;
+}
+
+:global(.dark) .Container {
+  @apply text-gray-40;
+}
+
+.wrapContainer {
+  @apply flex-wrap flex-row;
 }

--- a/content/deploy/community-cloud/status-and-limitations.md
+++ b/content/deploy/community-cloud/status-and-limitations.md
@@ -62,7 +62,7 @@ If you need to whitelist IP addresses for a connection, Community Cloud is curre
 
 </Warning>
 
-<div style={{ display: "flex", flexWrap: "wrap", flexDirection: "row", alignItems: "start" }}>
+<Flex wrap >
     <div style={{ width: "150px" }}>35.230.127.150</div>
     <div style={{ width: "150px" }}>35.203.151.101</div>
     <div style={{ width: "150px" }}>34.19.100.134</div>
@@ -81,7 +81,7 @@ If you need to whitelist IP addresses for a connection, Community Cloud is curre
     <div style={{ width: "150px" }}>35.227.190.87</div>
     <div style={{ width: "150px" }}>35.199.156.97</div>
     <div style={{ width: "150px" }}>34.82.135.155</div>
-</div>
+</Flex>
 
 ## Other limitations
 


### PR DESCRIPTION
## 📚 Context
Community Cloud IP addresses are listed in a flex container. The font color was not correctly inherited, making it difficult to read in dark mode.

## 🧠 Description of Changes
This PR updates the <Flex> component to allow wrapping and adjust font color to match the theme selection.

After:
<img width="942" alt="image" src="https://github.com/user-attachments/assets/6fdfb5d9-ca83-4551-ab10-3833adbf6a84">

Before:
<img width="920" alt="image" src="https://github.com/user-attachments/assets/e5aeba7a-7e99-4d12-b1d7-36a071b8501b">

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
