### PR TITLE
brief asyncio / multiprocessing, remove link to external asyncio guide

### DIFF
--- a/content/develop/concepts/app-design/multithreading.md
+++ b/content/develop/concepts/app-design/multithreading.md
@@ -15,7 +15,13 @@ Multithreading is a type of concurrency, which improves the efficiency of comput
 
 Multithreading is just one type of concurrency. Multiprocessing and coroutines are other forms of concurrency. You need to understand how your code is bottlenecked to choose the correct kind of concurrency.
 
-Multiprocessing is inherently parallel, meaning that resources are split and multiple tasks are performed simultaneously. Therefore, multiprocessing is helpful with compute-bound operations. In contrast, multithreading and coroutines are not inherently parallel and instead allow resource switching. This makes them good choices when your code is stuck _waiting_ for something, like an IO operation. AsyncIO uses coroutines and may be preferable with very slow IO operations. Threading may be preferable with faster IO operations. For a helpful guide to using AsyncIO with Streamlit, see this [Medium article by Sehmi-Conscious Thoughts](https://sehmi-conscious.medium.com/got-that-asyncio-feeling-f1a7c37cab8b).
+**Multithreading** is about more _threads_ in the current process.
+
+**Multiprocessing** uses more _processes_ and is inherently parallel, meaning that resources are split and multiple tasks are performed simultaneously. Therefore, multiprocessing is most helpful with compute-bound operations that would otherwise be stuck at Python's [GIL](https://en.wikipedia.org/wiki/Global_interpreter_lock).
+
+**AsyncIO** is a relatively new option to run _coroutines_ concurrently in single thread.
+
+As multithreading and coroutines are still in current process, they are not inherently parallel and instead allow resource switching. This makes them good choices when your code is stuck _waiting_ for something, like an IO operation. AsyncIO uses coroutines and may be preferable with plenty or very slow IO operations. Threading may be preferable with faster IO operations.
 
 Don't forget that Streamlit has [fragments](/develop/concepts/architecture/fragments) and [caching](/develop/concepts/architecture/caching), too! Use caching to avoid unnecessarily repeating computations or IO operations. Use fragments to isolate a bit of code you want to update separately from the rest of the app. You can set fragments to rerun at a specified interval, so they can be used to stream updates to a chart or table.
 


### PR DESCRIPTION
## 📚 Context

The medium article linked is IMO inappropriate to be referred to from streamlit doc, because its analysis and workaround to the asyncio hurdle is too arguable:

1. Tornado server has a event loop, this does not mean it should be used to run user's (potentially blocking) coroutine.
2. There are apparently other possibilities than `run_until_complete`, like in https://github.com/streamlit/streamlit/issues/8488#issuecomment-2844134343 . I think the author assumed too much on the problem to solve.
3. The workaround it suggested, to monkey patch asyncio module with a library, is too intrusive. 

## 🧠 Description of Changes

1. a little more comparison about multiprocessing / asyncio in this page
2. remove the link to the article.

## 💥 Impact

<!-- what is the scale of this change -->

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
