### PR TITLE
Redirect sis to 1.42.0

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -143,7 +143,7 @@ module.exports = {
     return [
       {
         source: "/sis/:path*",
-        destination: "/1.39.0/:path*",
+        destination: "/1.42.0/:path*",
       },
       {
         source: `/${LATEST_VERSION}/:path*`,


### PR DESCRIPTION
## 📚 Context
This PR adds a rewrite to send .../sis/... URLs to version 1.42.0 (on versioned pages).

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
