### PR TITLE
Add GitHub issue upvote hints to command reference pages

### DIFF
--- a/components/blocks/githubIssuesHint.js
+++ b/components/blocks/githubIssuesHint.js
@@ -1,0 +1,22 @@
+import React from "react";
+
+import Tip from "./tip";
+
+const GitHubIssuesHint = ({ label, name }) => {
+  const displayName = name || String(label).replace(/^feature:/, "");
+  const query = `is:issue state:open label:${label} sort:reactions-+1-desc`;
+  const url = `https://github.com/streamlit/streamlit/issues?q=${encodeURIComponent(query)}`;
+
+  return (
+    <Tip>
+      <p>
+        Want a new <code>{displayName}</code> feature or found a bug? Browse{" "}
+        <a href={url}>open issues</a> and react with a 👍 on the initial post of
+        the ones that matter to you. Your votes help Streamlit prioritize what to
+        work on next.
+      </p>
+    </Tip>
+  );
+};
+
+export default GitHubIssuesHint;

--- a/components/blocks/githubIssuesHint.js
+++ b/components/blocks/githubIssuesHint.js
@@ -12,8 +12,8 @@ const GitHubIssuesHint = ({ label, name }) => {
       <p>
         Want a new <code>{displayName}</code> feature or found a bug? Browse{" "}
         <a href={url}>open issues</a> and react with a 👍 on the initial post of
-        the ones that matter to you. Your votes help Streamlit prioritize what to
-        work on next.
+        the ones that matter to you. Your votes help us prioritize what to work
+        on next.
       </p>
     </Tip>
   );

