### PR TITLE
Fix first letter clipping in cheat sheet code blocks

### DIFF
--- a/components/blocks/codeTile.module.css
+++ b/components/blocks/codeTile.module.css
@@ -2,29 +2,25 @@
   @apply border-t border-t-white focus:outline-none focus-visible:outline-none;
   @apply text-gray-90 !important;
 }
-
 .Container button {
   @apply hidden;
 }
-
 .Container section {
   @apply m-0;
 }
-
 .Container section pre {
-  @apply m-0 p-0 pb-7 text-sm tracking-tight overflow-x-auto bg-white;
+  @apply m-0 p-0 pl-4 pb-7 text-sm tracking-tight overflow-x-auto bg-white;
   @apply text-gray-80;
+  mask-image: none;
+  -webkit-mask-image: none;
 }
-
 :global(.dark) .Container {
   @apply border-t-gray-100;
 }
-
 :global(.dark) .Container section pre {
   @apply bg-gray-100;
   @apply text-gray-40;
 }
-
 .Container h1,
 .Container h2,
 .Container h3,
@@ -34,26 +30,18 @@
 .Container p {
   @apply m-0 mt-4 mb-1 leading-relaxed font-bold;
 }
-
 .Container p {
   @apply text-xs mt-0 tracking-tight;
 }
-
-/* Size modifiers */
 .Full {
   @apply col-span-full;
 }
-
 .Half {
   @apply col-span-full sm:col-span-3;
 }
-
 .TwoThirds {
   @apply col-span-full md:col-span-3 lg:col-span-4;
 }
-
 .Third {
   @apply col-span-full md:col-span-3 lg:col-span-2;
 }
-
-/* Syntax highlighting is now handled globally via styles/syntax-highlighting.scss */


### PR DESCRIPTION
## 📚 Context
Fixes #1447

The first letter of every line in code blocks on the cheat sheet page 
was being visually clipped/hidden on Safari and Firefox on macOS.

## 🧠 Description of Changes
- Added `pl-4` (1rem left padding) to `.Container section pre` in 
  `components/blocks/codeTile.module.css`
- Added `mask-image: none` and `-webkit-mask-image: none` to remove 
  the left gradient overlay that was clipping the first character

**Current:**
_First letter of each code line is clipped (e.g. `pip` shows as `ip`)_

**Revised:**
_All characters visible with proper left padding_

## 💥 Impact
Size:
- [x] Small

## 🌐 References
- Fixes https://github.com/streamlit/docs/issues/1447

**Contribution License Agreement**
By submitting this pull request you agree that all contributions 
to this project are made under the Apache 2.0 license.