### PR TITLE
Correct private app limitation on Community Cloud

### DIFF
--- a/content/develop/api-reference/user/user.md
+++ b/content/develop/api-reference/user/user.md
@@ -8,6 +8,6 @@ description: st.user returns information about the logged-in user of private app
 
 ### Community Cloud
 
-Only Streamlit versions 1.41.0 and below can read user email from a Community Cloud account. To use `st.user` in Streamlit versions 1.42.0 and later, you must configure authentication (`[auth]`) in your app's secrets. Remember to update your identity provider's configuration and your app's secrets to allow your new domain. A list of [IP addresses](/deploy/streamlit-community-cloud/status#ip-addresses) used by Community Cloud is available if needed. An authentication-configured app counts as your one, allowed private app.
+Starting from Streamlit version 1.42.0, you can't use `st.user` to retrieve a user's Community Cloud account email. To access user information, you must set up an identity provider and configure authentication (`[auth]`) in your app's secrets. Remember to update your identity provider's configuration and your app's secrets to allow your new domain. A list of [IP addresses](/deploy/streamlit-community-cloud/status#ip-addresses) used by Community Cloud is available if needed. An authentication-configured app counts as your one, allowed private app.
 
 <Autofunction function="streamlit.user.to_dict" oldName="streamlit.experimental_user.to_dict" />

--- a/content/develop/api-reference/user/user.md
+++ b/content/develop/api-reference/user/user.md
@@ -8,8 +8,6 @@ description: st.user returns information about the logged-in user of private app
 
 ### Community Cloud
 
-On Community Cloud, if your app is not configured for authentication, `st.user` will have a single attribute: `email`. If a user is logged in and a member of your app's workspace, this will return the user's email. For all other cases, it returns `None`.
-
-On Community Cloud, if your app is configured for authentication (`[auth]` exists in your app's secrets), `st.user` will behave the same as a locally running app. Remember to update your identity provider's configuration and your app's secrets to allow your new domain. A list of [IP addresses](/deploy/streamlit-community-cloud/status#ip-addresses) used by Community Cloud is available if needed. An authentication-configured app counts as your one, allowed private app.
+Only Streamlit versions 1.41.0 and below can read user email from a Community Cloud account. To use `st.user` in Streamlit versions 1.42.0 and later, you must configure authentication (`[auth]`) in your app's secrets. Remember to update your identity provider's configuration and your app's secrets to allow your new domain. A list of [IP addresses](/deploy/streamlit-community-cloud/status#ip-addresses) used by Community Cloud is available if needed. An authentication-configured app counts as your one, allowed private app.
 
 <Autofunction function="streamlit.user.to_dict" oldName="streamlit.experimental_user.to_dict" />

--- a/content/develop/api-reference/user/user.md
+++ b/content/develop/api-reference/user/user.md
@@ -8,6 +8,6 @@ description: st.user returns information about the logged-in user of private app
 
 ### Community Cloud
 
-Starting from Streamlit version 1.42.0, you can't use `st.user` to retrieve a user's Community Cloud account email. To access user information, you must set up an identity provider and configure authentication (`[auth]`) in your app's secrets. Remember to update your identity provider's configuration and your app's secrets to allow your new domain. A list of [IP addresses](/deploy/streamlit-community-cloud/status#ip-addresses) used by Community Cloud is available if needed. An authentication-configured app counts as your one, allowed private app.
+Starting from Streamlit version 1.42.0, you can't use `st.user` to retrieve a user's Community Cloud account email. To access user information, you must set up an identity provider and configure authentication (`[auth]`) in your app's secrets. Remember to update your identity provider's configuration and your app's secrets to allow your new domain. A list of [IP addresses](/deploy/streamlit-community-cloud/status#ip-addresses) used by Community Cloud is available if needed. An authentication-configured app counts as your single allowed private app.
 
 <Autofunction function="streamlit.user.to_dict" oldName="streamlit.experimental_user.to_dict" />


### PR DESCRIPTION
## 📚 Context
A limitation was missed when a last minute change was introduced to `st.user` when authentication was released. This corrects the omission: `st.user` can't read Community Cloud account emails starting from Streamlit version 1.42.0.

closes streamlit/streamlit#11373

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
