### PR TITLE
Remove software-properties-common from Docker tutorial

### DIFF
--- a/content/deploy/tutorials/docker.md
+++ b/content/deploy/tutorials/docker.md
@@ -60,7 +60,6 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y \
     build-essential \
     curl \
-    software-properties-common \
     git \
     && rm -rf /var/lib/apt/lists/*
 
@@ -112,7 +111,6 @@ Let’s walk through each line of the Dockerfile :
    RUN apt-get update && apt-get install -y \
        build-essential \
        curl \
-       software-properties-common \
        git \
        && rm -rf /var/lib/apt/lists/*
    ```


### PR DESCRIPTION
Fixes #1493. This package is unavailable on python:3.12-slim (Debian 13/Trixie) and is not needed for the tutorial.

## 📚 Context
The `python:3.12-slim` base image is now based on Debian 13 (Trixie), where `software-properties-common` is no longer available as a package. Following the current Docker tutorial as-written causes the build to fail with an "Unable to locate package" error.

## 🧠 Description of Changes
Removed `software-properties-common \` from both Dockerfile code blocks in `content/deploy/tutorials/docker.md` (the main example, and the walkthrough step 3 example). This package was not used anywhere else in the tutorial, so removing it does not affect functionality.

## 💥 Impact
Size:
- [x] Small
- [ ] Not small

**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.