### PR TITLE
1.56 follow-up: release notes st.iframe link and cheat sheet

### DIFF
--- a/content/develop/quick-references/api-cheat-sheet.md
+++ b/content/develop/quick-references/api-cheat-sheet.md
@@ -7,8 +7,6 @@ keywords: API cheat sheet, Streamlit API, widgets, layout, data display, utility
 
 # Streamlit API cheat sheet
 
-This is a summary of the docs for the latest version of Streamlit, [v1.55.0](https://pypi.org/project/streamlit/1.55.0/).
-
 <Masonry>
 
 <CodeTile featured>
@@ -94,6 +92,7 @@ st.subheader("My sub")
 st.code("for i in range(8): foo()")
 st.badge("New")
 st.html("<p>Hi!</p>")
+st.iframe("https://docs.streamlit.io", height=600)
 ```
 
 </CodeTile>
@@ -291,6 +290,7 @@ fragment_function()
 st.button("Click me")
 st.download_button("Download file", data)
 st.link_button("Go to gallery", url)
+st.menu_button("Export", options=["CSV", "JSON", "PDF"])
 st.page_link("app.py", label="Home")
 st.data_editor("Edit data", data)
 st.checkbox("I agree")

--- a/content/develop/quick-references/release-notes/2026.md
+++ b/content/develop/quick-references/release-notes/2026.md
@@ -16,7 +16,7 @@ _Release date: March 31, 2026_
 **Highlights**
 
 - 🍿 Introducing [`st.menu_button`](/develop/api-reference/widgets/st.menu_button) — a new widget that renders a dropdown button with a customizable popover container for building menus, toolbars, and action lists ([#13981](https://github.com/streamlit/streamlit/pull/13981), [#11409](https://github.com/streamlit/streamlit/issues/11409)).
-- 🎁 Introducing [`st.iframe`](/develop/api-reference/media/st.iframe) — embed external URLs or raw HTML content directly in your app using an iframe ([#14433](https://github.com/streamlit/streamlit/pull/14433), [#12977](https://github.com/streamlit/streamlit/issues/12977)).
+- 🎁 Introducing [`st.iframe`](/develop/api-reference/text/st.iframe) — embed external URLs or raw HTML content directly in your app using an iframe ([#14433](https://github.com/streamlit/streamlit/pull/14433), [#12977](https://github.com/streamlit/streamlit/issues/12977)).
 - 🔍 [`st.selectbox`](/develop/api-reference/widgets/st.selectbox) and [`st.multiselect`](/develop/api-reference/widgets/st.multiselect) now support a `filter_mode` parameter that lets users search and filter options by typing ([#14537](https://github.com/streamlit/streamlit/pull/14537), [#6160](https://github.com/streamlit/streamlit/issues/6160), [#7238](https://github.com/streamlit/streamlit/issues/7238)).
 
 **Notable Changes**

--- a/content/develop/quick-references/release-notes/_index.md
+++ b/content/develop/quick-references/release-notes/_index.md
@@ -28,7 +28,7 @@ _Release date: March 31, 2026_
 **Highlights**
 
 - 🍿 Introducing [`st.menu_button`](/develop/api-reference/widgets/st.menu_button) — a new widget that renders a dropdown button with a customizable popover container for building menus, toolbars, and action lists ([#13981](https://github.com/streamlit/streamlit/pull/13981), [#11409](https://github.com/streamlit/streamlit/issues/11409)).
-- 🎁 Introducing [`st.iframe`](/develop/api-reference/media/st.iframe) — embed external URLs or raw HTML content directly in your app using an iframe ([#14433](https://github.com/streamlit/streamlit/pull/14433), [#12977](https://github.com/streamlit/streamlit/issues/12977)).
+- 🎁 Introducing [`st.iframe`](/develop/api-reference/text/st.iframe) — embed external URLs or raw HTML content directly in your app using an iframe ([#14433](https://github.com/streamlit/streamlit/pull/14433), [#12977](https://github.com/streamlit/streamlit/issues/12977)).
 - 🔍 [`st.selectbox`](/develop/api-reference/widgets/st.selectbox) and [`st.multiselect`](/develop/api-reference/widgets/st.multiselect) now support a `filter_mode` parameter that lets users search and filter options by typing ([#14537](https://github.com/streamlit/streamlit/pull/14537), [#6160](https://github.com/streamlit/streamlit/issues/6160), [#7238](https://github.com/streamlit/streamlit/issues/7238)).
 
 **Notable Changes**


### PR DESCRIPTION
## Release notes
- Fix `st.iframe` doc links on the main changelog and [2026 release notes](/develop/quick-reference/release-notes/2026): use `/develop/api-reference/text/st.iframe` (not `/media/st.iframe`).

## API cheat sheet
- Add `st.iframe` and `st.menu_button` examples.
- Remove the PyPI version summary line under the cheat sheet title.

Made with [Cursor](https://cursor.com)