### PR TITLE
[SNOW-1887437] Pass query params to snowflake trial signup page link

### DIFF
--- a/components/blocks/smartLink.js
+++ b/components/blocks/smartLink.js
@@ -1,0 +1,31 @@
+import React from "react";
+import { useRouter } from "next/router";
+
+const useQuery = () => {
+  const router = useRouter();
+  return router.query;
+};
+
+const SmartLink = () => {
+  const query = useQuery();
+  const utm_content = query.utm_content;
+  const baseUrl = "https://signup.snowflake.com/";
+  const params = new URLSearchParams({
+    utm_source: "streamlit",
+    utm_medium: "referral",
+    utm_campaign: "na-us-en-",
+    utm_content: utm_content || "-ss-streamlit-docs",
+  });
+  const signupUrlWithUTMs = `${baseUrl}?${params.toString()}`;
+  return (
+    <div>
+      Go to{" "}
+      <a href={signupUrlWithUTMs} target="_blank">
+        signup.snowflake.com
+      </a>
+      . (This link will open in a new tab.)
+    </div>
+  );
+};
+
+export default SmartLink;

--- a/components/blocks/snowflakeTrial.js
+++ b/components/blocks/snowflakeTrial.js
@@ -6,7 +6,7 @@ const useQuery = () => {
   return router.query;
 };
 
-const SmartLink = () => {
+const SnowflakeTrial = ({ text }) => {
   const query = useQuery();
   const utm_content = query.utm_content;
   const baseUrl = "https://signup.snowflake.com/";
@@ -17,15 +17,12 @@ const SmartLink = () => {
     utm_content: utm_content || "-ss-streamlit-docs",
   });
   const signupUrlWithUTMs = `${baseUrl}?${params.toString()}`;
+  const linkText = text || "signup.snowflake.com";
   return (
-    <div>
-      Go to{" "}
-      <a href={signupUrlWithUTMs} target="_blank">
-        signup.snowflake.com
-      </a>
-      . (This link will open in a new tab.)
-    </div>
+    <a href={signupUrlWithUTMs} target="_blank">
+      {linkText}
+    </a>
   );
 };
 
-export default SmartLink;
+export default SnowflakeTrial;

--- a/components/blocks/tile.js
+++ b/components/blocks/tile.js
@@ -69,7 +69,6 @@ const Tile = ({
         href={{ pathname: link || "/", query: router.query }}
         className={classNames("not-link", styles.Link)}
       >
-        {/*<Link href={link || "/"} className={classNames("not-link", styles.Link)}>*/}
         {image}
         <div>
           <h4 className={styles.Title}>{title || "Install Streamlit"}</h4>

--- a/components/blocks/tile.js
+++ b/components/blocks/tile.js
@@ -3,6 +3,7 @@ import classNames from "classnames";
 import Link from "next/link";
 
 import styles from "./tile.module.css";
+import { useRouter } from "next/router";
 
 const Tile = ({
   img,
@@ -54,6 +55,7 @@ const Tile = ({
   }
 
   const backgroundColor = BG_CLASS[background];
+  const router = useRouter();
 
   return (
     <div
@@ -63,7 +65,11 @@ const Tile = ({
         backgroundColor,
       )}
     >
-      <Link href={link || "/"} className={classNames("not-link", styles.Link)}>
+      <Link
+        href={{ pathname: link || "/", query: router.query }}
+        className={classNames("not-link", styles.Link)}
+      >
+        {/*<Link href={link || "/"} className={classNames("not-link", styles.Link)}>*/}
         {image}
         <div>
           <h4 className={styles.Title}>{title || "Install Streamlit"}</h4>

--- a/content/get-started/installation/sis.md
+++ b/content/get-started/installation/sis.md
@@ -19,7 +19,7 @@ All you need is an email address! Everything else happens in your 30-day trial a
 
 ## Create an account
 
-1. Go to <a href="https://signup.snowflake.com/?utm_source=streamlit&utm_medium=referral&utm_campaign=na-us-en-&utm_content=-ss-streamlit-docs" target="_blank">signup.snowflake.com</a>. (This link will open in a new tab.)
+1. <SmartLink />
 
 1. Fill in your information, and click "**CONTINUE**."
 

--- a/content/get-started/installation/sis.md
+++ b/content/get-started/installation/sis.md
@@ -19,7 +19,7 @@ All you need is an email address! Everything else happens in your 30-day trial a
 
 ## Create an account
 
-1. <SmartLink />
+1. Go to <SnowflakeTrial />. (This link will open in a new tab.)
 
 1. Fill in your information, and click "**CONTINUE**."
 

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -69,7 +69,7 @@ import Tip from "../components/blocks/tip";
 import Warning from "../components/blocks/warning";
 import YouTube from "../components/blocks/youTube";
 import Cloud from "../components/blocks/cloud";
-import SmartLink from "../components/blocks/smartLink";
+import SnowflakeTrial from "../components/blocks/snowflakeTrial";
 
 import styles from "../components/layouts/container.module.css";
 
@@ -148,7 +148,7 @@ export default function Article({
     Image,
     Download,
     Flex,
-    SmartLink,
+    SnowflakeTrial,
     Autofunction: (props) => (
       <Autofunction
         {...props}

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -69,6 +69,7 @@ import Tip from "../components/blocks/tip";
 import Warning from "../components/blocks/warning";
 import YouTube from "../components/blocks/youTube";
 import Cloud from "../components/blocks/cloud";
+import SmartLink from "../components/blocks/smartLink";
 
 import styles from "../components/layouts/container.module.css";
 
@@ -147,6 +148,7 @@ export default function Article({
     Image,
     Download,
     Flex,
+    SmartLink,
     Autofunction: (props) => (
       <Autofunction
         {...props}


### PR DESCRIPTION
## 📚 Context
For the convert to snowflake project we'd like to be able to dynamicaly set the utm_content marketing query param for the `Go to snowflake` link. Right know it's always `-ss-streamlit-docs`. After the change we would be able to set a different param for OOR email or the Cloud app limits settings

Testing:
1. open http://localhost:3000/deploy/snowflake?utm_content=ss-streamlit-cloud-settings
2. click on the `Streamlit in Snowflake` tile
3. click on the `Go to signup.snowflake.com` link
4. there should be utm_content=ss-streamlit-cloud-settings in the singup.snowflake.com insead of utm_content=-ss-streamlit-docs

Preview
https://deploy-preview-1220--streamlit-docs.netlify.app/deploy/snowflake?utm_content=ss-streamlit-cloud-settings

Verified with @sfc-gh-atoader if we're fine with this approach from the security perspective


<!-- Why do you want to make this change? What background should the reviewer know? -->

## 🧠 Description of Changes

<!-- What was specifically changed? Which files, algorithms, links, media? -->
<!-- Please add them here as a bulleted list -->

**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
