### PR TITLE
Update supported Python versions: drop 3.9, add 3.14

### DIFF
--- a/content/deploy/tutorials/docker.md
+++ b/content/deploy/tutorials/docker.md
@@ -53,7 +53,7 @@ Here's an example `Dockerfile` that you can add to the root of your directory. i
 ```docker
 # app/Dockerfile
 
-FROM python:3.9-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 
@@ -82,10 +82,10 @@ Let’s walk through each line of the Dockerfile :
 1. A `Dockerfile` must start with a [`FROM`](https://docs.docker.com/engine/reference/builder/#from) instruction. It sets the [Base Image](https://docs.docker.com/glossary/#base-image) (think OS) for the container:
 
    ```docker
-   FROM python:3.9-slim
+   FROM python:3.12-slim
    ```
 
-   Docker has a number of official Docker base images based on various Linux distributions. They also have base images that come with language-specific modules such as [Python](https://hub.docker.com/_/python). The `python` images come in many flavors, each designed for a specific use case. Here, we use the `python:3.9-slim` image which is a lightweight image that comes with the latest version of Python 3.9.
+   Docker has a number of official Docker base images based on various Linux distributions. They also have base images that come with language-specific modules such as [Python](https://hub.docker.com/_/python). The `python` images come in many flavors, each designed for a specific use case. Here, we use the `python:3.12-slim` image which is a lightweight image that comes with the latest version of Python 3.12.
 
    <Tip>
 

--- a/content/deploy/tutorials/kubernetes.md
+++ b/content/deploy/tutorials/kubernetes.md
@@ -90,7 +90,7 @@ Docker builds images by reading the instructions from a `Dockerfile`. A `Docke
 Here's an example `Dockerfile` that you can add to the root of your directory.
 
 ```docker
-FROM python:3.9-slim
+FROM python:3.12-slim
 
 RUN groupadd --gid 1000 appuser \
     && useradd --uid 1000 --gid 1000 -ms /bin/bash appuser

--- a/content/develop/concepts/custom-components/components-v1/v1-component-api.md
+++ b/content/develop/concepts/custom-components/components-v1/v1-component-api.md
@@ -93,7 +93,7 @@ To make the process of creating bi-directional Streamlit Components easier, we'v
 
 To build a Streamlit Component, you need the following installed in your development environment:
 
-- Python 3.9 - Python 3.13
+- Python 3.10 - Python 3.14
 - Streamlit
 - [nodejs](https://nodejs.org/en/)
 - [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/)

--- a/content/develop/tutorials/llms/llm-quickstart.md
+++ b/content/develop/tutorials/llms/llm-quickstart.md
@@ -28,7 +28,7 @@ Bonus: Deploy the app on Streamlit Community Cloud!
 
 ## Prerequisites
 
-- Python 3.9+
+- Python 3.10+
 - Streamlit
 - LangChain
 - [OpenAI API key](https://platform.openai.com/account/api-keys?ref=blog.streamlit.io)

--- a/content/get-started/installation/command-line.md
+++ b/content/get-started/installation/command-line.md
@@ -16,7 +16,7 @@ computer is properly set up. More specifically, you’ll need:
 
 1. **Python**
 
-   We support [version 3.9 to 3.13](https://www.python.org/downloads/).
+   We support [version 3.10 to 3.14](https://www.python.org/downloads/).
 
 1. **A Python environment manager** (recommended)
 

--- a/content/kb/FAQ/sanity-checks.md
+++ b/content/kb/FAQ/sanity-checks.md
@@ -15,7 +15,7 @@ guaranteeing compatibility with _at least_ the last three minor versions of Pyth
 As new versions of Python are released, we will try to be compatible with the new version as soon
 as possible, though frequently we are at the mercy of other Python packages to support these new versions as well.
 
-Streamlit currently supports versions 3.9, 3.10, 3.11, 3.12, and 3.13 of Python.
+Streamlit currently supports versions 3.10, 3.11, 3.12, 3.13, and 3.14 of Python.
 
 ## Check #1: Is Streamlit running?
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.12-slim
 
 COPY sources.list /etc/apt/sources.list
 


### PR DESCRIPTION
## Summary
- Drop Python 3.9 and add Python 3.14 to all supported version references across the docs
- Bump Docker base image from `python:3.9-slim` to `python:3.12-slim` in tutorial Dockerfiles and the internal `python/Dockerfile`
