### PR TITLE
Fix CodeTile background

### DIFF
--- a/components/blocks/codeTile.js
+++ b/components/blocks/codeTile.js
@@ -19,6 +19,7 @@ const CodeTile = ({ children, size, featured }) => {
     <section
       className={classNames(
         styles.Container,
+        "code-light",
         tileSize || "",
         featured && styles.Featured
       )}

--- a/components/blocks/codeTile.module.css
+++ b/components/blocks/codeTile.module.css
@@ -16,6 +16,11 @@
   @apply text-gray-80;
 }
 
+.Container > section::before,
+.Container > section::after {
+  display: none;
+}
+
 :global(.dark) .Container {
   @apply border-t-gray-100;
 }


### PR DESCRIPTION
## 📚 Context
When the code blocks were reworked to add the headers, and exception was carved out to make them always dark in most places, but not the API ref cards. The cheat sheet fell through the cracks when this exception was implemented, adding and locking in the side fades, but not the text colors and background.

## 🧠 Description of Changes
As a minimal fix, this PR removes the side fades from the cheat sheet. This keeps the text without a distinct background and no margins to inset it from the headers.

A more complete fix might be to undo the forced dark mode for code blocks and then make all code block respect the theme and restyle the cheat sheet.

Note: There is no side fade on the blocks that have the horizontal scroll, so that's less clear, but it needs more spacing refinement to give it the horizontal space to accommodate the fades. Hence, minimal fix.

## 💥 Impact
<table>
<tr>
<th colspan=2>After:</th>
<td>
<img width="715" height="401" alt="Screenshot 2026-06-08 at 9 15 13 PM" src="https://github.com/user-attachments/assets/a0f9052e-ee7e-4cb3-b4ba-304fc8e10a8d" />
</td>
<td>
<img width="748" height="405" alt="Screenshot 2026-06-08 at 9 15 21 PM" src="https://github.com/user-attachments/assets/b900fef7-72ae-47a8-9446-801c1c4b9212" />
</td>
</tr>
<tr>
<th colspan=2>Before:</th>
<td>
<img width="822" height="414" alt="Screenshot 2026-06-08 at 9 14 38 PM" src="https://github.com/user-attachments/assets/51b46b9b-f184-49ef-8b0b-e7363d88c81a" />
</td>
<td>
<img width="818" height="417" alt="Screenshot 2026-06-08 at 9 14 55 PM" src="https://github.com/user-attachments/assets/6a40c707-088c-4ba3-97fb-621aa9b33a4c" />
</td>
</tr>
</table>

## 🌐 References
Closes #1447

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
