### PR TITLE
Fix duplicated words in three docs pages

### DIFF
--- a/content/develop/api-reference/command-line/run.md
+++ b/content/develop/api-reference/command-line/run.md
@@ -39,7 +39,7 @@ For a complete list of configuration options, see [`config.toml`](/develop/api-r
 
 If you need to pass arguments directly to your script, you can pass them as positional arguments. If you use `sys.argv` to read your arguments, `sys.argv` returns a list of all arguments and does _not_ include any configuration options. Python interprets all arguments as strings.
 
-- `sys.argv[0]` returns the the path to your entrypoint file, even if you did not explicitly provide it.
+- `sys.argv[0]` returns the path to your entrypoint file, even if you did not explicitly provide it.
 - `sys.argv[1:]` returns a list of arguments in order and does not include any configuration options.
 
 ### Examples

--- a/content/develop/concepts/app-testing/automate-tests.md
+++ b/content/develop/concepts/app-testing/automate-tests.md
@@ -161,4 +161,4 @@ The above is just provided as an example. Streamlit App Action is a quick way to
 
 ## Working example
 
-As a final working example example, take a look at our [`streamlit/llm-examples` Actions](https://github.com/streamlit/llm-examples/actions), defined in [this workflow file](https://github.com/streamlit/llm-examples/blob/main/.github/workflows/app-testing.yml).
+As a final working example, take a look at our [`streamlit/llm-examples` Actions](https://github.com/streamlit/llm-examples/actions), defined in [this workflow file](https://github.com/streamlit/llm-examples/blob/main/.github/workflows/app-testing.yml).

--- a/content/develop/concepts/custom-components/publish.md
+++ b/content/develop/concepts/custom-components/publish.md
@@ -31,7 +31,7 @@ The [component-template](https://github.com/streamlit/component-template) GitHub
 
 1. Give your Component a name, if you haven't already
    - Rename the `template/my_component/` folder to `template/<component name>/`
-   - Pass your component's name as the the first argument to `declare_component()`
+   - Pass your component's name as the first argument to `declare_component()`
 2. Edit `MANIFEST.in`, change the path for recursive-include from `package/frontend/build *` to `<component name>/frontend/build *`
 3. Edit `setup.py`, adding your component's name and other relevant info
 4. Create a release build of your frontend code. This will add a new directory, `frontend/build/`, with your compiled frontend in it:


### PR DESCRIPTION
Small docs cleanup: removes three duplicated words I stumbled over while reading the docs.

- `content/develop/api-reference/command-line/run.md`: "returns the the path" → "returns the path"
- `content/develop/concepts/custom-components/publish.md`: "as the the first argument" → "as the first argument"
- `content/develop/concepts/app-testing/automate-tests.md`: "working example example" → "working example"

No other content changes.