### PR TITLE
fix: update broken link to renamed build-conversational-apps tutorial

### DIFF
--- a/content/develop/api-reference/chat/chat-input.md
+++ b/content/develop/api-reference/chat/chat-input.md
@@ -7,7 +7,7 @@ keywords: chat_input, chat, input, widget, conversational, llm, chatbot, interac
 
 <Tip>
 
-Read the [Build a basic LLM chat app](/develop/tutorials/llms/build-conversational-apps) tutorial to learn how to use `st.chat_message` and `st.chat_input` to build chat-based apps.
+Read the [Build a basic LLM chat app](/develop/tutorials/chat-and-llm-apps/build-conversational-apps) tutorial to learn how to use `st.chat_message` and `st.chat_input` to build chat-based apps.
 
 </Tip>
 

--- a/content/develop/api-reference/chat/chat-message.md
+++ b/content/develop/api-reference/chat/chat-message.md
@@ -7,7 +7,7 @@ keywords: chat_message, chat, message, container, conversational, llm, chatbot, 
 
 <Tip>
 
-Read the [Build a basic LLM chat app](/develop/tutorials/llms/build-conversational-apps) tutorial to learn how to use `st.chat_message` and `st.chat_input` to build chat-based apps.
+Read the [Build a basic LLM chat app](/develop/tutorials/chat-and-llm-apps/build-conversational-apps) tutorial to learn how to use `st.chat_message` and `st.chat_input` to build chat-based apps.
 
 </Tip>
 

--- a/content/develop/quick-references/api-cheat-sheet.md
+++ b/content/develop/quick-references/api-cheat-sheet.md
@@ -357,7 +357,7 @@ with st.container():
     st.chat_input("Say something")
 ```
 
-Learn how to [Build a basic LLM chat app](/develop/tutorials/llms/build-conversational-apps)
+Learn how to [Build a basic LLM chat app](/develop/tutorials/chat-and-llm-apps/build-conversational-apps)
 
 </CodeTile>
 

--- a/content/develop/quick-references/release-notes/2023.md
+++ b/content/develop/quick-references/release-notes/2023.md
@@ -209,7 +209,7 @@ _Release date: June 27, 2023_
 
 **Highlights**
 
-- 💬 Introducing `st.chat_message` and `st.chat_input` — two new [chat elements](/develop/api-reference/chat) that let you build conversational apps. Learn how to use these features in your LLM-powered chat apps in our [tutorial](/develop/tutorials/llms/build-conversational-apps).
+- 💬 Introducing `st.chat_message` and `st.chat_input` — two new [chat elements](/develop/api-reference/chat) that let you build conversational apps. Learn how to use these features in your LLM-powered chat apps in our [tutorial](/develop/tutorials/chat-and-llm-apps/build-conversational-apps).
 - 💾 Streamlit's caching decorators now allow you to customize Streamlit's hashing of input parameters with the keyword-only argument [`hash_funcs`](/develop/concepts/architecture/caching#the-hash_funcs-parameter).
 
 **Notable Changes**


### PR DESCRIPTION
## 📚 Context
The "Build a basic LLM chat app" tutorial was moved from `/develop/tutorials/llms/` to `/develop/tutorials/chat-and-llm-apps/`, but the old URL was still referenced in 4 other pages, resulting in broken links (confirmed 404 on the live site).

## 🧠 Description of Changes
Updated the broken link `/develop/tutorials/llms/build-conversational-apps` to the correct current URL `/develop/tutorials/chat-and-llm-apps/build-conversational-apps` in the following files:

- content/develop/api-reference/chat/chat-message.md
- content/develop/api-reference/chat/chat-input.md
- content/develop/quick-references/api-cheat-sheet.md
- content/develop/quick-references/release-notes/2023.md

## 💥 Impact
Size:
- [x] Small
- [ ] Not small