### PR TITLE
Docs: clarify picklable requirement for st.cache_resource

### DIFF
--- a/content/develop/api-reference/caching-and-state/cache-resource.md
+++ b/content/develop/api-reference/caching-and-state/cache-resource.md
@@ -11,6 +11,15 @@ This page only contains information on the `st.cache_resource` API. For a deeper
 
 </Tip>
 
+<Note>
+
+Due to the current implementation of Streamlit’s caching mechanism, objects passed to
+`st.cache_resource` must be **pickle-able** (serializable) in addition to being
+**hashable**. Objects that contain non-pickleable elements (such as functions)
+may raise errors like `TypeError: cannot pickle 'function' object`.
+
+</Note>
+
 <Autofunction function="streamlit.cache_resource" oldName="streamlit.experimental_singleton" />
 
 <Autofunction function="streamlit.cache_resource.clear" oldName="streamlit.experimental_singleton.clear" />

--- a/content/develop/api-reference/caching-and-state/cache-resource.md
+++ b/content/develop/api-reference/caching-and-state/cache-resource.md
@@ -15,8 +15,17 @@ This page only contains information on the `st.cache_resource` API. For a deeper
 
 Due to the current implementation of Streamlit’s caching mechanism, objects passed to
 `st.cache_resource` must be **pickle-able** (serializable) in addition to being
-**hashable**. Objects that contain non-pickleable elements (such as functions)
-may raise errors like `TypeError: cannot pickle 'function' object`.
+**hashable**.
+
+Streamlit’s rerun model relies on **content-based hashing** to determine when cached
+values can be reused across reruns. This hashing mechanism is implemented using
+Python’s pickling system (via the `__reduce__()` method). As a result, cached objects
+must be pickle-able.
+
+Objects that contain non-pickle-able elements (such as functions, lambdas, or open
+file handles) may raise errors such as:
+
+`TypeError: cannot pickle 'function' object`
 
 </Note>
 


### PR DESCRIPTION
Docs: clarify picklable requirement for st.cache_resource

Clarifies that st.cache_resource requires pickle-able objects in addition to
being hashable, aligning the documentation with current caching behavior and
addressing confusion reported in #1399.

📚 Context

This change clarifies a documented requirement mismatch discussed in #1399,
where st.cache_resource requires objects to be pickle-able in addition to
being hashable.


## 🧠 Description of Changes

Added a documentation note explaining that st.cache_resource requires
pickle-able objects in addition to being hashable.

This helps prevent confusion around errors such as: TypeError: cannot pickle 'function' object


💥 Impact

Size:Small

🌐 References

#1399 — Error (TypeError: cannot pickle 'function' object) thrown in
st.cache_resource is confusing because the documentation previously mentioned
only hashability, while pickle-ability is also required.

📜 Contribution License Agreement

By submitting this pull request, you agree that all contributions to this project
are made under the Apache 2.0 license
