### PR TITLE
Add streamlit skills to CLI documentation

### DIFF
--- a/content/develop/api-reference/command-line/_index.md
+++ b/content/develop/api-reference/command-line/_index.md
@@ -20,6 +20,7 @@ and help you diagnose and fix issues.
 - [`streamlit help`](/develop/api-reference/cli/help): Show the available CLI commands.
 - [`streamlit init`](/develop/api-reference/cli/init): Create the files for a new Streamlit app.
 - [`streamlit run`](/develop/api-reference/cli/run): Run your Streamlit app.
+- [`streamlit skills`](/develop/api-reference/cli/skills): Install Streamlit AI-agent skills.
 - [`streamlit version`](/develop/api-reference/cli/version): Show the version of Streamlit.
 
 ### Run your app

--- a/content/develop/api-reference/command-line/skills.md
+++ b/content/develop/api-reference/command-line/skills.md
@@ -1,0 +1,55 @@
+---
+title: streamlit skills
+slug: /develop/api-reference/cli/skills
+description: streamlit skills installs bundled Streamlit AI-agent skills to help AI agents build better Streamlit apps.
+keywords: streamlit skills, cli, command line, ai agent, skills, install skills, agent skills
+---
+
+## `$ streamlit skills`
+
+This command installs Streamlit AI-agent skills to help AI agents build better Streamlit apps.
+
+### Syntax
+
+```
+streamlit skills [OPTIONS]
+```
+
+### Options
+
+| Option           | Description                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------ |
+| `-g`, `--global` | Install globally in the user directory, making skills available across all projects. |
+| `-y`, `--yes`    | Skip confirmation prompts (non-interactive install).                                 |
+
+### Description
+
+By default, `streamlit skills` runs in **project mode**: it creates symlinks from `.agents/skills/` and `.claude/skills/` to the bundled skills in your Streamlit installation. Skills stay in sync automatically when Streamlit is upgraded.
+
+With `--global`, it installs a meta skill to the user directory that is available across all projects.
+
+### Examples
+
+- Install skills for your current project (interactive):
+
+  ```bash
+  streamlit skills
+  ```
+
+- Install skills globally across all projects (interactive):
+
+  ```bash
+  streamlit skills --global
+  ```
+
+- Install skills for your current project without confirmation prompts:
+
+  ```bash
+  streamlit skills --yes
+  ```
+
+- Install skills globally without confirmation prompts:
+
+  ```bash
+  streamlit skills -g -y
+  ```

--- a/content/menu.md
+++ b/content/menu.md
@@ -603,6 +603,8 @@ site_menu:
     url: /develop/api-reference/cli/init
   - category: Develop / API reference / Command line / streamlit run
     url: /develop/api-reference/cli/run
+  - category: Develop / API reference / Command line / streamlit skills
+    url: /develop/api-reference/cli/skills
   - category: Develop / API reference / Command line / streamlit version
     url: /develop/api-reference/cli/version
 


### PR DESCRIPTION
## Summary
- Add documentation for `streamlit skills` (introduced in 1.58) under the CLI reference
- Create `content/develop/api-reference/command-line/skills.md` with syntax, options, and examples
- Add entry to the CLI index (`command-line/_index.md`)
- Add entry to `content/menu.md` for sidebar nav

Made with [Cursor](https://cursor.com)