### PR TITLE
Fix: Fixed broken links in deploy/tutorials page

### DIFF
--- a/content/deploy/tutorials/_index.md
+++ b/content/deploy/tutorials/_index.md
@@ -35,8 +35,6 @@ This sections contains step-by-step guides on how to deploy Streamlit apps to va
 
 While we work on official Streamlit deployment guides for other hosting providers, here are some user-submitted tutorials for different cloud services:
 
-- [How to Deploy Streamlit to a Free **Amazon EC2** instance](https://medium.com/data-science/how-to-deploy-a-streamlit-app-using-an-amazon-free-ec2-instance-416a41f69dc3), by Rahul Agarwal.
-- [Host Streamlit on **Azure**](https://medium.com/data-science/deploying-a-streamlit-web-app-with-azure-app-service-1f09a2159743), by Richard Peterson.
 - [How to deploy Streamlit apps to **Google App Engine**](https://dev.to/whitphx/how-to-deploy-streamlit-apps-to-google-app-engine-407o), by [Yuichiro Tachibana (Tsuchiya)](https://discuss.streamlit.io/u/whitphx/summary).
 - [Host Streamlit on **Heroku**](https://towardsdatascience.com/quickly-build-and-deploy-an-application-with-streamlit-988ca08c7e83), by Maarten Grootendorst.
 - [Deploy Streamlit on **Ploomber Cloud**](https://docs.cloud.ploomber.io/en/latest/apps/streamlit.html), by Ido Michael.

--- a/content/deploy/tutorials/_index.md
+++ b/content/deploy/tutorials/_index.md
@@ -35,8 +35,8 @@ This sections contains step-by-step guides on how to deploy Streamlit apps to va
 
 While we work on official Streamlit deployment guides for other hosting providers, here are some user-submitted tutorials for different cloud services:
 
-- [How to Deploy Streamlit to a Free **Amazon EC2** instance](https://towardsdatascience.com/how-to-deploy-a-streamlit-app-using-an-amazon-free-ec2-instance-416a41f69dc3), by Rahul Agarwal.
-- [Host Streamlit on **Azure**](https://towardsdatascience.com/deploying-a-streamlit-web-app-with-azure-app-service-1f09a2159743), by Richard Peterson.
+- [How to Deploy Streamlit to a Free **Amazon EC2** instance](https://medium.com/data-science/how-to-deploy-a-streamlit-app-using-an-amazon-free-ec2-instance-416a41f69dc3), by Rahul Agarwal.
+- [Host Streamlit on **Azure**](https://medium.com/data-science/deploying-a-streamlit-web-app-with-azure-app-service-1f09a2159743), by Richard Peterson.
 - [How to deploy Streamlit apps to **Google App Engine**](https://dev.to/whitphx/how-to-deploy-streamlit-apps-to-google-app-engine-407o), by [Yuichiro Tachibana (Tsuchiya)](https://discuss.streamlit.io/u/whitphx/summary).
 - [Host Streamlit on **Heroku**](https://towardsdatascience.com/quickly-build-and-deploy-an-application-with-streamlit-988ca08c7e83), by Maarten Grootendorst.
 - [Deploy Streamlit on **Ploomber Cloud**](https://docs.cloud.ploomber.io/en/latest/apps/streamlit.html), by Ido Michael.


### PR DESCRIPTION
Some links for deploying on AWS EC2 and azure were broken, so I added links from the towards data science archive on medium. The content is the same but the links are working now

## 📚 Context

<!-- Why do you want to make this change? What background should the reviewer know? -->

Links for the third party tutorials were broken in the https://docs.streamlit.io/deploy/tutorials page

## 🧠 Description of Changes

<!-- What was specifically changed? Which files, algorithms, links, media? -->
<!-- Please add them here as a bulleted list -->

1.  Added 
**Revised:**

_Insert screenshot of your updated UI/code here_

**Current:**

_Insert screenshot of existing UI/code here_

## 💥 Impact

<!-- what is the scale of this change -->

Links on the deploy tutorial section will no longer be broken.

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->

## 🌐 References

<!-- Add link to a Design Document, forum thread, or a ticket that has the greater context for this change. -->
<!-- For small isolated changes, you can skip this section -->

Links that were broken

https://towardsdatascience.com/how-to-deploy-a-streamlit-app-using-an-amazon-free-ec2-instance-416a41f69dc3
https://towardsdatascience.com/deploying-a-streamlit-web-app-with-azure-app-service-1f09a2159743

Fixed Links:
https://medium.com/data-science/how-to-deploy-a-streamlit-app-using-an-amazon-free-ec2-instance-416a41f69dc3
https://medium.com/data-science/deploying-a-streamlit-web-app-with-azure-app-service-1f09a2159743

- [ ] [Notion](...)

<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
