### PR TITLE
Add st.App to API reference and cheat sheet

### DIFF
--- a/content/develop/api-reference/_index.md
+++ b/content/develop/api-reference/_index.md
@@ -1996,7 +1996,25 @@ rain(emoji="🎈", font_size=54,
 
 ## App logic and configuration
 
-### Authentication and user info
+### App server
+
+<br />
+
+<TileContainer>
+<RefCard href="/develop/api-reference/server/st.app">
+
+<h4>App</h4>
+
+Configure the underlying Starlette server for your app.
+
+```python
+app = st.App()
+```
+
+</RefCard>
+</TileContainer>
+
+### Authentication
 
 <br />
 

--- a/content/develop/api-reference/server/_index.md
+++ b/content/develop/api-reference/server/_index.md
@@ -1,0 +1,22 @@
+---
+title: App server
+slug: /develop/api-reference/server
+description: st.App lets you configure the underlying Starlette server for your Streamlit app, enabling custom HTTP routes, middleware, lifecycle hooks, and ASGI integration.
+keywords: server, st.App, ASGI, Starlette, middleware, routes, lifecycle, configuration
+---
+
+# App server
+
+<TileContainer>
+<RefCard href="/develop/api-reference/server/st.app">
+
+<h4>App</h4>
+
+Configure the underlying Starlette server for your app.
+
+```python
+app = st.App()
+```
+
+</RefCard>
+</TileContainer>

--- a/content/develop/api-reference/server/st.app.md
+++ b/content/develop/api-reference/server/st.app.md
@@ -1,0 +1,8 @@
+---
+title: st.App
+slug: /develop/api-reference/server/st.app
+description: st.App lets you configure the underlying Starlette server for your Streamlit app, enabling custom HTTP routes, middleware, lifecycle hooks, and ASGI integration.
+keywords: st.App, ASGI, Starlette, server, middleware, routes, lifecycle, configuration
+---
+
+<Autofunction function="streamlit.App" />

--- a/content/develop/api-reference/user/_index.md
+++ b/content/develop/api-reference/user/_index.md
@@ -1,11 +1,11 @@
 ---
-title: Authentication and user info
+title: Authentication
 slug: /develop/api-reference/user
 description: Add user authentication and personalization in your apps with login, logout, and user information access.
 keywords: authentication, user info, login, logout, user authentication, identity provider, personalized apps, user session, st.user, st.login, st.logout
 ---
 
-# Authentication and user info
+# Authentication
 
 Streamlit provides native support for user authentication so you can personalize your apps. You can also directly read headers and cookies.
 

--- a/content/develop/quick-references/api-cheat-sheet.md
+++ b/content/develop/quick-references/api-cheat-sheet.md
@@ -552,4 +552,15 @@ st.context.url
 ```
 
 </CodeTile>
+
+<CodeTile>
+
+#### Configure the app server
+
+```python hideHeader
+# Expose the underlying Starlette app
+app = st.App()
+```
+
+</CodeTile>
 </Masonry>

--- a/content/menu.md
+++ b/content/menu.md
@@ -443,13 +443,17 @@ site_menu:
   - category: Develop / API reference / Third-party components
     url: https://streamlit.io/components
   - category: Develop / API reference / APPLICATION LOGIC
-  - category: Develop / API reference / Authentication and user info
+  - category: Develop / API reference / App server
+    url: /develop/api-reference/server
+  - category: Develop / API reference / App server / st.App
+    url: /develop/api-reference/server/st.app
+  - category: Develop / API reference / Authentication
     url: /develop/api-reference/user
-  - category: Develop / API reference / Authentication and user info / st.login
+  - category: Develop / API reference / Authentication / st.login
     url: /develop/api-reference/user/st.login
-  - category: Develop / API reference / Authentication and user info / st.logout
+  - category: Develop / API reference / Authentication / st.logout
     url: /develop/api-reference/user/st.logout
-  - category: Develop / API reference / Authentication and user info / st.user
+  - category: Develop / API reference / Authentication / st.user
     url: /develop/api-reference/user/st.user
   - category: Develop / API reference / Navigation and pages
     url: /develop/api-reference/navigation


### PR DESCRIPTION
## Summary
- Add a new "Server" section under "App logic and configuration" in the API reference index
- Create `content/develop/api-reference/server/_index.md` with the `st.App` card
- Create `content/develop/api-reference/server/st.App.md` with the `<Autofunction>` for `streamlit.App`
- Add the Server section and `st.App` entry to `content/menu.md` for sidebar navigation

## Test plan
- [ ] Verify the "Server" section appears in the API reference index between "Custom Components" and "Configuration"
- [ ] Verify the `st.App` card links correctly to its detail page
- [ ] Verify the sidebar nav shows "Server" and "st.App" in the correct position

Made with [Cursor](https://cursor.com)