### PR TITLE
Commits don't wake apps

### DIFF
--- a/content/deploy/community-cloud/manage-your-app/_index.md
+++ b/content/deploy/community-cloud/manage-your-app/_index.md
@@ -136,7 +136,7 @@ If you are signed in to a developer account for an app over its limits, you can 
 
 ### App hibernation
 
-All apps without traffic for 12 hours go to sleep. Community Cloud hibernates apps to conserve resources and allow the best communal use of the platform. To keep your app awake, simply visit your app or commit to your app's repository.
+All apps without traffic for 12 hours go to sleep. Community Cloud hibernates apps to conserve resources and allow the best communal use of the platform. To keep your app awake, simply visit your app.
 
 When someone visits a sleeping app, they will see the sleeping page:
 

--- a/content/develop/api-reference/configuration/config-toml.md
+++ b/content/develop/api-reference/configuration/config-toml.md
@@ -411,6 +411,8 @@ showSidebarBorder =
 #### Sidebar theme
 
 ```toml
+[theme.sidebar]
+
 # Primary accent color.
 primaryColor =
 


### PR DESCRIPTION
## 📚 Context
Community Cloud apps require visitors to stay awake.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
