### PR TITLE
Add deeplink to replication note

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1160,3 +1160,4 @@
 /st.page.automatic-page-labels /develop/concepts/multipage-apps/overview#how-streamlit-converts-filenames-into-labels-and-titles
 /st.page.automatic-page-urls /develop/concepts/multipage-apps/overview#how-streamlit-converts-filenames-into-url-pathnames
 /end-users/enable-peripherals /knowledge-base/using-streamlit/enable-camera
+/replication /develop/concepts/architecture/architecture#websockets-and-session-management


### PR DESCRIPTION
## 📚 Context
To explain the consequences of replication within a config option, this PR adds a deeplink redirect to a section within the architecutral concepts page.

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
