### PR TITLE
Update pyplot docs using RLock

### DIFF
--- a/content/develop/api-reference/charts/pyplot.md
+++ b/content/develop/api-reference/charts/pyplot.md
@@ -10,8 +10,8 @@ description: st.pyplot displays a matplotlib.pyplot figure.
     Matplotlib [doesn't work well with threads](https://matplotlib.org/3.3.2/faq/howto_faq.html#working-with-threads). So if you're using Matplotlib you should wrap your code with locks as shown in the snippet below. This Matplotlib bug is more prominent when you deploy and share your app apps since you're more likely to get concurrent users then.
 
     ```python
-    from matplotlib.backends.backend_agg import RendererAgg
-    _lock = RendererAgg.lock
+    from threading import RLock
+    _lock = RLock()
 
     with _lock:
         fig.title('This is a figure)')

--- a/content/develop/api-reference/charts/pyplot.md
+++ b/content/develop/api-reference/charts/pyplot.md
@@ -7,15 +7,22 @@ description: st.pyplot displays a matplotlib.pyplot figure.
 <Autofunction function="streamlit.pyplot" />
 
 <Warning>
-    Matplotlib [doesn't work well with threads](https://matplotlib.org/3.3.2/faq/howto_faq.html#working-with-threads). So if you're using Matplotlib you should wrap your code with locks as shown in the snippet below. This Matplotlib bug is more prominent when you deploy and share your app apps since you're more likely to get concurrent users then.
+    Matplotlib [doesn't work well with threads](https://matplotlib.org/3.3.2/faq/howto_faq.html#working-with-threads). So if you're using Matplotlib you should wrap your code with locks. This Matplotlib bug is more prominent when you deploy and share your apps because you're more likely to get concurrent users then. The following example uses [`Rlock`](https://docs.python.org/3/library/threading.html#rlock-objects) from the `threading` module.
 
     ```python
+    import streamlit as st
+    import matplotlib.pyplot as plt
+    import numpy as np
     from threading import RLock
+
     _lock = RLock()
 
+    x = np.random.normal(1, 1, 100)
+    y = np.random.normal(1, 1, 100)
+
     with _lock:
-        fig.title('This is a figure)')
-        fig.plot([1,20,3,40])
+        fig, ax = plt.subplots()
+        ax.scatter(x, y)
         st.pyplot(fig)
     ```
 


### PR DESCRIPTION
## 📚 Context

[Following documentation for matplotlib throws AttributeError: ‘RendererAgg’ has no attribute ‘lock’](https://discuss.streamlit.io/t/following-documentation-for-matplotlib-throws-attributeerror-rendereragg-has-no-attribute-lock/72636)

## 🧠 Description of Changes
Update code snippet to use `threading.RLock` instead of the no longer existing `RendererAgg.lock`

Size:
- [ x ] Small 

## 🌐 References

[Forum discussion](https://discuss.streamlit.io/t/following-documentation-for-matplotlib-throws-attributeerror-rendereragg-has-no-attribute-lock/72636)

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
