### PR TITLE
Streamlit 1.60.0 release docs

### DIFF
--- a/content/develop/quick-references/release-notes/2026.md
+++ b/content/develop/quick-references/release-notes/2026.md
@@ -28,7 +28,7 @@ _Release date: July 21, 2026_
 - 📐 The `gap` parameter in [`st.columns`](/develop/api-reference/layout/st.columns) now accepts integer pixel values in addition to the existing string presets ([#15850](https://github.com/streamlit/streamlit/pull/15850), [#13005](https://github.com/streamlit/streamlit/issues/13005)).
 - 🎨 [`st.data_editor`](/develop/api-reference/data/st.data_editor) now uses `key` as the primary row identity when `num_rows="fixed"`, improving stability when the underlying data changes ([#15884](https://github.com/streamlit/streamlit/pull/15884)).
 - 📈 Zero delta values in [`st.metric`](/develop/api-reference/data/st.metric) are now displayed in neutral grey instead of green or red, so a zero change no longer implies a positive or negative direction ([#15790](https://github.com/streamlit/streamlit/pull/15790), [#15005](https://github.com/streamlit/streamlit/issues/15005)).
-- 🖌 Vega-Lite chart action buttons (fullscreen, download, etc.) are now integrated into the native Streamlit toolbar instead of the Vega-Lite overlay ([#15806](https://github.com/streamlit/streamlit/pull/15806)).
+- 🖌 Vega-Lite chart action buttons (download, copy spec to clipboard) are now integrated into the native Streamlit toolbar; the Vega-Lite action menu overlay has been removed ([#15806](https://github.com/streamlit/streamlit/pull/15806)).
 
 **Other Changes**
 
@@ -39,7 +39,7 @@ _Release date: July 21, 2026_
 - 🐝 Bug fix: `st.selectbox` now virtualizes long dropdown option lists for better rendering performance ([#15870](https://github.com/streamlit/streamlit/pull/15870), [#15863](https://github.com/streamlit/streamlit/issues/15863)).
 - 🐞 Bug fix: Viewport gutter is now preserved around dialogs on narrow screens ([#15875](https://github.com/streamlit/streamlit/pull/15875)).
 - 🕷️ Bug fix: React Aria dialog overlays now stack correctly when multiple dialogs are open ([#15876](https://github.com/streamlit/streamlit/pull/15876), [#15859](https://github.com/streamlit/streamlit/issues/15859)).
-- 🪳 Bug fix: The spurious "Missing Submit Button" warning is no longer shown for forms that have a submit button in a conditionally rendered block ([#15889](https://github.com/streamlit/streamlit/pull/15889), [#14247](https://github.com/streamlit/streamlit/issues/14247)).
+- 🪳 Bug fix: The "Missing Submit Button" warning has been removed ([#15889](https://github.com/streamlit/streamlit/pull/15889), [#14247](https://github.com/streamlit/streamlit/issues/14247)).
 - 🪰 Bug fix: `st.tabs` panels no longer stack visually after a widget rerun ([#15894](https://github.com/streamlit/streamlit/pull/15894), [#15893](https://github.com/streamlit/streamlit/issues/15893)).
 - 🦠 Bug fix: `st.metric` area chart fill baseline is now drawn correctly ([#15907](https://github.com/streamlit/streamlit/pull/15907)).
 - 🦟 Bug fix: `run_every` auto-rerun timers are now deduplicated per fragment, preventing duplicate reruns ([#15912](https://github.com/streamlit/streamlit/pull/15912)).

--- a/content/develop/quick-references/release-notes/2026.md
+++ b/content/develop/quick-references/release-notes/2026.md
@@ -9,6 +9,59 @@ keywords: changelog, release notes, version history
 
 This page contains release notes for Streamlit versions released in 2026. For the latest version of Streamlit, see [Release notes](/develop/quick-reference/release-notes).
 
+## **Version 1.60.0**
+
+_Release date: July 21, 2026_
+
+**Highlights**
+
+- ✨ You can now disable bulk data export app-wide with the new `client.disableDataExport` config option. When set, the CSV export button is hidden for [`st.dataframe`](/develop/api-reference/data/st.dataframe), [`st.data_editor`](/develop/api-reference/data/st.data_editor), and chart table views, and clipboard copy is disabled for read-only dataframes ([#15910](https://github.com/streamlit/streamlit/pull/15910), [#8402](https://github.com/streamlit/streamlit/issues/8402), [#11358](https://github.com/streamlit/streamlit/issues/11358)).
+
+**Notable Changes**
+
+- 🔒 Security hardening (**breaking changes**):
+  - Streamlit now rejects host messages that appear to originate from child iframes or injected scripts, preventing origin spoofing (CWE-346) ([#15800](https://github.com/streamlit/streamlit/pull/15800)).
+  - Client-supplied query strings are now capped at 512 KiB and 1,000 fields, guarding against unbounded resource allocation (CWE-770) ([#15803](https://github.com/streamlit/streamlit/pull/15803)).
+  - New `server.maxWidgetStateSize` config option (default 25 MB) limits the widget state payload a client can send per script rerun, hardening against oversized widget and custom-component payloads ([#15804](https://github.com/streamlit/streamlit/pull/15804)).
+- 📊 [`st.dataframe`](/develop/api-reference/data/st.dataframe) now preserves row selections when the user sorts the table ([#16020](https://github.com/streamlit/streamlit/pull/16020), [#8851](https://github.com/streamlit/streamlit/issues/8851)).
+- 🎛 [`st.tabs`](/develop/api-reference/layout/st.tabs) has a new `height` parameter to set a fixed pixel height for the tab panel area ([#15847](https://github.com/streamlit/streamlit/pull/15847), [#12217](https://github.com/streamlit/streamlit/issues/12217)).
+- 📐 The `gap` parameter in [`st.columns`](/develop/api-reference/layout/st.columns) now accepts integer pixel values in addition to the existing string presets ([#15850](https://github.com/streamlit/streamlit/pull/15850), [#13005](https://github.com/streamlit/streamlit/issues/13005)).
+- 🎨 [`st.data_editor`](/develop/api-reference/data/st.data_editor) now uses `key` as the primary row identity when `num_rows="fixed"`, improving stability when the underlying data changes ([#15884](https://github.com/streamlit/streamlit/pull/15884)).
+- 📈 Zero delta values in [`st.metric`](/develop/api-reference/data/st.metric) are now displayed in neutral grey instead of green or red, so a zero change no longer implies a positive or negative direction ([#15790](https://github.com/streamlit/streamlit/pull/15790), [#15005](https://github.com/streamlit/streamlit/issues/15005)).
+- 🖌 Vega-Lite chart action buttons (fullscreen, download, etc.) are now integrated into the native Streamlit toolbar instead of the Vega-Lite overlay ([#15806](https://github.com/streamlit/streamlit/pull/15806)).
+
+**Other Changes**
+
+- 🐛 Bug fix: Non-finite float values (e.g. `NaN`, `Inf`) in URL query params are now rejected to prevent unexpected behavior ([#15799](https://github.com/streamlit/streamlit/pull/15799)).
+- 🦋 Bug fix: Dangerous URLs in Graphviz link attributes are now sanitized ([#15819](https://github.com/streamlit/streamlit/pull/15819)).
+- 🪲 Bug fix: HTML in PyDeck chart tooltip interpolations is now escaped to prevent injection ([#15820](https://github.com/streamlit/streamlit/pull/15820)).
+- 🐜 Bug fix: Dangerous URLs in `st.link_button` and `st.image` are now sanitized ([#15851](https://github.com/streamlit/streamlit/pull/15851)).
+- 🐝 Bug fix: `st.selectbox` now virtualizes long dropdown option lists for better rendering performance ([#15870](https://github.com/streamlit/streamlit/pull/15870), [#15863](https://github.com/streamlit/streamlit/issues/15863)).
+- 🐞 Bug fix: Viewport gutter is now preserved around dialogs on narrow screens ([#15875](https://github.com/streamlit/streamlit/pull/15875)).
+- 🕷️ Bug fix: React Aria dialog overlays now stack correctly when multiple dialogs are open ([#15876](https://github.com/streamlit/streamlit/pull/15876), [#15859](https://github.com/streamlit/streamlit/issues/15859)).
+- 🪳 Bug fix: The spurious "Missing Submit Button" warning is no longer shown for forms that have a submit button in a conditionally rendered block ([#15889](https://github.com/streamlit/streamlit/pull/15889), [#14247](https://github.com/streamlit/streamlit/issues/14247)).
+- 🪰 Bug fix: `st.tabs` panels no longer stack visually after a widget rerun ([#15894](https://github.com/streamlit/streamlit/pull/15894), [#15893](https://github.com/streamlit/streamlit/issues/15893)).
+- 🦠 Bug fix: `st.metric` area chart fill baseline is now drawn correctly ([#15907](https://github.com/streamlit/streamlit/pull/15907)).
+- 🦟 Bug fix: `run_every` auto-rerun timers are now deduplicated per fragment, preventing duplicate reruns ([#15912](https://github.com/streamlit/streamlit/pull/15912)).
+- 🦂 Bug fix: Redundant keyboard tab stop removed from the file uploader dropzone for better accessibility ([#15928](https://github.com/streamlit/streamlit/pull/15928)).
+- 🦗 Bug fix: Auto-rerun correctly stops when a fragment is evicted ([#15932](https://github.com/streamlit/streamlit/pull/15932)).
+- 🕸️ Bug fix: A PyArrow 25 thread initialization crash is now avoided ([#15947](https://github.com/streamlit/streamlit/pull/15947)).
+- 🐌 Bug fix: Missing `httpx` error message for the auth extra is now surfaced correctly ([#15864](https://github.com/streamlit/streamlit/pull/15864)).
+- 🦎 Bug fix: `st.App` with programmatic secrets now correctly honors the `expose_tokens` setting ([#15865](https://github.com/streamlit/streamlit/pull/15865)).
+- 🦀 Bug fix: `RuntimeError: reentrant call inside _io.BufferedWriter` on Ctrl+C is fixed ([#15949](https://github.com/streamlit/streamlit/pull/15949), [#15740](https://github.com/streamlit/streamlit/issues/15740)). Thanks, [chang-pro](https://github.com/chang-pro)!
+- 👽 Bug fix: File watcher no longer crashes on Windows drive-root paths ([#15951](https://github.com/streamlit/streamlit/pull/15951), [#12731](https://github.com/streamlit/streamlit/issues/12731)).
+- 👻 Bug fix: Overlay stacking and dismissal inside popovers works correctly ([#15961](https://github.com/streamlit/streamlit/pull/15961)).
+- 🐛 Bug fix: Mobile keyboard no longer appears for `st.selectbox` when `filter_mode=None` ([#15962](https://github.com/streamlit/streamlit/pull/15962)).
+- 🦋 Bug fix: `st.selectbox` "No results" empty state is now styled correctly ([#15967](https://github.com/streamlit/streamlit/pull/15967)).
+- 🪲 Bug fix: `IndexError` in number formatting for values ≥ 1 quadrillion is fixed ([#15971](https://github.com/streamlit/streamlit/pull/15971)). Thanks, [eeshsaxena](https://github.com/eeshsaxena)!
+- 🐜 Bug fix: Type-to-search in `st.selectbox` is restored ([#15996](https://github.com/streamlit/streamlit/pull/15996), [#15985](https://github.com/streamlit/streamlit/issues/15985)).
+- 🐝 Bug fix: Typing a value in `st.number_input` inside a form now correctly submits on the first Enter press ([#16013](https://github.com/streamlit/streamlit/pull/16013), [#13751](https://github.com/streamlit/streamlit/issues/13751)).
+- 🐞 Bug fix: Hashing fallback warning messages are now more informative ([#16040](https://github.com/streamlit/streamlit/pull/16040), [#10957](https://github.com/streamlit/streamlit/issues/10957)).
+- 🕷️ Bug fix: Inconsistent checkbox margin in a horizontal container within a column is fixed ([#16060](https://github.com/streamlit/streamlit/pull/16060), [#13162](https://github.com/streamlit/streamlit/issues/13162)).
+- 🪳 Bug fix: Widgets inside a popover that is itself inside a dialog are now clickable ([#16067](https://github.com/streamlit/streamlit/pull/16067), [#16005](https://github.com/streamlit/streamlit/issues/16005)).
+- 🪰 Bug fix: `st.echo` output now correctly includes decorators on the displayed function ([#16068](https://github.com/streamlit/streamlit/pull/16068), [#9252](https://github.com/streamlit/streamlit/issues/9252)).
+- 🔩 Internal `TTLCache` implementation replaces the `cachetools` third-party dependency ([#16014](https://github.com/streamlit/streamlit/pull/16014)).
+
 ## **Version 1.59.0**
 
 _Release date: July 6, 2026_

--- a/content/develop/quick-references/release-notes/_index.md
+++ b/content/develop/quick-references/release-notes/_index.md
@@ -40,7 +40,7 @@ _Release date: July 21, 2026_
 - 📐 The `gap` parameter in [`st.columns`](/develop/api-reference/layout/st.columns) now accepts integer pixel values in addition to the existing string presets ([#15850](https://github.com/streamlit/streamlit/pull/15850), [#13005](https://github.com/streamlit/streamlit/issues/13005)).
 - 🎨 [`st.data_editor`](/develop/api-reference/data/st.data_editor) now uses `key` as the primary row identity when `num_rows="fixed"`, improving stability when the underlying data changes ([#15884](https://github.com/streamlit/streamlit/pull/15884)).
 - 📈 Zero delta values in [`st.metric`](/develop/api-reference/data/st.metric) are now displayed in neutral grey instead of green or red, so a zero change no longer implies a positive or negative direction ([#15790](https://github.com/streamlit/streamlit/pull/15790), [#15005](https://github.com/streamlit/streamlit/issues/15005)).
-- 🖌 Vega-Lite chart action buttons (fullscreen, download, etc.) are now integrated into the native Streamlit toolbar instead of the Vega-Lite overlay ([#15806](https://github.com/streamlit/streamlit/pull/15806)).
+- 🖌 Vega-Lite chart action buttons (download, copy spec to clipboard) are now integrated into the native Streamlit toolbar; the Vega-Lite action menu overlay has been removed ([#15806](https://github.com/streamlit/streamlit/pull/15806)).
 
 **Other Changes**
 
@@ -51,7 +51,7 @@ _Release date: July 21, 2026_
 - 🐝 Bug fix: `st.selectbox` now virtualizes long dropdown option lists for better rendering performance ([#15870](https://github.com/streamlit/streamlit/pull/15870), [#15863](https://github.com/streamlit/streamlit/issues/15863)).
 - 🐞 Bug fix: Viewport gutter is now preserved around dialogs on narrow screens ([#15875](https://github.com/streamlit/streamlit/pull/15875)).
 - 🕷️ Bug fix: React Aria dialog overlays now stack correctly when multiple dialogs are open ([#15876](https://github.com/streamlit/streamlit/pull/15876), [#15859](https://github.com/streamlit/streamlit/issues/15859)).
-- 🪳 Bug fix: The spurious "Missing Submit Button" warning is no longer shown for forms that have a submit button in a conditionally rendered block ([#15889](https://github.com/streamlit/streamlit/pull/15889), [#14247](https://github.com/streamlit/streamlit/issues/14247)).
+- 🪳 Bug fix: The "Missing Submit Button" warning has been removed ([#15889](https://github.com/streamlit/streamlit/pull/15889), [#14247](https://github.com/streamlit/streamlit/issues/14247)).
 - 🪰 Bug fix: `st.tabs` panels no longer stack visually after a widget rerun ([#15894](https://github.com/streamlit/streamlit/pull/15894), [#15893](https://github.com/streamlit/streamlit/issues/15893)).
 - 🦠 Bug fix: `st.metric` area chart fill baseline is now drawn correctly ([#15907](https://github.com/streamlit/streamlit/pull/15907)).
 - 🦟 Bug fix: `run_every` auto-rerun timers are now deduplicated per fragment, preventing duplicate reruns ([#15912](https://github.com/streamlit/streamlit/pull/15912)).

--- a/content/develop/quick-references/release-notes/_index.md
+++ b/content/develop/quick-references/release-notes/_index.md
@@ -21,62 +21,58 @@ pip install --upgrade streamlit
 
 </Tip>
 
-## **Version 1.59.0 (latest)**
+## **Version 1.60.0 (latest)**
 
-_Release date: July 6, 2026_
+_Release date: July 21, 2026_
 
 **Highlights**
 
-- ✨ Introducing [`ButtonColumn`](/develop/api-reference/data/st.column_config/st.column_config.buttoncolumn) — a new column type for [`st.dataframe`](/develop/api-reference/data/st.dataframe) and [`st.data_editor`](/develop/api-reference/data/st.data_editor) that renders clickable buttons inside table cells, letting users trigger actions directly from a row ([#14544](https://github.com/streamlit/streamlit/pull/14544), [#7015](https://github.com/streamlit/streamlit/issues/7015)).
-- 📊 [`st.dataframe`](/develop/api-reference/data/st.dataframe) has a new column statistics submenu — click the dropdown icon in any column header to see per-column summary stats ([#14307](https://github.com/streamlit/streamlit/pull/14307), [#13148](https://github.com/streamlit/streamlit/issues/13148)).
-- 🍿 Introducing [`st.skeleton`](/develop/api-reference/status/st.skeleton) — a new element that renders animated loading placeholders, making it easy to give users visual feedback while content is loading ([#15169](https://github.com/streamlit/streamlit/pull/15169), [#8032](https://github.com/streamlit/streamlit/issues/8032)).
-- 🎨 Introducing [`st.mermaid_chart`](/develop/api-reference/charts/st.mermaid_chart) — render Mermaid diagrams directly in your app, letting you embed flowcharts, sequence diagrams, and more. Mermaid also works from [`st.markdown`](/develop/api-reference/text/st.markdown) ([#14022](https://github.com/streamlit/streamlit/pull/14022), [#10721](https://github.com/streamlit/streamlit/issues/10721)).
+- ✨ You can now disable bulk data export app-wide with the new `client.disableDataExport` config option. When set, the CSV export button is hidden for [`st.dataframe`](/develop/api-reference/data/st.dataframe), [`st.data_editor`](/develop/api-reference/data/st.data_editor), and chart table views, and clipboard copy is disabled for read-only dataframes ([#15910](https://github.com/streamlit/streamlit/pull/15910), [#8402](https://github.com/streamlit/streamlit/issues/8402), [#11358](https://github.com/streamlit/streamlit/issues/11358)).
 
 **Notable Changes**
 
-- 🎛 [`st.chat_input`](/develop/api-reference/chat/st.chat_input) has a new `submit_mode` parameter that controls widget behavior after the user submits a message, e.g. showing a stop button or disabling the chat input ([#14344](https://github.com/streamlit/streamlit/pull/14344), [#8323](https://github.com/streamlit/streamlit/issues/8323), [#11854](https://github.com/streamlit/streamlit/issues/11854)).
-- 📋 [`st.dataframe`](/develop/api-reference/data/st.dataframe) and [`st.data_editor`](/develop/api-reference/data/st.data_editor) support a new [`MarkdownColumn`](/develop/api-reference/data/st.column_config/st.column_config.markdowncolumn) type in `st.column_config` that renders Markdown text inside table cells ([#13931](https://github.com/streamlit/streamlit/pull/13931), [#10211](https://github.com/streamlit/streamlit/issues/10211)).
-- 🔗 [`st.markdown`](/develop/api-reference/text/st.markdown) has a new `anchors` parameter for adding linkable heading anchors to Markdown content ([#15722](https://github.com/streamlit/streamlit/pull/15722), [#13913](https://github.com/streamlit/streamlit/issues/13913)).
-- 💻 You can now launch Streamlit apps directly with `python app.py` or `uv run app.py` using the new `App.run()` entry point — no more `streamlit run` required ([#15563](https://github.com/streamlit/streamlit/pull/15563), [#9450](https://github.com/streamlit/streamlit/issues/9450), [#11420](https://github.com/streamlit/streamlit/issues/11420)).
-- 🧩 [`st.fragment`](/develop/api-reference/execution-flow/st.fragment) can now write to containers defined outside the fragment. Fragments can update any part of your app — including elements created before the fragment — without triggering a full rerun ([#15623](https://github.com/streamlit/streamlit/pull/15623), [#15620](https://github.com/streamlit/streamlit/pull/15620), [#10481](https://github.com/streamlit/streamlit/issues/10481)).
-- 📎 [`st.chat_input`](/develop/api-reference/chat/st.chat_input) now supports pasting files directly into the input field ([#15558](https://github.com/streamlit/streamlit/pull/15558), [#10307](https://github.com/streamlit/streamlit/issues/10307)).
-- 🤖 [`st.write_stream`](/develop/api-reference/write-magic/st.write_stream) now supports OpenAI Responses API streams in addition to the existing Chat Completions streams ([#15559](https://github.com/streamlit/streamlit/pull/15559), [#11061](https://github.com/streamlit/streamlit/issues/11061)).
-- 🔒 [`st.set_page_config`](/develop/api-reference/configuration/st.set_page_config) supports a new `"locked"` option for `initial_sidebar_state` that prevents users from toggling the sidebar open or closed ([#15459](https://github.com/streamlit/streamlit/pull/15459), [#15411](https://github.com/streamlit/streamlit/issues/15411)).
-- 💅 Widgets have a new `persist_state` parameter for finer control over how widget state is preserved across reruns ([#15645](https://github.com/streamlit/streamlit/pull/15645)).
-- 📷 [`st.camera_input`](/develop/api-reference/widgets/st.camera_input) has a new `resolution` parameter to control the captured image resolution ([#15766](https://github.com/streamlit/streamlit/pull/15766), [#4320](https://github.com/streamlit/streamlit/issues/4320)).
-- 🧪 [`AppTest`](/develop/api-reference/app-testing/st.testing.v1.apptest) now supports testing `st.download_button` and `st.image` ([#15528](https://github.com/streamlit/streamlit/pull/15528), [#9003](https://github.com/streamlit/streamlit/issues/9003)).
-- 💾 Programmatic secrets now support list values ([#15491](https://github.com/streamlit/streamlit/pull/15491)).
-- ⌨ You can now look up Streamlit API documentation from the CLI with `streamlit docs <command>` ([#15547](https://github.com/streamlit/streamlit/pull/15547)).
-- 🔐 A new `server.xsrfCookieSameSite` config option lets you customize the `SameSite` attribute of the XSRF cookie for deployments with specific cross-site requirements ([#15634](https://github.com/streamlit/streamlit/pull/15634), [#5793](https://github.com/streamlit/streamlit/issues/5793), [#9397](https://github.com/streamlit/streamlit/issues/9397)).
-- 💡 Streamlit now recommends installing AI coding skills on app startup to improve your development workflow with AI coding assistants ([#15437](https://github.com/streamlit/streamlit/pull/15437), [#15473](https://github.com/streamlit/streamlit/pull/15473)).
-- ⚙ The `/_stcore/metrics` endpoint now reports memory stats in a less detailed (cheaper) form by default ([#15472](https://github.com/streamlit/streamlit/pull/15472)).
-- 👻 The deprecated Snowpark connection type has been removed. Migrate to a supported connection type ([#15784](https://github.com/streamlit/streamlit/pull/15784)).
-- 👻 The deprecated [`st.bokeh_chart`](/develop/api-reference/charts/st.bokeh_chart) command has been removed. Use the [`streamlit-bokeh`](https://github.com/streamlit/streamlit-bokeh) component instead ([#15636](https://github.com/streamlit/streamlit/pull/15636)).
+- 🔒 Security hardening (**breaking changes**):
+  - Streamlit now rejects host messages that appear to originate from child iframes or injected scripts, preventing origin spoofing (CWE-346) ([#15800](https://github.com/streamlit/streamlit/pull/15800)).
+  - Client-supplied query strings are now capped at 512 KiB and 1,000 fields, guarding against unbounded resource allocation (CWE-770) ([#15803](https://github.com/streamlit/streamlit/pull/15803)).
+  - New `server.maxWidgetStateSize` config option (default 25 MB) limits the widget state payload a client can send per script rerun, hardening against oversized widget and custom-component payloads ([#15804](https://github.com/streamlit/streamlit/pull/15804)).
+- 📊 [`st.dataframe`](/develop/api-reference/data/st.dataframe) now preserves row selections when the user sorts the table ([#16020](https://github.com/streamlit/streamlit/pull/16020), [#8851](https://github.com/streamlit/streamlit/issues/8851)).
+- 🎛 [`st.tabs`](/develop/api-reference/layout/st.tabs) has a new `height` parameter to set a fixed pixel height for the tab panel area ([#15847](https://github.com/streamlit/streamlit/pull/15847), [#12217](https://github.com/streamlit/streamlit/issues/12217)).
+- 📐 The `gap` parameter in [`st.columns`](/develop/api-reference/layout/st.columns) now accepts integer pixel values in addition to the existing string presets ([#15850](https://github.com/streamlit/streamlit/pull/15850), [#13005](https://github.com/streamlit/streamlit/issues/13005)).
+- 🎨 [`st.data_editor`](/develop/api-reference/data/st.data_editor) now uses `key` as the primary row identity when `num_rows="fixed"`, improving stability when the underlying data changes ([#15884](https://github.com/streamlit/streamlit/pull/15884)).
+- 📈 Zero delta values in [`st.metric`](/develop/api-reference/data/st.metric) are now displayed in neutral grey instead of green or red, so a zero change no longer implies a positive or negative direction ([#15790](https://github.com/streamlit/streamlit/pull/15790), [#15005](https://github.com/streamlit/streamlit/issues/15005)).
+- 🖌 Vega-Lite chart action buttons (fullscreen, download, etc.) are now integrated into the native Streamlit toolbar instead of the Vega-Lite overlay ([#15806](https://github.com/streamlit/streamlit/pull/15806)).
 
 **Other Changes**
 
-- ⚡ VegaLite charts now use Vega's native resize API for faster rendering when the container size changes ([#15302](https://github.com/streamlit/streamlit/pull/15302)).
-- 🎨 The pagination widget's selected-state styling has been redesigned ([#15550](https://github.com/streamlit/streamlit/pull/15550)).
-- 🔧 Various fixes related to the Baseweb library removal ([#15737](https://github.com/streamlit/streamlit/pull/15737)).
-- 🐛 Bug fix: The metrics endpoint no longer errors when SQLAlchemy connections are present ([#15334](https://github.com/streamlit/streamlit/pull/15334)).
-- 🦋 Bug fix: `@st.fragment(run_every=...)` no longer raises a `TypeError` in `_run_with_thread_state` ([#15376](https://github.com/streamlit/streamlit/pull/15376)).
-- 🪲 Bug fix: Named Snowflake connections defined in config files are now correctly discovered and used ([#15382](https://github.com/streamlit/streamlit/pull/15382)).
-- 🐜 Bug fix: P-mode PIL palette images are now hashed correctly to prevent hash collisions ([#15397](https://github.com/streamlit/streamlit/pull/15397)).
-- 🐝 Bug fix: The server now correctly binds to IPv6 dual-stack wildcards for the default address ([#15400](https://github.com/streamlit/streamlit/pull/15400)).
-- 🐞 Bug fix: Stale and invalid auth cookies are now cleared on login ([#15420](https://github.com/streamlit/streamlit/pull/15420)).
-- 🕷️ Bug fix: `widgetMgr` is synced correctly to fix lazy loading in `tab.open` ([#15460](https://github.com/streamlit/streamlit/pull/15460)).
-- 🪳 Bug fix: Installed Custom Component v2 components are now correctly discovered in `AppTest` ([#15488](https://github.com/streamlit/streamlit/pull/15488)).
-- 🪰 Bug fix: [`st.pills`](/develop/api-reference/widgets/st.pills) and [`st.segmented_control`](/develop/api-reference/widgets/st.segmented_control) callbacks now fire correctly after selection ([#15522](https://github.com/streamlit/streamlit/pull/15522)).
-- 🦠 Bug fix: The page title is no longer reset to the default on rerun ([#15527](https://github.com/streamlit/streamlit/pull/15527)).
-- 🦟 Bug fix: The "Missing Submit Button" warning no longer flashes briefly on app load ([#15561](https://github.com/streamlit/streamlit/pull/15561)).
-- 🦂 Bug fix: Streamlit now defaults to the polling file watcher in WSL environments, avoiding inotify issues ([#15562](https://github.com/streamlit/streamlit/pull/15562)).
-- 🦗 Bug fix: `AppTest` now correctly handles formatted labels in `format_func` widgets ([#15564](https://github.com/streamlit/streamlit/pull/15564)).
-- 🕸️ Bug fix: The invalid session upload error message now explains multi-replica deployment as a possible cause ([#15635](https://github.com/streamlit/streamlit/pull/15635)).
-- 🐌 Bug fix: [`st.selectbox`](/develop/api-reference/widgets/st.selectbox) no longer loses its selection when `format_func` depends on object identity ([#15639](https://github.com/streamlit/streamlit/pull/15639)).
-- 🦎 Bug fix: Pressing Escape no longer clears the current selection in [`st.multiselect`](/develop/api-reference/widgets/st.multiselect) ([#15646](https://github.com/streamlit/streamlit/pull/15646)).
-- 🦀 Bug fix: `StreamlitPage` now validates that its `source` matches the registered page, catching misconfiguration earlier ([#15721](https://github.com/streamlit/streamlit/pull/15721), [#10572](https://github.com/streamlit/streamlit/issues/10572)).
-- 👽 Bug fix: [`st.dataframe`](/develop/api-reference/data/st.dataframe) no longer intercepts the Ctrl+F keyboard shortcut when the search bar is disabled ([#15764](https://github.com/streamlit/streamlit/pull/15764)).
-- 🐛 Bug fix: Column headers in [`st.dataframe`](/develop/api-reference/data/st.dataframe) no longer wrap text in the column header menu ([#15772](https://github.com/streamlit/streamlit/pull/15772)).
+- 🐛 Bug fix: Non-finite float values (e.g. `NaN`, `Inf`) in URL query params are now rejected to prevent unexpected behavior ([#15799](https://github.com/streamlit/streamlit/pull/15799)).
+- 🦋 Bug fix: Dangerous URLs in Graphviz link attributes are now sanitized ([#15819](https://github.com/streamlit/streamlit/pull/15819)).
+- 🪲 Bug fix: HTML in PyDeck chart tooltip interpolations is now escaped to prevent injection ([#15820](https://github.com/streamlit/streamlit/pull/15820)).
+- 🐜 Bug fix: Dangerous URLs in `st.link_button` and `st.image` are now sanitized ([#15851](https://github.com/streamlit/streamlit/pull/15851)).
+- 🐝 Bug fix: `st.selectbox` now virtualizes long dropdown option lists for better rendering performance ([#15870](https://github.com/streamlit/streamlit/pull/15870), [#15863](https://github.com/streamlit/streamlit/issues/15863)).
+- 🐞 Bug fix: Viewport gutter is now preserved around dialogs on narrow screens ([#15875](https://github.com/streamlit/streamlit/pull/15875)).
+- 🕷️ Bug fix: React Aria dialog overlays now stack correctly when multiple dialogs are open ([#15876](https://github.com/streamlit/streamlit/pull/15876), [#15859](https://github.com/streamlit/streamlit/issues/15859)).
+- 🪳 Bug fix: The spurious "Missing Submit Button" warning is no longer shown for forms that have a submit button in a conditionally rendered block ([#15889](https://github.com/streamlit/streamlit/pull/15889), [#14247](https://github.com/streamlit/streamlit/issues/14247)).
+- 🪰 Bug fix: `st.tabs` panels no longer stack visually after a widget rerun ([#15894](https://github.com/streamlit/streamlit/pull/15894), [#15893](https://github.com/streamlit/streamlit/issues/15893)).
+- 🦠 Bug fix: `st.metric` area chart fill baseline is now drawn correctly ([#15907](https://github.com/streamlit/streamlit/pull/15907)).
+- 🦟 Bug fix: `run_every` auto-rerun timers are now deduplicated per fragment, preventing duplicate reruns ([#15912](https://github.com/streamlit/streamlit/pull/15912)).
+- 🦂 Bug fix: Redundant keyboard tab stop removed from the file uploader dropzone for better accessibility ([#15928](https://github.com/streamlit/streamlit/pull/15928)).
+- 🦗 Bug fix: Auto-rerun correctly stops when a fragment is evicted ([#15932](https://github.com/streamlit/streamlit/pull/15932)).
+- 🕸️ Bug fix: A PyArrow 25 thread initialization crash is now avoided ([#15947](https://github.com/streamlit/streamlit/pull/15947)).
+- 🐌 Bug fix: Missing `httpx` error message for the auth extra is now surfaced correctly ([#15864](https://github.com/streamlit/streamlit/pull/15864)).
+- 🦎 Bug fix: `st.App` with programmatic secrets now correctly honors the `expose_tokens` setting ([#15865](https://github.com/streamlit/streamlit/pull/15865)).
+- 🦀 Bug fix: `RuntimeError: reentrant call inside _io.BufferedWriter` on Ctrl+C is fixed ([#15949](https://github.com/streamlit/streamlit/pull/15949), [#15740](https://github.com/streamlit/streamlit/issues/15740)). Thanks, [chang-pro](https://github.com/chang-pro)!
+- 👽 Bug fix: File watcher no longer crashes on Windows drive-root paths ([#15951](https://github.com/streamlit/streamlit/pull/15951), [#12731](https://github.com/streamlit/streamlit/issues/12731)).
+- 👻 Bug fix: Overlay stacking and dismissal inside popovers works correctly ([#15961](https://github.com/streamlit/streamlit/pull/15961)).
+- 🐛 Bug fix: Mobile keyboard no longer appears for `st.selectbox` when `filter_mode=None` ([#15962](https://github.com/streamlit/streamlit/pull/15962)).
+- 🦋 Bug fix: `st.selectbox` "No results" empty state is now styled correctly ([#15967](https://github.com/streamlit/streamlit/pull/15967)).
+- 🪲 Bug fix: `IndexError` in number formatting for values ≥ 1 quadrillion is fixed ([#15971](https://github.com/streamlit/streamlit/pull/15971)). Thanks, [eeshsaxena](https://github.com/eeshsaxena)!
+- 🐜 Bug fix: Type-to-search in `st.selectbox` is restored ([#15996](https://github.com/streamlit/streamlit/pull/15996), [#15985](https://github.com/streamlit/streamlit/issues/15985)).
+- 🐝 Bug fix: Typing a value in `st.number_input` inside a form now correctly submits on the first Enter press ([#16013](https://github.com/streamlit/streamlit/pull/16013), [#13751](https://github.com/streamlit/streamlit/issues/13751)).
+- 🐞 Bug fix: Hashing fallback warning messages are now more informative ([#16040](https://github.com/streamlit/streamlit/pull/16040), [#10957](https://github.com/streamlit/streamlit/issues/10957)).
+- 🕷️ Bug fix: Inconsistent checkbox margin in a horizontal container within a column is fixed ([#16060](https://github.com/streamlit/streamlit/pull/16060), [#13162](https://github.com/streamlit/streamlit/issues/13162)).
+- 🪳 Bug fix: Widgets inside a popover that is itself inside a dialog are now clickable ([#16067](https://github.com/streamlit/streamlit/pull/16067), [#16005](https://github.com/streamlit/streamlit/issues/16005)).
+- 🪰 Bug fix: `st.echo` output now correctly includes decorators on the displayed function ([#16068](https://github.com/streamlit/streamlit/pull/16068), [#9252](https://github.com/streamlit/streamlit/issues/9252)).
+- 🔩 Internal `TTLCache` implementation replaces the `cachetools` third-party dependency ([#16014](https://github.com/streamlit/streamlit/pull/16014)).
 
 ## Older versions of Streamlit
 


### PR DESCRIPTION
## Summary

- Updates release notes (`_index.md` and `2026.md`) for Streamlit 1.60.0 (released July 21, 2026)
- Generates updated docstrings via `python/generate.py` with Streamlit 1.60.0 (new `1.60.0` key appended to `streamlit.json`)
- No new `st.*` commands in this release — no new API tiles, detail pages, or example apps needed

## Test plan

- [ ] Verify release notes render correctly on the docs site
- [ ] Verify `streamlit.json` diff shows only a single new hunk at the end of the file


Made with [Cursor](https://cursor.com)