### PR TITLE
Remove incorrect docs credits from 1.57.0 release notes

### DIFF
--- a/content/develop/quick-references/release-notes/2026.md
+++ b/content/develop/quick-references/release-notes/2026.md
@@ -47,8 +47,6 @@ _Release date: April 29, 2026_
 - 🪰 Bug fix: [`st.bar_chart`](/develop/api-reference/charts/st.bar_chart) axis labels now correctly swap when `horizontal=True` ([#14866](https://github.com/streamlit/streamlit/pull/14866), [#14830](https://github.com/streamlit/streamlit/issues/14830)).
 - 🦠 Bug fix: [`st.text_area`](/develop/api-reference/widgets/st.text_area) with `height="content"` now sizes correctly on initial load ([#14884](https://github.com/streamlit/streamlit/pull/14884), [#14876](https://github.com/streamlit/streamlit/issues/14876)).
 - 🦟 Bug fix: [`st.file_uploader`](/develop/api-reference/widgets/st.file_uploader) no longer shows duplicate equivalent file extensions in the accepted types display ([#14552](https://github.com/streamlit/streamlit/pull/14552), [#11991](https://github.com/streamlit/streamlit/issues/11991)).
-- 📝 Updated documentation for dataframe programmatic selections ([#14616](https://github.com/streamlit/streamlit/pull/14616)). Thanks, [MathCatsAnd](https://github.com/MathCatsAnd)!
-- 📖 Updated documentation for audio and video column types in dataframes ([#14628](https://github.com/streamlit/streamlit/pull/14628)). Thanks, [MathCatsAnd](https://github.com/MathCatsAnd)!
 
 ## **Version 1.56.0**
 

--- a/content/develop/quick-references/release-notes/_index.md
+++ b/content/develop/quick-references/release-notes/_index.md
@@ -59,8 +59,6 @@ _Release date: April 29, 2026_
 - 🪰 Bug fix: [`st.bar_chart`](/develop/api-reference/charts/st.bar_chart) axis labels now correctly swap when `horizontal=True` ([#14866](https://github.com/streamlit/streamlit/pull/14866), [#14830](https://github.com/streamlit/streamlit/issues/14830)).
 - 🦠 Bug fix: [`st.text_area`](/develop/api-reference/widgets/st.text_area) with `height="content"` now sizes correctly on initial load ([#14884](https://github.com/streamlit/streamlit/pull/14884), [#14876](https://github.com/streamlit/streamlit/issues/14876)).
 - 🦟 Bug fix: [`st.file_uploader`](/develop/api-reference/widgets/st.file_uploader) no longer shows duplicate equivalent file extensions in the accepted types display ([#14552](https://github.com/streamlit/streamlit/pull/14552), [#11991](https://github.com/streamlit/streamlit/issues/11991)).
-- 📝 Updated documentation for dataframe programmatic selections ([#14616](https://github.com/streamlit/streamlit/pull/14616)). Thanks, [MathCatsAnd](https://github.com/MathCatsAnd)!
-- 📖 Updated documentation for audio and video column types in dataframes ([#14628](https://github.com/streamlit/streamlit/pull/14628)). Thanks, [MathCatsAnd](https://github.com/MathCatsAnd)!
 
 ## **Version 1.56.0**
 


### PR DESCRIPTION
## 📚 Context

Two bullets in the 1.57.0 release notes credited docs-site updates to MathCatsAnd, but those PRs were Streamlit library changes, not updates to docs.streamlit.io.

## 🧠 Description of Changes

Remove from **Other Changes** in both release notes pages:

- Updated documentation for dataframe programmatic selections (#14616)
- Updated documentation for audio and video column types in dataframes (#14628)

**Files:**

- `content/develop/quick-references/release-notes/2026.md`
- `content/develop/quick-references/release-notes/_index.md`

## 💥 Impact

Size:

- [x] Small
- [ ] Not small

## 🌐 References

- [ ] [Notion](...)

## Test plan

- [ ] Preview 1.57.0 section on release notes index and 2026 page — bullets removed


Made with [Cursor](https://cursor.com)