### PR TITLE
fix: add missing fragments documentation to index

### DIFF
--- a/content/develop/concepts/architecture/_index.md
+++ b/content/develop/concepts/architecture/_index.md
@@ -57,6 +57,14 @@ Use forms to isolate user input and prevent unnecessary app reruns.
 
 </RefCard>
 
+<RefCard href="/develop/concepts/architecture/fragments">
+
+<h5>Fragments</h5>
+
+Restrict the scope of reruns to defined blocks of code with fragments.
+
+</RefCard>
+
 <RefCard href="/develop/concepts/architecture/widget-behavior">
 
 <h5>Widget behavior</h5>


### PR DESCRIPTION
## 📚 Context

<!-- Why do you want to make this change? What background should the reviewer know? -->
A link to the fragments documentation is missing from the "Architecture and Execution" page, hampering discoverability.

## 🧠 Description of Changes

<!-- What was specifically changed? Which files, algorithms, links, media? -->
<!-- Please add them here as a bulleted list -->
- Add a link to `content/develop/concepts/architecture/fragments.md` in `content/develop/concepts/architecture/_index.md`.

**Current:**

<img width="1310" height="1382" alt="image" src="https://github.com/user-attachments/assets/76d7196f-2823-4bca-bdb2-131e276037d9" />

**Revised:**

<img width="1310" height="1482" alt="image" src="https://github.com/user-attachments/assets/ddc53219-e861-4272-8f5a-c1151c23f959" />

## 💥 Impact

<!-- what is the scale of this change -->
Readers will be able to find the fragments documentation more easily.

Size:

- [x] Small <!-- Small bug fix or small edit to existing code that amounts to few lines) -->
- [ ] Not small <!-- Everything else -->