### PR TITLE
Add example app source files for st.pagination

### DIFF
--- a/python/api-examples-source/widget.pagination.py
+++ b/python/api-examples-source/widget.pagination.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+page = st.pagination(num_pages=10)
+st.write(f"Showing page {page}")

--- a/python/api-examples-source/widget.pagination_dataframe.py
+++ b/python/api-examples-source/widget.pagination_dataframe.py
@@ -1,0 +1,15 @@
+import streamlit as st
+import pandas as pd
+
+df = pd.DataFrame({"A": range(100), "B": range(100, 200)})
+rows_per_page = 10
+total_pages = (len(df) + rows_per_page - 1) // rows_per_page
+
+# Use placeholders to show dataframe above pagination
+dataframe_slot = st.empty()
+with st.container(horizontal_alignment="right"):
+    page = st.pagination(num_pages=total_pages)
+
+start_idx = (page - 1) * rows_per_page
+end_idx = start_idx + rows_per_page
+dataframe_slot.dataframe(df.iloc[start_idx:end_idx])


### PR DESCRIPTION
## Summary

- Add `widget.pagination.py` — basic usage example (for `doc-pagination.streamlit.app`)
- Add `widget.pagination_dataframe.py` — paginated dataframe example (for `doc-pagination-dataframe.streamlit.app`)

These are the source files for the two embedded app demos referenced in the `st.pagination` docstring via `.. output::` directives. Without these files deployed as Community Cloud apps, the iframes on the docs page fail to load.

The code is taken directly from the Examples section of the `pagination()` docstring in `lib/streamlit/elements/widgets/pagination.py`.