### PR TITLE
docs: fix two grammar errors in README (menu section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ However, a user has to know the URL to visit the page. The page is therefore _re
 
 How do you make the page you created appear in the Menu? Edit the special markdown file `content/menu.md`. All it has is front matter in YAML.
 
-Suppose you have created an "Quickstart" page that is available at `docs.streamlit.io/get-started/installation/quickstart`. You want to it to appear in the Menu within the "Get started" section, nested under the "Installation" page.
+Suppose you have created a "Quickstart" page that is available at `docs.streamlit.io/get-started/installation/quickstart`. You want it to appear in the Menu within the "Get started" section, nested under the "Installation" page.
 
 To do so, find the lines that define the `category`, `url` and `visible` properties for "Get Started" in `menu.md` and add three new lines below it, containing:
 


### PR DESCRIPTION
This PR fixes two small grammar issues in the README “Add pages to the Menu” section:

“an ‘Quickstart’ page” → “a ‘Quickstart’ page”

“You want to it to appear…” → “You want it to appear…”

Source lines are in the repo’s README under the “Add pages to the Menu” heading. No content changes beyond grammar.
