### PR TITLE
Change example on config page to use new `showErrorDetails` value

### DIFF
--- a/content/develop/api-reference/configuration/config-toml.md
+++ b/content/develop/api-reference/configuration/config-toml.md
@@ -21,7 +21,7 @@ To define your configuration globally, you must first locate your global `.strea
 
 ```toml
 [client]
-showErrorDetails = false
+showErrorDetails = "none"
 
 [theme]
 primaryColor = "#F63366"


### PR DESCRIPTION
## 📚 Context

The basic example on [the config options page](https://docs.streamlit.io/develop/api-reference/configuration/config.toml) uses `showErrorDetails = false`, which is now deprecated. 

## 🧠 Description of Changes

This PR turns it into `showErrorDetails = "none"`.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
