### PR TITLE
Update widget-behavior.md

### DIFF
--- a/content/develop/concepts/architecture/widget-behavior.md
+++ b/content/develop/concepts/architecture/widget-behavior.md
@@ -169,7 +169,7 @@ def load_value(key):
     st.session_state["_"+key] = st.session_state[key]
 
 load_value("my_key")
-st.number_input("Number of filters", key="_my_key", on_change=store_value, args=["my_key"])
+st.number_input("Number of filters", key="_my_key", on_change=store_value, args=(my_key,))
 ```
 
 ## Widget life cycle

--- a/content/develop/concepts/multipage-apps/widgets.md
+++ b/content/develop/concepts/multipage-apps/widgets.md
@@ -67,7 +67,7 @@ def load_value(key):
     st.session_state["_"+key] = st.session_state[key]
 
 load_value("my_key")
-st.number_input("Number of filters", key="_my_key", on_change=store_value, args=["my_key"])
+st.number_input("Number of filters", key="_my_key", on_change=store_value, args=("my_key",))
 ```
 
 ## Option 3: Interrupt the widget clean-up process


### PR DESCRIPTION
Update widget value-persistence example code to use a tuple for the args of the callback instead of a list[str] to align with the type hint for WidgetArgs in runtime/state/common.py

`WidgetArgs: TypeAlias = tuple[Any, ...]`

## 📚 Context

When pasting the example code into my editor I am shown a Pylance[reportArgumentType] error

<img width="780" height="109" alt="image" src="https://github.com/user-attachments/assets/76720cd7-9157-45be-83ff-4f72dbf6b063" />

<img width="779" height="114" alt="image" src="https://github.com/user-attachments/assets/552bf16e-bba4-4653-8e4c-64462bacc0ce" />


## 🧠 Description of Changes

 - Example for callback args uses a tuple[str,] instead of a list[str]


## 💥 Impact

No impact except pasting code form the documentation has no pylance type error

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->


<!-- Want to edit this template? https://github.com/streamlit/docs/edit/master/.github/pull_request_template.md -->

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
