### PR TITLE
Community Cloud uses Debian 11

### DIFF
--- a/content/deploy/community-cloud/deploy-your-app/app-dependencies.md
+++ b/content/deploy/community-cloud/deploy-your-app/app-dependencies.md
@@ -106,7 +106,7 @@ You should only use one dependency file for your app. If you include more than o
 
 ## apt-get dependencies
 
-For many apps, a `packages.txt` file is not required. However, if your script requires any software to be installed that is not a Python package, you need a `packages.txt` file. Community Cloud is built on Debian Linux. Anything you want to `apt-get install` must go in your `packages.txt` file.
+For many apps, a `packages.txt` file is not required. However, if your script requires any software to be installed that is not a Python package, you need a `packages.txt` file. Community Cloud is built on Debian Linux. Anything you want to `apt-get install` must go in your `packages.txt` file. To browse available packages that can be installed, see the Debian 11 ("bullseye") [package list](https://packages.debian.org/bullseye/).
 
 If `packages.txt` exists in the root directory of your repository we automatically detect it, parse it, and install the listed packages. You can read more about apt-get in <a href="https://linux.die.net/man/8/apt-get" target="_blank">Linux documentation</a>.
 

--- a/content/deploy/community-cloud/status-and-limitations.md
+++ b/content/deploy/community-cloud/status-and-limitations.md
@@ -26,6 +26,13 @@ You can deploy multiple apps from your repository, and your entrypoint file(s) m
 - Community Cloud only recognizes one `.streamlit/configuration.toml` file at the root (of each branch) of your repository.
 - You must declare image, video, and audio file paths for Streamlit commands relative to the root of your repository. For example, `st.image`, `st.logo`, and the `page_icon` parameter in `st.set_page_config` expect file locations relative to your working directory (i.e. where you execute `streamlit run`).
 
+## Linux environments
+
+Community Cloud is built on Debian Linux.
+
+- Community Cloud uses Debian 11 ("bullseye"). To browse available packages that can be installed, see the [package list](https://packages.debian.org/bullseye/).
+- All file paths must use forward-slash path separators.
+
 ## Python environments
 
 - You cannot mix and match Python package managers for a single app. Community Cloud configures your app's Python environment based on the first environment configuration file it finds. For more information, see [Other Python package managers](/deploy/streamlit-community-cloud/deploy-your-app/app-dependencies#other-python-package-managers).
@@ -87,5 +94,4 @@ If you need to whitelist IP addresses for a connection, Community Cloud is curre
 
 - When you print something to the Cloud logs, you may need to do a `sys.stdout.flush()` before it shows up.
 - Community Cloud hosts all apps in the United States. This is currently not configurable.
-- Community Cloud is built on Debian Linux. All file paths must use forward-slash path separators.
 - Community Cloud rate limits app updates from GitHub to no more than five per minute.


### PR DESCRIPTION
## 📚 Context
Although this should be updated soon, Community Cloud currently runs on Debian 11. This limits what can be installed through `apt-get`. This PR notes the limitation and links the the available package list for the version.

Closes #1211 

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