--- a/components/blocks/githubIssuesHint.js
+++ b/components/blocks/githubIssuesHint.js
@@ -4,7 +4,7 @@ import Tip from "./tip";
 
 const GitHubIssuesHint = ({ label, name }) => {
   const displayName = name || String(label).replace(/^feature:/, "");
-  const query = `is:issue state:open label:${label} sort:reactions-+1-desc`;
+  const query = `is:issue state:open label:"${label}" sort:reactions-+1-desc`;
   const url = `https://github.com/streamlit/streamlit/issues?q=${encodeURIComponent(query)}`;
 
   return (

--- a/content/develop/api-reference/caching-and-state/cache-data.md
+++ b/content/develop/api-reference/caching-and-state/cache-data.md
@@ -73,3 +73,5 @@ def show_data():
     st.write("And here is the raw data:")
     st.dataframe(data)
 ```
+
+<GitHubIssuesHint label="feature:cache" name="st.cache_data" />

--- a/content/develop/api-reference/caching-and-state/cache-resource.md
+++ b/content/develop/api-reference/caching-and-state/cache-resource.md
@@ -71,3 +71,5 @@ def load_model():
     st.write("Here's the model:")
     return model
 ```
+
+<GitHubIssuesHint label="feature:cache" name="st.cache_resource" />

--- a/content/develop/api-reference/caching-and-state/context.md
+++ b/content/develop/api-reference/caching-and-state/context.md
@@ -24,3 +24,5 @@ keywords: context, cookies, headers, browser, session, locale, theme, timezone, 
 <Autofunction function="context.timezone_offset" />
 
 <Autofunction function="context.url" />
+
+<GitHubIssuesHint label="feature:st.context" name="st.context" />

--- a/content/develop/api-reference/caching-and-state/query_params.md
+++ b/content/develop/api-reference/caching-and-state/query_params.md
@@ -57,3 +57,5 @@ When a key is repeated in your app's URL (`?a=1&a=2&a=3`), dict-like methods wil
 <Autofunction function="streamlit.query_params.get_all" />
 
 <Autofunction function="streamlit.query_params.to_dict" />
+
+<GitHubIssuesHint label="feature:query-params" name="st.query_params" />

--- a/content/develop/api-reference/caching-and-state/session_state.md
+++ b/content/develop/api-reference/caching-and-state/session_state.md
@@ -224,3 +224,5 @@ When `runner.enforceSerializableSessionState` is set to `true`, Session State im
   ```
 
   ![state-button-exception](/images/state_button_exception.png)
+
+<GitHubIssuesHint label="feature:st.session_state" name="st.session_state" />

--- a/content/develop/api-reference/charts/altair_chart.md
+++ b/content/develop/api-reference/charts/altair_chart.md
@@ -121,3 +121,5 @@ Notice how the custom colors are still reflected in the chart, even when the Str
 <Cloud name="doc-altair-custom-colors" height="675px" />
 
 For many more examples of Altair charts with and without the Streamlit theme, check out the [altair.streamlit.app](https://altair.streamlit.app).
+
+<GitHubIssuesHint label="feature:st.altair_chart" name="st.altair_chart" />

--- a/content/develop/api-reference/charts/area_chart.md
+++ b/content/develop/api-reference/charts/area_chart.md
@@ -6,3 +6,5 @@ keywords: area chart, chart, visualization, data, plot, graph, dataframe, filled
 ---
 
 <Autofunction function="streamlit.area_chart" />
+
+<GitHubIssuesHint label="feature:builtin-charts" name="st.area_chart" />

--- a/content/develop/api-reference/charts/bar_chart.md
+++ b/content/develop/api-reference/charts/bar_chart.md
@@ -6,3 +6,5 @@ keywords: bar chart, chart, visualization, data, plot, graph, dataframe, categor
 ---
 
 <Autofunction function="streamlit.bar_chart" />
+
+<GitHubIssuesHint label="feature:builtin-charts" name="st.bar_chart" />

--- a/content/develop/api-reference/charts/bokeh_chart.md
+++ b/content/develop/api-reference/charts/bokeh_chart.md
@@ -6,3 +6,5 @@ keywords: bokeh_chart, bokeh, chart, visualization, data, plot, graph, interacti
 ---
 
 <Autofunction function="streamlit.bokeh_chart" deprecated={true} deprecatedText="<code>st.bokeh_chart</code> was deprecated in version 1.49.0 and removed in version 1.52.0. Use the <a href='https://github.com/streamlit/streamlit-bokeh'><code>streamlit-bokeh</code></a> custom component instead."/>
+
+<GitHubIssuesHint label="feature:st.bokeh_chart" name="st.bokeh_chart" />

--- a/content/develop/api-reference/charts/graphviz_chart.md
+++ b/content/develop/api-reference/charts/graphviz_chart.md
@@ -6,3 +6,5 @@ keywords: graphviz_chart, graphviz, chart, visualization, graph, dagre-d3, netwo
 ---
 
 <Autofunction function="streamlit.graphviz_chart" />
+
+<GitHubIssuesHint label="feature:st.graphviz_chart" name="st.graphviz_chart" />

--- a/content/develop/api-reference/charts/line_chart.md
+++ b/content/develop/api-reference/charts/line_chart.md
@@ -6,3 +6,5 @@ keywords: line chart, chart, visualization, data, plot, graph, dataframe, time s
 ---
 
 <Autofunction function="streamlit.line_chart" />
+
+<GitHubIssuesHint label="feature:builtin-charts" name="st.line_chart" />

--- a/content/develop/api-reference/charts/map.md
+++ b/content/develop/api-reference/charts/map.md
@@ -6,3 +6,5 @@ keywords: map, geographic, visualization, data, plot, graph, dataframe, coordina
 ---
 
 <Autofunction function="streamlit.map" />
+
+<GitHubIssuesHint label="feature:st.map" name="st.map" />

--- a/content/develop/api-reference/charts/mermaid_chart.md
+++ b/content/develop/api-reference/charts/mermaid_chart.md
@@ -7,4 +7,4 @@ keywords: st.mermaid_chart, mermaid, diagram, flowchart, sequence diagram, graph
 
 <Autofunction function="streamlit.mermaid_chart" />
 
-<GitHubIssuesHint label="feature:charts" name="st.mermaid_chart" />
+<GitHubIssuesHint label="feature:st.mermaid_chart" name="st.mermaid_chart" />

--- a/content/develop/api-reference/charts/mermaid_chart.md
+++ b/content/develop/api-reference/charts/mermaid_chart.md
@@ -6,3 +6,5 @@ keywords: st.mermaid_chart, mermaid, diagram, flowchart, sequence diagram, graph
 ---
 
 <Autofunction function="streamlit.mermaid_chart" />
+
+<GitHubIssuesHint label="feature:charts" name="st.mermaid_chart" />

--- a/content/develop/api-reference/charts/plotly_chart.md
+++ b/content/develop/api-reference/charts/plotly_chart.md
@@ -82,3 +82,5 @@ Notice how the custom color scale is still reflected in the chart, even when the
 <Cloud name="doc-plotly-custom-colors" height="650px" />
 
 For many more examples of Plotly charts with and without the Streamlit theme, check out the [plotly.streamlit.app](https://plotly.streamlit.app).
+
+<GitHubIssuesHint label="feature:st.plotly_chart" name="st.plotly_chart" />

--- a/content/develop/api-reference/charts/pydeck_chart.md
+++ b/content/develop/api-reference/charts/pydeck_chart.md
@@ -12,3 +12,5 @@ keywords: pydeck_chart, pydeck, chart, visualization, data, plot, graph, deck.gl
 <Autofunction function="PydeckState" />
 
 <Autofunction function="PydeckSelectionState" />
+
+<GitHubIssuesHint label="feature:st.pydeck_chart" name="st.pydeck_chart" />

--- a/content/develop/api-reference/charts/pyplot.md
+++ b/content/develop/api-reference/charts/pyplot.md
@@ -34,3 +34,5 @@ Always pass a Matplotlib `Figure` to `st.pyplot`. Calling `st.pyplot()` with no 
     ```
 
 </Warning>
+
+<GitHubIssuesHint label="feature:st.pyplot" name="st.pyplot" />

--- a/content/develop/api-reference/charts/scatter_chart.md
+++ b/content/develop/api-reference/charts/scatter_chart.md
@@ -6,3 +6,5 @@ keywords: scatter chart, chart, visualization, data, plot, graph, dataframe, cor
 ---
 
 <Autofunction function="streamlit.scatter_chart" />
+
+<GitHubIssuesHint label="feature:builtin-charts" name="st.scatter_chart" />

--- a/content/develop/api-reference/charts/vega_lite_chart.md
+++ b/content/develop/api-reference/charts/vega_lite_chart.md
@@ -58,3 +58,5 @@ Click the tabs in the interactive app below to see the charts with the Streamlit
 <Cloud name="doc-vega-lite-theme" height="500px" />
 
 If you're wondering if your own customizations will still be taken into account, don't worry! You can still make changes to your chart configurations. In other words, although we now enable the Streamlit theme by default, you can overwrite it with custom colors or fonts. For example, if you want a chart line to be green instead of the default red, you can do it!
+
+<GitHubIssuesHint label="feature:st.vega_lite_chart" name="st.vega_lite_chart" />

--- a/content/develop/api-reference/chat/chat-input.md
+++ b/content/develop/api-reference/chat/chat-input.md
@@ -18,3 +18,5 @@ Read the [Build a basic LLM chat app](/develop/tutorials/chat-and-llm-apps/build
 For an overview of the `st.chat_input` and `st.chat_message` API, check out this video tutorial by Chanin Nantasenamat ([@dataprofessor](https://www.youtube.com/dataprofessor)), a Senior Developer Advocate at Streamlit.
 
 <YouTube videoId="4sPnOqeUDmk" />
+
+<GitHubIssuesHint label="feature:st.chat_input" name="st.chat_input" />

--- a/content/develop/api-reference/chat/chat-message.md
+++ b/content/develop/api-reference/chat/chat-message.md
@@ -16,3 +16,5 @@ Read the [Build a basic LLM chat app](/develop/tutorials/chat-and-llm-apps/build
 For an overview of the `st.chat_message` and `st.chat_input` API, check out this video tutorial by Chanin Nantasenamat ([@dataprofessor](https://www.youtube.com/dataprofessor)), a Senior Developer Advocate at Streamlit.
 
 <YouTube videoId="4sPnOqeUDmk" />
+
+<GitHubIssuesHint label="feature:st.chat_message" name="st.chat_message" />

--- a/content/develop/api-reference/command-line/cache.md
+++ b/content/develop/api-reference/command-line/cache.md
@@ -14,3 +14,5 @@ Clear persisted files from the on-disk [Streamlit cache](/develop/api-reference/
 ```
 streamlit cache clear
 ```
+
+<GitHubIssuesHint label="feature:cli" name="streamlit cache" />

--- a/content/develop/api-reference/command-line/cache.md
+++ b/content/develop/api-reference/command-line/cache.md
@@ -14,5 +14,3 @@ Clear persisted files from the on-disk [Streamlit cache](/develop/api-reference/
 ```
 streamlit cache clear
 ```
-
-<GitHubIssuesHint label="feature:cli" name="streamlit cache" />

--- a/content/develop/api-reference/command-line/config.md
+++ b/content/develop/api-reference/command-line/config.md
@@ -14,3 +14,5 @@ Print all the available configuration options, including their descriptions, def
 ```
 streamlit config show
 ```
+
+<GitHubIssuesHint label="feature:cli" name="streamlit config show" />

--- a/content/develop/api-reference/command-line/config.md
+++ b/content/develop/api-reference/command-line/config.md
@@ -14,5 +14,3 @@ Print all the available configuration options, including their descriptions, def
 ```
 streamlit config show
 ```
-
-<GitHubIssuesHint label="feature:cli" name="streamlit config show" />

--- a/content/develop/api-reference/command-line/docs.md
+++ b/content/develop/api-reference/command-line/docs.md
@@ -14,5 +14,3 @@ Open the Streamlit docs in your default browser.
 ```
 streamlit docs
 ```
-
-<GitHubIssuesHint label="feature:cli" name="streamlit docs" />

--- a/content/develop/api-reference/command-line/docs.md
+++ b/content/develop/api-reference/command-line/docs.md
@@ -14,3 +14,5 @@ Open the Streamlit docs in your default browser.
 ```
 streamlit docs
 ```
+
+<GitHubIssuesHint label="feature:cli" name="streamlit docs" />

--- a/content/develop/api-reference/command-line/hello.md
+++ b/content/develop/api-reference/command-line/hello.md
@@ -44,5 +44,3 @@ To run the Hello app with a blue accent color, from any directory, execute the f
 ```
 streamlit hello --theme.primaryColor=blue
 ```
-
-<GitHubIssuesHint label="feature:cli" name="streamlit hello" />

--- a/content/develop/api-reference/command-line/hello.md
+++ b/content/develop/api-reference/command-line/hello.md
@@ -44,3 +44,5 @@ To run the Hello app with a blue accent color, from any directory, execute the f
 ```
 streamlit hello --theme.primaryColor=blue
 ```
+
+<GitHubIssuesHint label="feature:cli" name="streamlit hello" />

--- a/content/develop/api-reference/command-line/help.md
+++ b/content/develop/api-reference/command-line/help.md
@@ -14,3 +14,5 @@ Print the available commands for the Streamlit CLI tool. This command is equival
 ```
 streamlit help
 ```
+
+<GitHubIssuesHint label="feature:cli" name="streamlit help" />

--- a/content/develop/api-reference/command-line/help.md
+++ b/content/develop/api-reference/command-line/help.md
@@ -14,5 +14,3 @@ Print the available commands for the Streamlit CLI tool. This command is equival
 ```
 streamlit help
 ```
-
-<GitHubIssuesHint label="feature:cli" name="streamlit help" />

--- a/content/develop/api-reference/command-line/init.md
+++ b/content/develop/api-reference/command-line/init.md
@@ -65,3 +65,5 @@ streamlit init <directory>
    This is equivalent to executing `streamlit run project/streamlit_app.py` from your current working directory.
 
 3. Begin editing your `streamlit_app.py` file and save your changes.
+
+<GitHubIssuesHint label="feature:cli" name="streamlit init" />

--- a/content/develop/api-reference/command-line/init.md
+++ b/content/develop/api-reference/command-line/init.md
@@ -65,5 +65,3 @@ streamlit init <directory>
    This is equivalent to executing `streamlit run project/streamlit_app.py` from your current working directory.
 
 3. Begin editing your `streamlit_app.py` file and save your changes.
-
-<GitHubIssuesHint label="feature:cli" name="streamlit init" />

--- a/content/develop/api-reference/command-line/run.md
+++ b/content/develop/api-reference/command-line/run.md
@@ -100,3 +100,5 @@ If you need to pass arguments directly to your script, you can pass them as posi
   sys.argv[2] == "of"
   sys.argv[3] == "arguments"
   ```
+
+<GitHubIssuesHint label="feature:cli" name="streamlit run" />

--- a/content/develop/api-reference/command-line/run.md
+++ b/content/develop/api-reference/command-line/run.md
@@ -100,5 +100,3 @@ If you need to pass arguments directly to your script, you can pass them as posi
   sys.argv[2] == "of"
   sys.argv[3] == "arguments"
   ```
-
-<GitHubIssuesHint label="feature:cli" name="streamlit run" />

--- a/content/develop/api-reference/command-line/skills.md
+++ b/content/develop/api-reference/command-line/skills.md
@@ -53,3 +53,5 @@ With `--global`, it installs a meta skill to the user directory that is availabl
   ```bash
   streamlit skills -g -y
   ```
+
+<GitHubIssuesHint label="feature:cli" name="streamlit skills" />

--- a/content/develop/api-reference/command-line/skills.md
+++ b/content/develop/api-reference/command-line/skills.md
@@ -53,5 +53,3 @@ With `--global`, it installs a meta skill to the user directory that is availabl
   ```bash
   streamlit skills -g -y
   ```
-
-<GitHubIssuesHint label="feature:cli" name="streamlit skills" />

--- a/content/develop/api-reference/command-line/version.md
+++ b/content/develop/api-reference/command-line/version.md
@@ -14,3 +14,5 @@ Print Streamlit's version number. This command is equivalent to executing `strea
 ```
 streamlit version
 ```
+
+<GitHubIssuesHint label="feature:cli" name="streamlit version" />

--- a/content/develop/api-reference/command-line/version.md
+++ b/content/develop/api-reference/command-line/version.md
@@ -14,5 +14,3 @@ Print Streamlit's version number. This command is equivalent to executing `strea
 ```
 streamlit version
 ```
-
-<GitHubIssuesHint label="feature:cli" name="streamlit version" />

--- a/content/develop/api-reference/configuration/config-toml.md
+++ b/content/develop/api-reference/configuration/config-toml.md
@@ -1566,3 +1566,5 @@ chartDivergingColors =
 # Default: [ <path to local environment's secrets.toml file>, <path to project's secrets.toml file>,]
 files = [ "~/.streamlit/secrets.toml", "~/project directory/.streamlit/secrets.toml",]
 ```
+
+<GitHubIssuesHint label="feature:config" name="config.toml" />

--- a/content/develop/api-reference/configuration/get_option.md
+++ b/content/develop/api-reference/configuration/get_option.md
@@ -6,3 +6,5 @@ keywords: get_option, configuration, option, retrieve, get setting, config value
 ---
 
 <Autofunction function="streamlit.get_option" />
+
+<GitHubIssuesHint label="feature:config" name="st.get_option" />

--- a/content/develop/api-reference/configuration/get_option.md
+++ b/content/develop/api-reference/configuration/get_option.md
@@ -6,5 +6,3 @@ keywords: get_option, configuration, option, retrieve, get setting, config value
 ---
 
 <Autofunction function="streamlit.get_option" />
-
-<GitHubIssuesHint label="feature:config" name="st.get_option" />

--- a/content/develop/api-reference/configuration/set_option.md
+++ b/content/develop/api-reference/configuration/set_option.md
@@ -6,5 +6,3 @@ keywords: set_option, configuration, option, update, set setting, config value, 
 ---
 
 <Autofunction function="streamlit.set_option" />
-
-<GitHubIssuesHint label="feature:config" name="st.set_option" />

--- a/content/develop/api-reference/configuration/set_option.md
+++ b/content/develop/api-reference/configuration/set_option.md
@@ -6,3 +6,5 @@ keywords: set_option, configuration, option, update, set setting, config value, 
 ---
 
 <Autofunction function="streamlit.set_option" />
+
+<GitHubIssuesHint label="feature:config" name="st.set_option" />

--- a/content/develop/api-reference/configuration/set_page_config.md
+++ b/content/develop/api-reference/configuration/set_page_config.md
@@ -6,3 +6,5 @@ keywords: set_page_config, page config, title, favicon, layout, initial sidebar 
 ---
 
 <Autofunction function="streamlit.set_page_config" />
+
+<GitHubIssuesHint label="feature:st.set_page_config" name="st.set_page_config" />

--- a/content/develop/api-reference/connections/connection.md
+++ b/content/develop/api-reference/connections/connection.md
@@ -16,3 +16,5 @@ This page only contains the `st.connection` API. For a deeper dive into creating
 For a comprehensive overview of this feature, check out this video tutorial by Joshua Carroll, Streamlit's Product Manager for Developer Experience. You'll learn about the feature's utility in creating and managing data connections within your apps by using real-world examples.
 
 <YouTube videoId="xQwDfW7UHMo" />
+
+<GitHubIssuesHint label="feature:connections" name="st.connection" />

--- a/content/develop/api-reference/connections/connections-baseconnection.md
+++ b/content/develop/api-reference/connections/connections-baseconnection.md
@@ -18,3 +18,5 @@ This page only contains information on the `st.connections.BaseConnection` class
 <Autofunction function="streamlit.connections.BaseConnection.close" />
 
 <Autofunction function="streamlit.connections.BaseConnection.scope" />
+
+<GitHubIssuesHint label="feature:connections" name="st.connections.BaseConnection" />

--- a/content/develop/api-reference/connections/connections-snowflake.md
+++ b/content/develop/api-reference/connections/connections-snowflake.md
@@ -24,3 +24,5 @@ This page only contains the `st.connections.SnowflakeConnection` class. For a de
 <Autofunction function="streamlit.connections.SnowflakeConnection.session" />
 
 <Autofunction function="streamlit.connections.SnowflakeConnection.write_pandas" />
+
+<GitHubIssuesHint label="feature:connections" name="st.connections.SnowflakeConnection" />

--- a/content/develop/api-reference/connections/connections-snowpark.md
+++ b/content/develop/api-reference/connections/connections-snowpark.md
@@ -20,3 +20,5 @@ This page only contains the `st.connections.SnowparkConnection` class. For a dee
 <Autofunction function="streamlit.connections.SnowparkConnection.safe_session" />
 
 <Autofunction function="streamlit.connections.SnowparkConnection.session" />
+
+<GitHubIssuesHint label="feature:connections" name="st.connections.SnowparkConnection" />

--- a/content/develop/api-reference/connections/connections-sql.md
+++ b/content/develop/api-reference/connections/connections-sql.md
@@ -24,3 +24,5 @@ This page only contains the `st.connections.SQLConnection` class. For a deeper d
 <Autofunction function="streamlit.connections.SQLConnection.engine" />
 
 <Autofunction function="streamlit.connections.SQLConnection.session" />
+
+<GitHubIssuesHint label="feature:connections" name="st.connections.SQLConnection" />

--- a/content/develop/api-reference/connections/secrets-toml.md
+++ b/content/develop/api-reference/connections/secrets-toml.md
@@ -40,3 +40,5 @@ st.secrets["OpenAI_key"] == "your OpenAI key"
 st.secrets["database"]["user"] == "your username"
 st.secrets.database.password == "your password"
 ```
+
+<GitHubIssuesHint label="feature:st.secrets" name="secrets.toml" />

--- a/content/develop/api-reference/connections/secrets.md
+++ b/content/develop/api-reference/connections/secrets.md
@@ -36,3 +36,5 @@ st.secrets["OpenAI_key"] == "your OpenAI key"
 st.secrets["database"]["user"] == "your username"
 st.secrets.database.password == "your password"
 ```
+
+<GitHubIssuesHint label="feature:st.secrets" name="st.secrets" />

--- a/content/develop/api-reference/control-flow/dialog.md
+++ b/content/develop/api-reference/control-flow/dialog.md
@@ -6,3 +6,5 @@ keywords: st.dialog, dialog, modal, overlay, popup, execution flow, control flow
 ---
 
 <Autofunction function="streamlit.dialog" oldName="streamlit.experimental_dialog" />
+
+<GitHubIssuesHint label="feature:st.dialog" name="st.dialog" />

--- a/content/develop/api-reference/control-flow/form.md
+++ b/content/develop/api-reference/control-flow/form.md
@@ -12,3 +12,5 @@ This page only contains information on the `st.forms` API. For a deeper dive int
 </Tip>
 
 <Autofunction function="streamlit.form" />
+
+<GitHubIssuesHint label="feature:st.form" name="st.form" />

--- a/content/develop/api-reference/control-flow/form_submit_button.md
+++ b/content/develop/api-reference/control-flow/form_submit_button.md
@@ -6,3 +6,5 @@ keywords: form_submit_button, form, submit, button, execution flow, control flow
 ---
 
 <Autofunction function="streamlit.form_submit_button" />
+
+<GitHubIssuesHint label="feature:st.form_submit_button" name="st.form_submit_button" />

--- a/content/develop/api-reference/control-flow/fragment.md
+++ b/content/develop/api-reference/control-flow/fragment.md
@@ -6,3 +6,5 @@ keywords: st.fragment, fragment, decorator, rerun, independent, execution flow, 
 ---
 
 <Autofunction function="streamlit.fragment" oldName="streamlit.experimental_fragment" />
+
+<GitHubIssuesHint label="feature:st.fragment" name="st.fragment" />

--- a/content/develop/api-reference/control-flow/rerun.md
+++ b/content/develop/api-reference/control-flow/rerun.md
@@ -58,3 +58,5 @@ if st.button("Baz"):
 
 container.header(st.session_state.value)
 ```
+
+<GitHubIssuesHint label="feature:st.rerun" name="st.rerun" />

--- a/content/develop/api-reference/control-flow/stop.md
+++ b/content/develop/api-reference/control-flow/stop.md
@@ -6,3 +6,5 @@ keywords: st.stop, stop, execution, halt, control flow, terminate, end
 ---
 
 <Autofunction function="streamlit.stop" />
+
+<GitHubIssuesHint label="feature:st.stop" name="st.stop" />

--- a/content/develop/api-reference/custom-components/component.md
+++ b/content/develop/api-reference/custom-components/component.md
@@ -6,3 +6,5 @@ keywords: st.components.v2.component, custom components v2, register component, 
 ---
 
 <Autofunction function="streamlit.components.v2.component" />
+
+<GitHubIssuesHint label="feature:custom-components" name="st.components.v2.component" />

--- a/content/develop/api-reference/custom-components/componentrenderer.md
+++ b/content/develop/api-reference/custom-components/componentrenderer.md
@@ -8,3 +8,5 @@ keywords: bidicomponentcallable, bidirectional, custom components v2, interface,
 <Autofunction function="ComponentRenderer" oldName="BidiComponentCallable" />
 
 <Autofunction function="ComponentResult" oldName="BidiComponentResult" />
+
+<GitHubIssuesHint label="feature:custom-components" name="ComponentRenderer" />

--- a/content/develop/api-reference/custom-components/declare_component.md
+++ b/content/develop/api-reference/custom-components/declare_component.md
@@ -6,3 +6,5 @@ keywords: declare_component, custom component, register, frontend, react, javasc
 ---
 
 <Autofunction function="streamlit.components.v1.declare_component" />
+
+<GitHubIssuesHint label="feature:custom-components" name="st.components.v1.declare_component" />

--- a/content/develop/api-reference/custom-components/html.md
+++ b/content/develop/api-reference/custom-components/html.md
@@ -6,5 +6,3 @@ keywords: html, iframe, custom component, html string, display, frontend, web co
 ---
 
 <Autofunction function="streamlit.components.v1.html" deprecated={true} deprecatedText="<code>st.components.v1.html</code> was deprecated in version 1.56.0 and will be removed in a later version. Use <a href='/develop/api-reference/text/st.html'><code>st.html</code></a> instead."/>
-
-<GitHubIssuesHint label="feature:custom-components" name="st.components.v1.html" />

--- a/content/develop/api-reference/custom-components/html.md
+++ b/content/develop/api-reference/custom-components/html.md
@@ -6,3 +6,5 @@ keywords: html, iframe, custom component, html string, display, frontend, web co
 ---
 
 <Autofunction function="streamlit.components.v1.html" deprecated={true} deprecatedText="<code>st.components.v1.html</code> was deprecated in version 1.56.0 and will be removed in a later version. Use <a href='/develop/api-reference/text/st.html'><code>st.html</code></a> instead."/>
+
+<GitHubIssuesHint label="feature:custom-components" name="st.components.v1.html" />

--- a/content/develop/api-reference/custom-components/iframe.md
+++ b/content/develop/api-reference/custom-components/iframe.md
@@ -6,5 +6,3 @@ keywords: st.components.v1.iframe, iframe, embed html, external content, web con
 ---
 
 <Autofunction function="streamlit.components.v1.iframe" deprecated={true} deprecatedText="<code>st.components.v1.iframe</code> was deprecated in version 1.56.0 and will be removed in a later version. Use <a href='/develop/api-reference/text/st.iframe'><code>st.iframe</code></a> instead."/>
-
-<GitHubIssuesHint label="feature:custom-components" name="st.components.v1.iframe" />

--- a/content/develop/api-reference/custom-components/iframe.md
+++ b/content/develop/api-reference/custom-components/iframe.md
@@ -6,3 +6,5 @@ keywords: st.components.v1.iframe, iframe, embed html, external content, web con
 ---
 
 <Autofunction function="streamlit.components.v1.iframe" deprecated={true} deprecatedText="<code>st.components.v1.iframe</code> was deprecated in version 1.56.0 and will be removed in a later version. Use <a href='/develop/api-reference/text/st.iframe'><code>st.iframe</code></a> instead."/>
+
+<GitHubIssuesHint label="feature:custom-components" name="st.components.v1.iframe" />

--- a/content/develop/api-reference/data/column_config/_index.md
+++ b/content/develop/api-reference/data/column_config/_index.md
@@ -283,3 +283,5 @@ ProgressColumn("Sales volume", min_value=0, max_value=1000, format="$%f")
 </RefCard>
 
 </TileContainer>
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config" />

--- a/content/develop/api-reference/data/column_config/areachartcolumn.md
+++ b/content/develop/api-reference/data/column_config/areachartcolumn.md
@@ -6,3 +6,5 @@ keywords: st.column_config.AreaChartColumn, area chart column, inline charts, ti
 ---
 
 <Autofunction function="streamlit.column_config.AreaChartColumn" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.AreaChartColumn" />

--- a/content/develop/api-reference/data/column_config/audiocolumn.md
+++ b/content/develop/api-reference/data/column_config/audiocolumn.md
@@ -6,3 +6,5 @@ keywords: st.column_config.AudioColumn, audio column, play audio, audio urls, au
 ---
 
 <Autofunction function="streamlit.column_config.AudioColumn" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.AudioColumn" />

--- a/content/develop/api-reference/data/column_config/barchartcolumn.md
+++ b/content/develop/api-reference/data/column_config/barchartcolumn.md
@@ -6,3 +6,5 @@ keywords: st.column_config.BarChartColumn, bar chart column, inline charts, hori
 ---
 
 <Autofunction function="streamlit.column_config.BarChartColumn" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.BarChartColumn" />

--- a/content/develop/api-reference/data/column_config/buttoncolumn.md
+++ b/content/develop/api-reference/data/column_config/buttoncolumn.md
@@ -8,3 +8,5 @@ keywords: st.column_config.ButtonColumn, button column, clickable buttons, dataf
 <Autofunction function="streamlit.column_config.ButtonColumn" />
 
 <Autofunction function="ButtonColumnClickState" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.ButtonColumn" />

--- a/content/develop/api-reference/data/column_config/checkboxcolumn.md
+++ b/content/develop/api-reference/data/column_config/checkboxcolumn.md
@@ -6,3 +6,5 @@ keywords: st.column_config.CheckboxColumn, checkbox column, boolean column, true
 ---
 
 <Autofunction function="streamlit.column_config.CheckboxColumn" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.CheckboxColumn" />

--- a/content/develop/api-reference/data/column_config/column.md
+++ b/content/develop/api-reference/data/column_config/column.md
@@ -6,3 +6,5 @@ keywords: st.column_config.Column, column configuration, base column, column set
 ---
 
 <Autofunction function="streamlit.column_config.Column" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.Column" />

--- a/content/develop/api-reference/data/column_config/datecolumn.md
+++ b/content/develop/api-reference/data/column_config/datecolumn.md
@@ -6,3 +6,5 @@ keywords: st.column_config.DateColumn, date column, date picker, date input, dat
 ---
 
 <Autofunction function="streamlit.column_config.DateColumn" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.DateColumn" />

--- a/content/develop/api-reference/data/column_config/datetimecolumn.md
+++ b/content/develop/api-reference/data/column_config/datetimecolumn.md
@@ -6,3 +6,5 @@ keywords: st.column_config.DatetimeColumn, datetime column, datetime picker, dat
 ---
 
 <Autofunction function="streamlit.column_config.DatetimeColumn" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.DatetimeColumn" />

--- a/content/develop/api-reference/data/column_config/imagecolumn.md
+++ b/content/develop/api-reference/data/column_config/imagecolumn.md
@@ -6,3 +6,5 @@ keywords: st.column_config.ImageColumn, image column, display images, image urls
 ---
 
 <Autofunction function="streamlit.column_config.ImageColumn" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.ImageColumn" />

--- a/content/develop/api-reference/data/column_config/jsoncolumn.md
+++ b/content/develop/api-reference/data/column_config/jsoncolumn.md
@@ -6,3 +6,5 @@ keywords: st.column_config.JsonColumn, json column, json data, structured data, 
 ---
 
 <Autofunction function="streamlit.column_config.JsonColumn" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.JsonColumn" />

--- a/content/develop/api-reference/data/column_config/linechartcolumn.md
+++ b/content/develop/api-reference/data/column_config/linechartcolumn.md
@@ -6,3 +6,5 @@ keywords: st.column_config.LineChartColumn, line chart column, inline charts, ti
 ---
 
 <Autofunction function="streamlit.column_config.LineChartColumn" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.LineChartColumn" />

--- a/content/develop/api-reference/data/column_config/linkcolumn.md
+++ b/content/develop/api-reference/data/column_config/linkcolumn.md
@@ -6,3 +6,5 @@ keywords: st.column_config.LinkColumn, link column, clickable links, urls, hyper
 ---
 
 <Autofunction function="streamlit.column_config.LinkColumn" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.LinkColumn" />

--- a/content/develop/api-reference/data/column_config/listcolumn.md
+++ b/content/develop/api-reference/data/column_config/listcolumn.md
@@ -6,3 +6,5 @@ keywords: st.column_config.ListColumn, list column, array column, list data, seq
 ---
 
 <Autofunction function="streamlit.column_config.ListColumn" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.ListColumn" />

--- a/content/develop/api-reference/data/column_config/markdowncolumn.md
+++ b/content/develop/api-reference/data/column_config/markdowncolumn.md
@@ -6,3 +6,5 @@ keywords: st.column_config.MarkdownColumn, markdown column, rendered markdown, d
 ---
 
 <Autofunction function="streamlit.column_config.MarkdownColumn" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.MarkdownColumn" />

--- a/content/develop/api-reference/data/column_config/multiselectcolumn.md
+++ b/content/develop/api-reference/data/column_config/multiselectcolumn.md
@@ -6,3 +6,5 @@ keywords: st.column_config.MultiselectColumn, multiselect column, dropdown colum
 ---
 
 <Autofunction function="streamlit.column_config.MultiselectColumn" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.MultiselectColumn" />

--- a/content/develop/api-reference/data/column_config/numbercolumn.md
+++ b/content/develop/api-reference/data/column_config/numbercolumn.md
@@ -6,3 +6,5 @@ keywords: st.column_config.NumberColumn, number column, numerical data, number f
 ---
 
 <Autofunction function="streamlit.column_config.NumberColumn" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.NumberColumn" />

--- a/content/develop/api-reference/data/column_config/progresscolumn.md
+++ b/content/develop/api-reference/data/column_config/progresscolumn.md
@@ -6,3 +6,5 @@ keywords: st.column_config.ProgressColumn, progress column, progress bar, progre
 ---
 
 <Autofunction function="streamlit.column_config.ProgressColumn" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.ProgressColumn" />

--- a/content/develop/api-reference/data/column_config/selectboxcolumn.md
+++ b/content/develop/api-reference/data/column_config/selectboxcolumn.md
@@ -6,3 +6,5 @@ keywords: st.column_config.SelectboxColumn, selectbox column, dropdown column, s
 ---
 
 <Autofunction function="streamlit.column_config.SelectboxColumn" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.SelectboxColumn" />

--- a/content/develop/api-reference/data/column_config/textcolumn.md
+++ b/content/develop/api-reference/data/column_config/textcolumn.md
@@ -6,3 +6,5 @@ keywords: st.column_config.TextColumn, text column, text input, string column, t
 ---
 
 <Autofunction function="streamlit.column_config.TextColumn" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.TextColumn" />

--- a/content/develop/api-reference/data/column_config/timecolumn.md
+++ b/content/develop/api-reference/data/column_config/timecolumn.md
@@ -6,3 +6,5 @@ keywords: st.column_config.TimeColumn, time column, time picker, time input, tim
 ---
 
 <Autofunction function="streamlit.column_config.TimeColumn" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.TimeColumn" />

--- a/content/develop/api-reference/data/column_config/videocolumn.md
+++ b/content/develop/api-reference/data/column_config/videocolumn.md
@@ -6,3 +6,5 @@ keywords: st.column_config.VideoColumn, video column, display videos, video urls
 ---
 
 <Autofunction function="streamlit.column_config.VideoColumn" />
+
+<GitHubIssuesHint label="feature:st.column_config" name="st.column_config.VideoColumn" />

--- a/content/develop/api-reference/data/data_editor.md
+++ b/content/develop/api-reference/data/data_editor.md
@@ -20,3 +20,5 @@ You can configure the display and editing behavior of columns in `st.dataframe` 
 <Cloud name="doc-column-config-overview" query="embed_options=disable_scrolling" height="480px" />
 
 <Autofunction function="DataEditorState" />
+
+<GitHubIssuesHint label="feature:st.data_editor" name="st.data_editor" />

--- a/content/develop/api-reference/data/dataframe.md
+++ b/content/develop/api-reference/data/dataframe.md
@@ -28,3 +28,5 @@ Dataframes displayed with `st.dataframe` are interactive. End users can sort, re
 You can configure the display and editing behavior of columns in `st.dataframe` and `st.data_editor` via the [Column configuration API](/develop/api-reference/data/st.column_config). We have developed the API to let you add images, charts, and clickable URLs in dataframe and data editor columns. Additionally, you can make individual columns editable, set columns as categorical and specify which options they can take, hide the index of the dataframe, and much more.
 
 <Cloud name="doc-column-config-overview" query="embed_options=disable_scrolling" height="480px" />
+
+<GitHubIssuesHint label="feature:st.dataframe" name="st.dataframe" />

--- a/content/develop/api-reference/data/json.md
+++ b/content/develop/api-reference/data/json.md
@@ -6,3 +6,5 @@ keywords: st.json, json display, pretty print json, json formatting, json viewer
 ---
 
 <Autofunction function="streamlit.json" />
+
+<GitHubIssuesHint label="feature:st.json" name="st.json" />

--- a/content/develop/api-reference/data/metric.md
+++ b/content/develop/api-reference/data/metric.md
@@ -6,3 +6,5 @@ keywords: st.metric, metric display, kpi display, dashboard metrics, metric indi
 ---
 
 <Autofunction function="streamlit.metric" />
+
+<GitHubIssuesHint label="feature:st.metric" name="st.metric" />

--- a/content/develop/api-reference/data/table.md
+++ b/content/develop/api-reference/data/table.md
@@ -12,3 +12,5 @@ Static tables with `st.table` are the most basic way to display dataframes. For 
 </Tip>
 
 <Autofunction function="streamlit.table" />
+
+<GitHubIssuesHint label="feature:st.table" name="st.table" />

--- a/content/develop/api-reference/layout/columns.md
+++ b/content/develop/api-reference/layout/columns.md
@@ -6,3 +6,5 @@ keywords: st.columns, columns, side by side layout, column layout, grid layout, 
 ---
 
 <Autofunction function="streamlit.columns" />
+
+<GitHubIssuesHint label="feature:st.columns" name="st.columns" />

--- a/content/develop/api-reference/layout/container.md
+++ b/content/develop/api-reference/layout/container.md
@@ -6,3 +6,5 @@ keywords: st.container, container, multi element container, layout container, el
 ---
 
 <Autofunction function="streamlit.container" />
+
+<GitHubIssuesHint label="feature:st.container" name="st.container" />

--- a/content/develop/api-reference/layout/empty.md
+++ b/content/develop/api-reference/layout/empty.md
@@ -6,3 +6,5 @@ keywords: st.empty, empty container, single element container, placeholder conta
 ---
 
 <Autofunction function="streamlit.empty" />
+
+<GitHubIssuesHint label="feature:st.empty" name="st.empty" />

--- a/content/develop/api-reference/layout/expander.md
+++ b/content/develop/api-reference/layout/expander.md
@@ -8,3 +8,5 @@ keywords: st.expander, expander, collapsible container, expandable container, ac
 <Autofunction function="streamlit.expander" />
 
 <Autofunction function="ExpanderContainer" />
+
+<GitHubIssuesHint label="feature:st.expander" name="st.expander" />

--- a/content/develop/api-reference/layout/popover.md
+++ b/content/develop/api-reference/layout/popover.md
@@ -8,3 +8,5 @@ keywords: st.popover, popover, popup container, overlay container, floating cont
 <Autofunction function="streamlit.popover" />
 
 <Autofunction function="PopoverContainer" />
+
+<GitHubIssuesHint label="feature:st.popover" name="st.popover" />

--- a/content/develop/api-reference/layout/sidebar.md
+++ b/content/develop/api-reference/layout/sidebar.md
@@ -71,3 +71,5 @@ with st.sidebar:
         time.sleep(5)
     st.success("Done!")
 ```
+
+<GitHubIssuesHint label="feature:st.sidebar" name="st.sidebar" />

--- a/content/develop/api-reference/layout/tabs.md
+++ b/content/develop/api-reference/layout/tabs.md
@@ -8,3 +8,5 @@ keywords: st.tabs, tabs, tab container, tabbed interface, tab navigation, tabbed
 <Autofunction function="streamlit.tabs" />
 
 <Autofunction function="TabContainer" />
+
+<GitHubIssuesHint label="feature:st.tabs" name="st.tabs" />

--- a/content/develop/api-reference/media/audio.md
+++ b/content/develop/api-reference/media/audio.md
@@ -6,3 +6,5 @@ keywords: st.audio, audio player, audio file, sound player, music player, audio 
 ---
 
 <Autofunction function="streamlit.audio" />
+
+<GitHubIssuesHint label="feature:st.audio" name="st.audio" />

--- a/content/develop/api-reference/media/image.md
+++ b/content/develop/api-reference/media/image.md
@@ -6,3 +6,5 @@ keywords: st.image, display image, image gallery, picture display, photo display
 ---
 
 <Autofunction function="streamlit.image" />
+
+<GitHubIssuesHint label="feature:st.image" name="st.image" />

--- a/content/develop/api-reference/media/logo.md
+++ b/content/develop/api-reference/media/logo.md
@@ -6,3 +6,5 @@ keywords: st.logo, app logo, brand logo, header logo, sidebar logo, branding, co
 ---
 
 <Autofunction function="streamlit.logo" />
+
+<GitHubIssuesHint label="feature:st.logo" name="st.logo" />

--- a/content/develop/api-reference/media/pdf.md
+++ b/content/develop/api-reference/media/pdf.md
@@ -6,3 +6,5 @@ keywords: st.pdf, pdf viewer, pdf display, document viewer, pdf reader, document
 ---
 
 <Autofunction function="streamlit.pdf" />
+
+<GitHubIssuesHint label="feature:st.pdf" name="st.pdf" />

--- a/content/develop/api-reference/media/video.md
+++ b/content/develop/api-reference/media/video.md
@@ -6,3 +6,5 @@ keywords: st.video, video player, video display, movie player, video streaming, 
 ---
 
 <Autofunction function="streamlit.video" />
+
+<GitHubIssuesHint label="feature:st.video" name="st.video" />

--- a/content/develop/api-reference/navigation/navigation.md
+++ b/content/develop/api-reference/navigation/navigation.md
@@ -6,3 +6,5 @@ keywords: st.navigation, navigation menu, page selection, multipage app, page me
 ---
 
 <Autofunction function="streamlit.navigation" />
+
+<GitHubIssuesHint label="feature:st.navigation" name="st.navigation" />

--- a/content/develop/api-reference/navigation/page.md
+++ b/content/develop/api-reference/navigation/page.md
@@ -11,4 +11,4 @@ keywords: st.Page, StreamlitPage, page object, multipage app, page initializatio
 
 <Autofunction function="StreamlitPage.run" />
 
-<GitHubIssuesHint label="feature:multipage-apps" name="st.Page" />
+<GitHubIssuesHint label="feature:st.Page" name="st.Page" />

--- a/content/develop/api-reference/navigation/page.md
+++ b/content/develop/api-reference/navigation/page.md
@@ -10,3 +10,5 @@ keywords: st.Page, StreamlitPage, page object, multipage app, page initializatio
 <Autofunction function="StreamlitPage" />
 
 <Autofunction function="StreamlitPage.run" />
+
+<GitHubIssuesHint label="feature:multipage-apps" name="st.Page" />

--- a/content/develop/api-reference/navigation/switch_page.md
+++ b/content/develop/api-reference/navigation/switch_page.md
@@ -6,3 +6,5 @@ keywords: st.switch_page, switch page, programmatic navigation, page redirect, n
 ---
 
 <Autofunction function="streamlit.switch_page" />
+
+<GitHubIssuesHint label="feature:st.switch_page" name="st.switch_page" />

--- a/content/develop/api-reference/server/st.app.md
+++ b/content/develop/api-reference/server/st.app.md
@@ -6,3 +6,5 @@ keywords: st.App, ASGI, Starlette, server, middleware, routes, lifecycle, config
 ---
 
 <Autofunction function="streamlit.App" />
+
+<GitHubIssuesHint label="feature:st.App" name="st.App" />

--- a/content/develop/api-reference/status/balloons.md
+++ b/content/develop/api-reference/status/balloons.md
@@ -6,3 +6,5 @@ keywords: st.balloons, celebratory balloons, celebration, success animation, bal
 ---
 
 <Autofunction function="streamlit.balloons" />
+
+<GitHubIssuesHint label="feature:st.balloons" name="st.balloons" />

--- a/content/develop/api-reference/status/error.md
+++ b/content/develop/api-reference/status/error.md
@@ -6,3 +6,5 @@ keywords: st.error, error message, error display, error notification, error aler
 ---
 
 <Autofunction function="streamlit.error" />
+
+<GitHubIssuesHint label="feature:st.error" name="st.error" />

--- a/content/develop/api-reference/status/exception.md
+++ b/content/develop/api-reference/status/exception.md
@@ -6,3 +6,5 @@ keywords: st.exception, exception display, exception handling, error traceback, 
 ---
 
 <Autofunction function="streamlit.exception" />
+
+<GitHubIssuesHint label="feature:st.exception" name="st.exception" />

--- a/content/develop/api-reference/status/info.md
+++ b/content/develop/api-reference/status/info.md
@@ -6,3 +6,5 @@ keywords: st.info, info message, information display, info notification, info al
 ---
 
 <Autofunction function="streamlit.info" />
+
+<GitHubIssuesHint label="feature:st.info" name="st.info" />

--- a/content/develop/api-reference/status/progress.md
+++ b/content/develop/api-reference/status/progress.md
@@ -6,3 +6,5 @@ keywords: st.progress, progress bar, loading bar, progress indicator, task progr
 ---
 
 <Autofunction function="streamlit.progress" />
+
+<GitHubIssuesHint label="feature:st.progress" name="st.progress" />

--- a/content/develop/api-reference/status/snow.md
+++ b/content/develop/api-reference/status/snow.md
@@ -6,3 +6,5 @@ keywords: st.snow, celebratory snow, snow animation, winter celebration, snowfla
 ---
 
 <Autofunction function="streamlit.snow" />
+
+<GitHubIssuesHint label="feature:st.snow" name="st.snow" />

--- a/content/develop/api-reference/status/spinner.md
+++ b/content/develop/api-reference/status/spinner.md
@@ -6,3 +6,5 @@ keywords: st.spinner, loading spinner, loading message, loading indicator, spinn
 ---
 
 <Autofunction function="streamlit.spinner" />
+
+<GitHubIssuesHint label="feature:st.spinner" name="st.spinner" />

--- a/content/develop/api-reference/status/status.md
+++ b/content/develop/api-reference/status/status.md
@@ -8,3 +8,5 @@ keywords: st.status, status container, mutable expander, status expander, status
 <Autofunction function="streamlit.status" />
 
 <Autofunction function="StatusContainer.update" />
+
+<GitHubIssuesHint label="feature:st.status" name="st.status" />

--- a/content/develop/api-reference/status/success.md
+++ b/content/develop/api-reference/status/success.md
@@ -6,3 +6,5 @@ keywords: st.success, success message, success notification, success alert, gree
 ---
 
 <Autofunction function="streamlit.success" />
+
+<GitHubIssuesHint label="feature:st.success" name="st.success" />

--- a/content/develop/api-reference/status/toast.md
+++ b/content/develop/api-reference/status/toast.md
@@ -6,3 +6,5 @@ keywords: st.toast, toast notification, toast message, popup notification, tempo
 ---
 
 <Autofunction function="streamlit.toast" />
+
+<GitHubIssuesHint label="feature:st.toast" name="st.toast" />

--- a/content/develop/api-reference/status/warning.md
+++ b/content/develop/api-reference/status/warning.md
@@ -6,3 +6,5 @@ keywords: st.warning, warning message, warning notification, warning alert, yell
 ---
 
 <Autofunction function="streamlit.warning" />
+
+<GitHubIssuesHint label="feature:st.warning" name="st.warning" />

--- a/content/develop/api-reference/testing/st.testing.v1.AppTest.md
+++ b/content/develop/api-reference/testing/st.testing.v1.AppTest.md
@@ -116,3 +116,5 @@ Note that you can also retrieve elements within a specific container in the same
 <Autofunction function="AppTest.toggle" />
 
 <Autofunction function="AppTest.warning" />
+
+<GitHubIssuesHint label="feature:app-testing" name="st.testing.v1.AppTest" />

--- a/content/develop/api-reference/text/badge.md
+++ b/content/develop/api-reference/text/badge.md
@@ -6,3 +6,5 @@ keywords: st.badge, badge, tag, colored badge, status badge, label, indicator, c
 ---
 
 <Autofunction function="streamlit.badge" />
+
+<GitHubIssuesHint label="feature:st.badge" name="st.badge" />

--- a/content/develop/api-reference/text/caption.md
+++ b/content/develop/api-reference/text/caption.md
@@ -8,3 +8,5 @@ keywords: st.caption, caption, small text, small font, subtitle, description tex
 <Autofunction function="streamlit.caption" />
 
 <Image src="/images/api/st.caption.png" clean />
+
+<GitHubIssuesHint label="feature:st.caption" name="st.caption" />

--- a/content/develop/api-reference/text/code.md
+++ b/content/develop/api-reference/text/code.md
@@ -6,3 +6,5 @@ keywords: code, block, syntax highlighting, programming, display, text
 ---
 
 <Autofunction function="streamlit.code" />
+
+<GitHubIssuesHint label="feature:st.code" name="st.code" />

--- a/content/develop/api-reference/text/divider.md
+++ b/content/develop/api-reference/text/divider.md
@@ -24,3 +24,5 @@ st.divider()  # 👈 Another horizontal rule
 ```
 
 <Image src="/images/api/st.divider.png" clean />
+
+<GitHubIssuesHint label="feature:st.divider" name="st.divider" />

--- a/content/develop/api-reference/text/echo.md
+++ b/content/develop/api-reference/text/echo.md
@@ -80,3 +80,5 @@ You can have multiple `st.echo()` blocks in the same file.
 Use it as often as you wish!
 
 </Note>
+
+<GitHubIssuesHint label="feature:st.echo" name="st.echo" />

--- a/content/develop/api-reference/text/header.md
+++ b/content/develop/api-reference/text/header.md
@@ -6,3 +6,5 @@ keywords: st.header, header, heading, title, header text, large text, h2, header
 ---
 
 <Autofunction function="streamlit.header" />
+
+<GitHubIssuesHint label="feature:st.header" name="st.header" />

--- a/content/develop/api-reference/text/help.md
+++ b/content/develop/api-reference/text/help.md
@@ -6,3 +6,5 @@ keywords: st.help, help, documentation, docstring, help text, function help, obj
 ---
 
 <Autofunction function="streamlit.help" />
+
+<GitHubIssuesHint label="feature:st.help" name="st.help" />

--- a/content/develop/api-reference/text/html.md
+++ b/content/develop/api-reference/text/html.md
@@ -6,3 +6,5 @@ keywords: st.html, html, html rendering, html display, custom html, html strings
 ---
 
 <Autofunction function="streamlit.html" />
+
+<GitHubIssuesHint label="feature:st.html" name="st.html" />

--- a/content/develop/api-reference/text/latex.md
+++ b/content/develop/api-reference/text/latex.md
@@ -8,3 +8,5 @@ keywords: st.latex, latex, math, mathematical expressions, equations, latex math
 <Autofunction function="streamlit.latex" />
 
 <Image src="/images/api/st.latex.png" clean />
+
+<GitHubIssuesHint label="feature:st.latex" name="st.latex" />

--- a/content/develop/api-reference/text/markdown.md
+++ b/content/develop/api-reference/text/markdown.md
@@ -23,3 +23,5 @@ st.markdown(md)
 ```
 
 <Cloud name="doc-markdown1" height="500px" />
+
+<GitHubIssuesHint label="feature:markdown" name="st.markdown" />

--- a/content/develop/api-reference/text/subheader.md
+++ b/content/develop/api-reference/text/subheader.md
@@ -6,3 +6,5 @@ keywords: subheader, text, formatting, heading, display
 ---
 
 <Autofunction function="streamlit.subheader" />
+
+<GitHubIssuesHint label="feature:st.header" name="st.subheader" />

--- a/content/develop/api-reference/text/text.md
+++ b/content/develop/api-reference/text/text.md
@@ -6,3 +6,5 @@ keywords: st.text, text, plain text, raw text, unformatted text
 ---
 
 <Autofunction function="streamlit.text" />
+
+<GitHubIssuesHint label="feature:st.text" name="st.text" />

--- a/content/develop/api-reference/text/title.md
+++ b/content/develop/api-reference/text/title.md
@@ -6,3 +6,5 @@ keywords: st.title, title, main title, app title, large title, h1, title formatt
 ---
 
 <Autofunction function="streamlit.title" />
+
+<GitHubIssuesHint label="feature:st.title" name="st.title" />

--- a/content/develop/api-reference/user/login.md
+++ b/content/develop/api-reference/user/login.md
@@ -12,3 +12,5 @@ Learn more in [User authentication and information](/develop/concepts/connection
 </Tip>
 
 <Autofunction function="streamlit.login" />
+
+<GitHubIssuesHint label="feature:st.login" name="st.login" />

--- a/content/develop/api-reference/user/logout.md
+++ b/content/develop/api-reference/user/logout.md
@@ -12,3 +12,5 @@ Learn more in [User authentication and information](/develop/concepts/connection
 </Tip>
 
 <Autofunction function="streamlit.logout" />
+
+<GitHubIssuesHint label="feature:authentication" name="st.logout" />

--- a/content/develop/api-reference/user/user.md
+++ b/content/develop/api-reference/user/user.md
@@ -14,3 +14,5 @@ keywords: st.user, user info, user information, logged-in user, community cloud 
 Starting from Streamlit version 1.42.0, you can't use `st.user` to retrieve a user's Community Cloud account email. To access user information, you must set up an identity provider and configure authentication (`[auth]`) in your app's secrets. Remember to update your identity provider's configuration and your app's secrets to allow your new domain. A list of [IP addresses](/deploy/streamlit-community-cloud/status#ip-addresses) used by Community Cloud is available if needed. An authentication-configured app counts as your single allowed private app.
 
 <Autofunction function="streamlit.user.to_dict" oldName="streamlit.experimental_user.to_dict" />
+
+<GitHubIssuesHint label="feature:st.user" name="st.user" />

--- a/content/develop/api-reference/widgets/audio_input.md
+++ b/content/develop/api-reference/widgets/audio_input.md
@@ -6,3 +6,5 @@ keywords: st.audio_input, audio input, microphone, audio recording, voice input,
 ---
 
 <Autofunction function="streamlit.audio_input" oldName="streamlit.experimental_audio_input" />
+
+<GitHubIssuesHint label="feature:st.audio_input" name="st.audio_input" />

--- a/content/develop/api-reference/widgets/button.md
+++ b/content/develop/api-reference/widgets/button.md
@@ -20,3 +20,5 @@ Check out our video on how to use one of Streamlit's core functions, the button!
 In the video below, we'll take it a step further and learn how to combine a [button](/develop/api-reference/widgets/st.button), [checkbox](/develop/api-reference/widgets/st.checkbox) and [radio button](/develop/api-reference/widgets/st.radio)!
 
 <YouTube videoId="EnXJBsCIl_A" />
+
+<GitHubIssuesHint label="feature:st.button" name="st.button" />

--- a/content/develop/api-reference/widgets/camera_input.md
+++ b/content/develop/api-reference/widgets/camera_input.md
@@ -173,3 +173,5 @@ if img_file_buffer is not None:
     # Should output shape: torch.Size([channels, height, width])
     st.write(torch_img.shape)
 ```
+
+<GitHubIssuesHint label="feature:st.camera_input" name="st.camera_input" />

--- a/content/develop/api-reference/widgets/checkbox.md
+++ b/content/develop/api-reference/widgets/checkbox.md
@@ -16,3 +16,5 @@ Check out our video on how to use one of Streamlit's core functions, the checkbo
 In the video below, we'll take it a step further and learn how to combine a [button](/develop/api-reference/widgets/st.button), [checkbox](/develop/api-reference/widgets/st.checkbox) and [radio button](/develop/api-reference/widgets/st.radio)!
 
 <YouTube videoId="EnXJBsCIl_A" />
+
+<GitHubIssuesHint label="feature:st.checkbox" name="st.checkbox" />

--- a/content/develop/api-reference/widgets/color_picker.md
+++ b/content/develop/api-reference/widgets/color_picker.md
@@ -6,3 +6,5 @@ keywords: st.color_picker, color picker, color selection, color widget, hex colo
 ---
 
 <Autofunction function="streamlit.color_picker" />
+
+<GitHubIssuesHint label="feature:st.color_picker" name="st.color_picker" />

--- a/content/develop/api-reference/widgets/date_input.md
+++ b/content/develop/api-reference/widgets/date_input.md
@@ -6,3 +6,5 @@ keywords: st.date_input, date input, calendar, date picker, date selection, date
 ---
 
 <Autofunction function="streamlit.date_input" />
+
+<GitHubIssuesHint label="feature:st.date_input" name="st.date_input" />

--- a/content/develop/api-reference/widgets/datetime_input.md
+++ b/content/develop/api-reference/widgets/datetime_input.md
@@ -6,3 +6,5 @@ keywords: st.datetime_input, datetime input, datetime picker, datetime selection
 ---
 
 <Autofunction function="streamlit.datetime_input" />
+
+<GitHubIssuesHint label="feature:st.datetime_input" name="st.datetime_input" />

--- a/content/develop/api-reference/widgets/download_button.md
+++ b/content/develop/api-reference/widgets/download_button.md
@@ -6,3 +6,5 @@ keywords: st.download_button, download button, file download, download widget, e
 ---
 
 <Autofunction function="streamlit.download_button" />
+
+<GitHubIssuesHint label="feature:st.download_button" name="st.download_button" />

--- a/content/develop/api-reference/widgets/feedback.md
+++ b/content/develop/api-reference/widgets/feedback.md
@@ -6,3 +6,5 @@ keywords: st.feedback, feedback, user feedback, ratings, feedback widget, thumbs
 ---
 
 <Autofunction function="streamlit.feedback" />
+
+<GitHubIssuesHint label="feature:st.feedback" name="st.feedback" />

--- a/content/develop/api-reference/widgets/file_uploader.md
+++ b/content/develop/api-reference/widgets/file_uploader.md
@@ -8,3 +8,5 @@ keywords: st.file_uploader, file uploader, file upload, upload widget, file inpu
 <Autofunction function="streamlit.file_uploader" />
 
 <Autofunction function="UploadedFile" />
+
+<GitHubIssuesHint label="feature:st.file_uploader" name="st.file_uploader" />

--- a/content/develop/api-reference/widgets/link_button.md
+++ b/content/develop/api-reference/widgets/link_button.md
@@ -6,3 +6,5 @@ keywords: st.link_button, link button, external link, url button, navigation but
 ---
 
 <Autofunction function="streamlit.link_button" />
+
+<GitHubIssuesHint label="feature:st.link_button" name="st.link_button" />

--- a/content/develop/api-reference/widgets/menu_button.md
+++ b/content/develop/api-reference/widgets/menu_button.md
@@ -6,3 +6,5 @@ keywords: menu, multi-action button, drop-down button, multiple trigger button
 ---
 
 <Autofunction function="streamlit.menu_button" />
+
+<GitHubIssuesHint label="feature:st.menu_button" name="st.menu_button" />

--- a/content/develop/api-reference/widgets/multiselect.md
+++ b/content/develop/api-reference/widgets/multiselect.md
@@ -6,3 +6,5 @@ keywords: st.multiselect, multiselect, multiple selection, multi choice, select 
 ---
 
 <Autofunction function="streamlit.multiselect" />
+
+<GitHubIssuesHint label="feature:st.multiselect" name="st.multiselect" />

--- a/content/develop/api-reference/widgets/number_input.md
+++ b/content/develop/api-reference/widgets/number_input.md
@@ -6,3 +6,5 @@ keywords: st.number_input, number input, numeric input, integer input, float inp
 ---
 
 <Autofunction function="streamlit.number_input" />
+
+<GitHubIssuesHint label="feature:st.number_input" name="st.number_input" />

--- a/content/develop/api-reference/widgets/page_link.md
+++ b/content/develop/api-reference/widgets/page_link.md
@@ -12,3 +12,5 @@ Check out our [tutorial](/develop/tutorials/multipage/st.page_link-nav) to learn
 </Tip>
 
 <Autofunction function="streamlit.page_link" />
+
+<GitHubIssuesHint label="feature:st.page_link" name="st.page_link" />

--- a/content/develop/api-reference/widgets/pills.md
+++ b/content/develop/api-reference/widgets/pills.md
@@ -6,3 +6,5 @@ keywords: st.pills, pills, pill buttons, button selection, pill selector, toggle
 ---
 
 <Autofunction function="streamlit.pills" />
+
+<GitHubIssuesHint label="feature:st.pills" name="st.pills" />

--- a/content/develop/api-reference/widgets/radio.md
+++ b/content/develop/api-reference/widgets/radio.md
@@ -48,3 +48,5 @@ Check out our video on how to use one of Streamlit's core functions, the radio b
 In the video below, we'll take it a step further and learn how to combine a [button](/develop/api-reference/widgets/st.button), [checkbox](/develop/api-reference/widgets/st.checkbox) and radio button!
 
 <YouTube videoId="EnXJBsCIl_A" />
+
+<GitHubIssuesHint label="feature:st.radio" name="st.radio" />

--- a/content/develop/api-reference/widgets/segmented_control.md
+++ b/content/develop/api-reference/widgets/segmented_control.md
@@ -6,3 +6,5 @@ keywords: st.segmented_control, segmented control, segmented button, button segm
 ---
 
 <Autofunction function="streamlit.segmented_control" />
+
+<GitHubIssuesHint label="feature:st.segmented_control" name="st.segmented_control" />

--- a/content/develop/api-reference/widgets/select_slider.md
+++ b/content/develop/api-reference/widgets/select_slider.md
@@ -14,3 +14,5 @@ Check out our video on how to use one of Streamlit's core functions, the select 
 
 In the video below, we'll take it a step further and make a double-ended slider.
 <YouTube videoId="sCvdt79asrE" />
+
+<GitHubIssuesHint label="feature:st.select_slider" name="st.select_slider" />

--- a/content/develop/api-reference/widgets/selectbox.md
+++ b/content/develop/api-reference/widgets/selectbox.md
@@ -39,3 +39,5 @@ with col2:
 ```
 
 <Cloud name="doc-selectbox1" height="300px" />
+
+<GitHubIssuesHint label="feature:st.selectbox" name="st.selectbox" />

--- a/content/develop/api-reference/widgets/slider.md
+++ b/content/develop/api-reference/widgets/slider.md
@@ -14,3 +14,5 @@ Check out our video on how to use one of Streamlit's core functions, the slider!
 
 In the video below, we'll take it a step further and make a double-ended slider.
 <YouTube videoId="sCvdt79asrE" />
+
+<GitHubIssuesHint label="feature:st.slider" name="st.slider" />

--- a/content/develop/api-reference/widgets/st.pagination.md
+++ b/content/develop/api-reference/widgets/st.pagination.md
@@ -6,3 +6,5 @@ keywords: pagination, paged interface, pages, navigation, widget
 ---
 
 <Autofunction function="streamlit.pagination" />
+
+<GitHubIssuesHint label="feature:st.pagination" name="st.pagination" />

--- a/content/develop/api-reference/widgets/text_area.md
+++ b/content/develop/api-reference/widgets/text_area.md
@@ -6,3 +6,5 @@ keywords: st.text_area, text area, multi-line text, textarea, text input, long t
 ---
 
 <Autofunction function="streamlit.text_area" />
+
+<GitHubIssuesHint label="feature:st.text_area" name="st.text_area" />

--- a/content/develop/api-reference/widgets/text_input.md
+++ b/content/develop/api-reference/widgets/text_input.md
@@ -47,3 +47,5 @@ with col2:
 ```
 
 <Cloud name="doc-text-input1" height="400px" />
+
+<GitHubIssuesHint label="feature:st.text_input" name="st.text_input" />

--- a/content/develop/api-reference/widgets/time_input.md
+++ b/content/develop/api-reference/widgets/time_input.md
@@ -6,3 +6,5 @@ keywords: st.time_input, time input, time picker, time selection, time widget, c
 ---
 
 <Autofunction function="streamlit.time_input" />
+
+<GitHubIssuesHint label="feature:st.time_input" name="st.time_input" />

--- a/content/develop/api-reference/widgets/toggle.md
+++ b/content/develop/api-reference/widgets/toggle.md
@@ -6,3 +6,5 @@ keywords: st.toggle, toggle, switch, toggle switch, on off, boolean toggle, togg
 ---
 
 <Autofunction function="streamlit.toggle" />
+
+<GitHubIssuesHint label="feature:st.toggle" name="st.toggle" />

--- a/content/develop/api-reference/write-magic/magic.md
+++ b/content/develop/api-reference/write-magic/magic.md
@@ -63,3 +63,5 @@ magicEnabled = false
 Learn what the [`st.write`](/develop/api-reference/write-magic/st.write) and [magic](/develop/api-reference/write-magic/magic) commands are and how to use them.
 
 <YouTube videoId="wpDuY9I2fDg" />
+
+<GitHubIssuesHint label="feature:magic" name="Magic" />

--- a/content/develop/api-reference/write-magic/write.md
+++ b/content/develop/api-reference/write-magic/write.md
@@ -12,3 +12,5 @@ keywords: st.write, write, display content, versatile display, swiss army knife,
 Learn what the [`st.write`](/develop/api-reference/write-magic/st.write) and [magic](/develop/api-reference/write-magic/magic) commands are and how to use them.
 
 <YouTube videoId="wpDuY9I2fDg" />
+
+<GitHubIssuesHint label="feature:st.write" name="st.write" />

--- a/content/develop/api-reference/write-magic/write_stream.md
+++ b/content/develop/api-reference/write-magic/write_stream.md
@@ -19,3 +19,5 @@ for chunk in unsupported_stream:
 For an example, see how we use [Replicate](https://replicate.com/docs/get-started/python) with [Snowflake Arctic](https://www.snowflake.com/en/data-cloud/arctic/) in [this code](https://github.com/streamlit/snowflake-arctic-st-demo/blob/0f0d8b49f328f72ae58ced2e9000790fb5e56e6f/simple_app.py#L58).
 
 </Tip>
+
+<GitHubIssuesHint label="feature:st.write_stream" name="st.write_stream" />

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -89,6 +89,7 @@ import DataSourcesCard from "../components/blocks/dataSourcesCard";
 import Tile from "../components/blocks/tile";
 import InlineCallout from "../components/blocks/inlineCallout";
 import Tip from "../components/blocks/tip";
+import GitHubIssuesHint from "../components/blocks/githubIssuesHint";
 import Warning from "../components/blocks/warning";
 import YouTube from "../components/blocks/youTube";
 import Cloud from "../components/blocks/cloud";
@@ -156,6 +157,7 @@ export default function Article({
     Note,
     NoteSplit,
     Tip,
+    GitHubIssuesHint,
     Deprecation,
     Important,
     Code,


### PR DESCRIPTION
## Summary
- Add a reusable `GitHubIssuesHint` callout that links each command to related open GitHub issues, sorted by 👍 reactions.
- Place the hint at the end of command reference pages so users can upvote feature requests and bugs that matter to them.
- Map pages to Streamlit issue labels (`feature:st.dataframe`, `feature:builtin-charts`, `feature:cli`, and so on).

<img width="770" height="201" alt="image" src="https://github.com/user-attachments/assets/d2fa6e49-1aa8-45bc-991c-be563d9ad893" />


## Test plan
- [ ] Open a command page with a dedicated label (for example `st.dataframe`) and confirm the tip appears at the bottom.
- [ ] Confirm the GitHub link filters open issues for that label and sorts by reactions.
- [ ] Open a grouped page (for example `st.line_chart` or `streamlit run`) and confirm it uses the shared label.
- [ ] Check light and dark theme rendering of the tip.


Made with [Cursor](https://cursor.com)